### PR TITLE
By default, no longer do cleanup of setup_docker

### DIFF
--- a/tests/integration/targets/setup_docker/defaults/main.yml
+++ b/tests/integration/targets/setup_docker/defaults/main.yml
@@ -1,7 +1,7 @@
 docker_cli_version: '0.0'
 docker_api_version: '0.0'
 docker_py_version: '0.0'
-docker_skip_cleanup: no
+docker_skip_cleanup: yes
 docker_prereq_packages: []
 docker_packages:
   - docker-ce


### PR DESCRIPTION
##### SUMMARY
Cleanup means purging the docker daemon. This was necessary when the
docker tests were run as part of ansible/ansible and community.general
CI, but in the community.docker CI the problematic runs are on their
own CI node.

This should speed up CI, since unnecessary cleanups and re-installs aren't done anymore.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
