### PR TITLE
docker_container: deprecate current behavior when specifying all with other port mappings

### DIFF
--- a/changelogs/fragments/60-docker_container-publish-all.yml
+++ b/changelogs/fragments/60-docker_container-publish-all.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+- "docker_container - currently ``published_ports`` can contain port mappings next to the special value ``all``, in which case the port mappings are ignored. This behavior is deprecated for community.docker 2.0.0, at which point it will either be forbidden, or this behavior will be properly implemented similar to how the Docker CLI tool handles this (https://github.com/ansible-collections/community.docker/issues/8, https://github.com/ansible-collections/community.docker/pull/60)."

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -1366,7 +1366,7 @@ class TaskParameters(DockerBaseClass):
 
         self.publish_all_ports = False
         self.published_ports = self._parse_publish_ports()
-        if self.published_ports in ('all', 'ALL'):
+        if self.published_ports == 'all':
             self.publish_all_ports = True
             self.published_ports = None
 
@@ -1684,6 +1684,14 @@ class TaskParameters(DockerBaseClass):
             return None
 
         if 'all' in self.published_ports:
+            if len(self.published_ports) > 1:
+                self.client.module.deprecate(
+                    'Specifying "all" in published_ports together with port mappings is not properly '
+                    'supported by the module. The port mappings are currently ignored. Please specify '
+                    'only port mappings, or the value "all". The behavior for mixed usage will either '
+                    'be forbidden in version 2.0.0, or properly handled. In any case, the way you '
+                    'currently use the module will change in a breaking way',
+                    collection_name='community.docker', version='2.0.0')
             return 'all'
 
         default_ip = self.default_host_ip


### PR DESCRIPTION
##### SUMMARY
Regarding #8, deprecate the current behavior when `published_ports` contains port mappings next to the special value `all`.

The deprecation meesage informs user that the current behavior (which they might not be aware of) will change in a breaking way, namely either it will be forbidden, or properly handled (like Docker CLI) in community.docker 2.0.0.

I didn't want to promise that I implement it properly, that's why I keep the possibliity to simply forbid it. In that case, specifying both `all` and port mappings will make the module fail. This can be changed anytime later (would be a new feature at that point).

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
docker_container
