### PR TITLE
Add collection-side support for the docker action group

### DIFF
--- a/changelogs/fragments/17-action-group.yml
+++ b/changelogs/fragments/17-action-group.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "Add collection-side support of the ``docker`` action group / module defaults group (https://github.com/ansible-collections/community.docker/pull/17)."

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,24 @@
 ---
 requires_ansible: '>=2.9.10'
+action_groups:
+  docker:
+  - docker_compose
+  - docker_config
+  - docker_container
+  - docker_container_info
+  - docker_host_info
+  - docker_image
+  - docker_image_info
+  - docker_login
+  - docker_network
+  - docker_network_info
+  - docker_node
+  - docker_node_info
+  - docker_prune
+  - docker_secret
+  - docker_swarm
+  - docker_swarm_info
+  - docker_swarm_service
+  - docker_swarm_service_info
+  - docker_volume
+  - docker_volume_info


### PR DESCRIPTION
##### SUMMARY
For the `docker` action group / module defaults group to work with this collection, we need to mention it in meta/runtime.yml.

Also see related PR ansible/ansible#72428.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meta/runtime.yml
