### PR TITLE
Fix IPv6 zone handling

### DIFF
--- a/changelogs/fragments/66-ipv6-zones.yml
+++ b/changelogs/fragments/66-ipv6-zones.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- "docker_container - allow IPv6 zones (RFC 4007) in bind IPs (https://github.com/ansible-collections/community.docker/pull/66)."
+- "docker_image - allow IPv6 zones (RFC 4007) in network CIDRs (https://github.com/ansible-collections/community.docker/pull/66)."

--- a/changelogs/fragments/66-ipv6-zones.yml
+++ b/changelogs/fragments/66-ipv6-zones.yml
@@ -1,3 +1,2 @@
 bugfixes:
 - "docker_container - allow IPv6 zones (RFC 4007) in bind IPs (https://github.com/ansible-collections/community.docker/pull/66)."
-- "docker_image - allow IPv6 zones (RFC 4007) in network CIDRs (https://github.com/ansible-collections/community.docker/pull/66)."

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -1756,7 +1756,7 @@ class TaskParameters(DockerBaseClass):
             elif p_len == 3:
                 # We only allow IPv4 and IPv6 addresses for the bind address
                 ipaddr = parts[0]
-                if not re.match(r'^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$', parts[0]) and not re.match(r'^\[[0-9a-fA-F:]+\]$', ipaddr):
+                if not re.match(r'^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$', parts[0]) and not re.match(r'^\[[0-9a-fA-F:]+(?:|%[^\]/]+)\]$', ipaddr):
                     self.fail(('Bind addresses for published ports must be IPv4 or IPv6 addresses, not hostnames. '
                                'Use the dig lookup to resolve hostnames. (Found hostname: {0})').format(ipaddr))
                 if re.match(r'^\[[0-9a-fA-F:]+\]$', ipaddr):

--- a/plugins/modules/docker_network.py
+++ b/plugins/modules/docker_network.py
@@ -303,7 +303,7 @@ def container_names_in_network(network):
 
 
 CIDR_IPV4 = re.compile(r'^([0-9]{1,3}\.){3}[0-9]{1,3}/([0-9]|[1-2][0-9]|3[0-2])$')
-CIDR_IPV6 = re.compile(r'^[0-9a-fA-F:]+(?:|%[^\]/]+)/([0-9]|[1-9][0-9]|1[0-2][0-9])$')
+CIDR_IPV6 = re.compile(r'^[0-9a-fA-F:]+/([0-9]|[1-9][0-9]|1[0-2][0-9])$')
 
 
 def validate_cidr(cidr):

--- a/plugins/modules/docker_network.py
+++ b/plugins/modules/docker_network.py
@@ -303,7 +303,7 @@ def container_names_in_network(network):
 
 
 CIDR_IPV4 = re.compile(r'^([0-9]{1,3}\.){3}[0-9]{1,3}/([0-9]|[1-2][0-9]|3[0-2])$')
-CIDR_IPV6 = re.compile(r'^[0-9a-fA-F:]+/([0-9]|[1-9][0-9]|1[0-2][0-9])$')
+CIDR_IPV6 = re.compile(r'^[0-9a-fA-F:]+(?:|%[^\]/]+)/([0-9]|[1-9][0-9]|1[0-2][0-9])$')
 
 
 def validate_cidr(cidr):

--- a/tests/integration/targets/docker_container/tasks/tests/options.yml
+++ b/tests/integration/targets/docker_container/tasks/tests/options.yml
@@ -2950,8 +2950,21 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
     published_ports:
     - '127.0.0.1:9002:9002/tcp'
     - '[::1]:9003:9003/tcp'
+    - '[fe80::1%test]:90:90/tcp'
     force_kill: yes
   register: published_ports_5
+
+- name: published_ports (ports with IP addresses, idempotent)
+  docker_container:
+    image: "{{ docker_test_image_alpine }}"
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    published_ports:
+    - '127.0.0.1:9002:9002/tcp'
+    - '[::1]:9003:9003/tcp'
+    - '[fe80::1%test]:90:90/tcp'
+  register: published_ports_6
 
 - name: published_ports (no published ports)
   docker_container:
@@ -2963,7 +2976,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
     comparisons:
       published_ports: strict
     force_kill: yes
-  register: published_ports_6
+  register: published_ports_7
 
 - name: published_ports (default_host_ip not set)
   docker_container:
@@ -2975,7 +2988,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
     - '9001'
     - '9002'
     force_kill: yes
-  register: published_ports_7
+  register: published_ports_8
 
 - name: published_ports (default_host_ip set to empty string)
   docker_container:
@@ -2988,7 +3001,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
     - '9001'
     default_host_ip: ''
     force_kill: yes
-  register: published_ports_8
+  register: published_ports_9
 
 - name: published_ports (default_host_ip set to empty string, idempotent)
   docker_container:
@@ -3000,7 +3013,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
     - '9002'
     - '9001'
     default_host_ip: ''
-  register: published_ports_9
+  register: published_ports_10
 
 - name: published_ports (default_host_ip unset)
   docker_container:
@@ -3012,7 +3025,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
     - '9002'
     - '9001'
     force_kill: yes
-  register: published_ports_10
+  register: published_ports_11
 
 - name: cleanup
   docker_container:
@@ -3028,11 +3041,12 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
     - published_ports_3 is not changed
     - published_ports_4 is changed
     - published_ports_5 is changed
-    - published_ports_6 is changed
+    - published_ports_6 is not changed
     - published_ports_7 is changed
     - published_ports_8 is changed
-    - published_ports_9 is not changed
-    - published_ports_10 is changed
+    - published_ports_9 is changed
+    - published_ports_10 is not changed
+    - published_ports_11 is changed
 
 ####################################################################
 ## pull ############################################################


### PR DESCRIPTION
##### SUMMARY
Fixes #65. The same problem also appears in docker_network's CIDR validation. I don't know whether Docker supports zones here, but I don't see why we should restrict to non-zone CIDRs.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container
docker_network
