### PR TITLE
Remove PATH hack

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -36,7 +36,7 @@ variables:
 resources:
   containers:
     - container: default
-      image: quay.io/ansible/azure-pipelines-test-container:1.7.0
+      image: quay.io/ansible/azure-pipelines-test-container:1.7.1
 
 pool: Standard
 

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -183,10 +183,10 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
-          nameFormat: RHEL 8.2 {0}
-          testFormat: 2.10/rhel/8.2/{0}
+          nameFormat: RHEL {0}
+          testFormat: devel/rhel/{0}
           targets:
-            - test: ''
+            - test: '8.2'
           groups:
             - 1
             - 2
@@ -197,14 +197,17 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
-          nameFormat: RHEL 8.2 {0}
-          testFormat: 2.9/rhel/8.2/{0}
+          nameFormat: RHEL {0}
+          testFormat: devel/rhel/{0}
           targets:
-            - test: ''
+            - test: '8.2'
           groups:
             - 1
             - 2
             - 3
+
+  ## Finally
+
   - stage: Summary
     condition: succeededOrFailed()
     dependsOn:

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -14,9 +14,6 @@ function join {
     echo "$*";
 }
 
-# HACK remove once azure-pipelines-test-container has been fixed
-export PATH=$PATH:$HOME/.local/bin
-
 # Ensure we can write other collections to this dir
 sudo chown "$(whoami)" "${PWD}/../../"
 


### PR DESCRIPTION
##### SUMMARY
azure-pipelines-test-container:1.7.1 contains a proper fix for ensuring
PATH contains the location of pip installed binaries so we can remove
the hack.

##### ISSUE TYPE
- Bugfix Pull Request
