### PR TITLE
docker_container: cgroup_parent

### DIFF
--- a/changelogs/fragments/59-docker_container-cgroup-parent.yml
+++ b/changelogs/fragments/59-docker_container-cgroup-parent.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "docker_container - support specifying ``cgroup_parent`` (https://github.com/ansible-collections/community.docker/issues/6, https://github.com/ansible-collections/community.docker/pull/59)."

--- a/plugins/doc_fragments/docker.py
+++ b/plugins/doc_fragments/docker.py
@@ -111,6 +111,9 @@ notes:
 
     DOCKER_PY_1_DOCUMENTATION = r'''
 options: {}
+notes:
+  - This module uses the L(Docker SDK for Python,https://docker-py.readthedocs.io/en/stable/) to
+    communicate with the Docker daemon.
 requirements:
   - "Docker SDK for Python: Please note that the L(docker-py,https://pypi.org/project/docker-py/)
      Python module has been superseded by L(docker,https://pypi.org/project/docker/)
@@ -127,6 +130,9 @@ requirements:
 
     DOCKER_PY_2_DOCUMENTATION = r'''
 options: {}
+notes:
+  - This module uses the L(Docker SDK for Python,https://docker-py.readthedocs.io/en/stable/) to
+    communicate with the Docker daemon.
 requirements:
   - "Python >= 2.7"
   - "Docker SDK for Python: Please note that the L(docker-py,https://pypi.org/project/docker-py/)

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -52,6 +52,11 @@ options:
       - List of capabilities to drop from the container.
     type: list
     elements: str
+  cgroup_parent:
+    description:
+      - Specify the parent cgroup for the container.
+    type: str
+    version_added: 1.1.0
   cleanup:
     description:
       - Use with I(detach=false) to remove the container after successful execution.
@@ -1589,6 +1594,7 @@ class TaskParameters(DockerBaseClass):
             publish_all_ports='publish_all_ports',
             links='links',
             privileged='privileged',
+            cgroup_parent='cgroup_parent',
             dns='dns_servers',
             dns_opt='dns_opts',
             dns_search='dns_search_domains',
@@ -2175,6 +2181,7 @@ class Container(DockerBaseClass):
             interactive=config.get('OpenStdin'),
             capabilities=host_config.get('CapAdd'),
             cap_drop=host_config.get('CapDrop'),
+            cgroup_parent=host_config.get('CgroupParent'),
             expected_devices=host_config.get('Devices'),
             dns_servers=host_config.get('Dns'),
             dns_opts=host_config.get('DnsOptions'),
@@ -3371,6 +3378,7 @@ def main():
         blkio_weight=dict(type='int'),
         capabilities=dict(type='list', elements='str'),
         cap_drop=dict(type='list', elements='str'),
+        cgroup_parent=dict(type='str'),
         cleanup=dict(type='bool', default=False),
         command=dict(type='raw'),
         comparisons=dict(type='dict'),

--- a/tests/integration/targets/docker_container/tasks/tests/options.yml
+++ b/tests/integration/targets/docker_container/tasks/tests/options.yml
@@ -158,6 +158,40 @@
     - capabilities_4 is changed
 
 ####################################################################
+## cgroup_parent ###################################################
+####################################################################
+
+- name: cgroup_parent
+  docker_container:
+    image: "{{ docker_test_image_alpine }}"
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    cgroup_parent: ''
+  register: cgroup_parent_1
+
+- name: cgroup_parent (idempotency)
+  docker_container:
+    image: "{{ docker_test_image_alpine }}"
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    cgroup_parent: ''
+  register: cgroup_parent_2
+
+- name: cleanup
+  docker_container:
+    name: "{{ cname }}"
+    state: absent
+    force_kill: yes
+  diff: no
+
+- assert:
+    that:
+    - cgroup_parent_1 is changed
+    - cgroup_parent_2 is not changed
+
+####################################################################
 ## command #########################################################
 ####################################################################
 


### PR DESCRIPTION
##### SUMMARY
Fixes #6.

Unfortunately cgroup_parent is pretty much undocumented, the docs do not seem to mention it at all. The feature was added in Docker SDK for Python 1.4.0 (https://github.com/docker/docker-py/commit/3caaa0050b044462157b755f3810e44857d73761), so we can use it with all supported versions of the Docker SKD for Python (we require >= 1.8.0). It has already been mentioned in the API docs for 1.19 (https://docs.docker.com/engine/api/v1.19/#operation/ContainerCreate), so it should be available for all Docker API versions we support (>= 1.20).

This PR also mentions in all Docker SDK for Python based modules that they use the Docker SDK for Python to communicate with the docker daemon, since that is apparently unclear according to #6 ("Missing documentation how docker-container creates containers").

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docker_container
