### PR TITLE
Fix docker_api connection: do not initialize client too early

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -190,6 +190,7 @@ stages:
             - 1
             - 2
             - 3
+            - 4
   - stage: Remote_2_9
     displayName: Remote 2.9
     dependsOn: []
@@ -204,6 +205,7 @@ stages:
             - 1
             - 2
             - 3
+            - 4
 
   ## Finally
 


### PR DESCRIPTION
##### SUMMARY
This makes the connection plugin fail under Ansible 2.9, see https://github.com/ansible-collections/community.docker/pull/61/checks?check_run_id=1613987701 or https://app.shippable.com/github/ansible-collections/community.docker/runs/196/42/tests.

Also makes sure that connection plugins are tested with Ansible 2.9 and 2.10. They run in group 4, but only for the VMs (to make sure code coverage works).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/connection/docker_api.py
