### PR TITLE
docker.py: allow docker versions beginning with 'v'

### DIFF
--- a/changelogs/fragments/76-leading-v-support-in-docker-version.yml
+++ b/changelogs/fragments/76-leading-v-support-in-docker-version.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - community.docker.docker - some docker versions have a leading 'v' in the output of the command ``docker version --format "{{.Server.Version}}"`` wich raise a ``TypeError`` (https://github.com/ansible-collections/community.docker/pull/76)
+  - docker connection plugin - fix Docker version parsing, as some docker versions have a leading ``v`` in the output of the command ``docker version --format "{{.Server.Version}}"`` (https://github.com/ansible-collections/community.docker/pull/76).

--- a/changelogs/fragments/76-leading-v-support-in-docker-version.yml
+++ b/changelogs/fragments/76-leading-v-support-in-docker-version.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - community.docker.docker - some docker versions have a leading 'v' in the output of the command ``docker version --format "{{.Server.Version}}"`` wich raise a ``TypeError`` (https://github.com/ansible-collections/community.docker/pull/76)

--- a/plugins/connection/docker.py
+++ b/plugins/connection/docker.py
@@ -120,7 +120,9 @@ class Connection(ConnectionBase):
 
     @staticmethod
     def _sanitize_version(version):
-        return re.sub(u'[^0-9a-zA-Z.]', u'', version)
+        version = re.sub(u'[^0-9a-zA-Z.]', u'', version)
+        version = re.sub(u'^v', u'', version)
+        return version
 
     def _old_docker_version(self):
         cmd_args = []


### PR DESCRIPTION
I don't know why, but here, the docker version output begins with a 'v':
```
$ docker version --format "{{.Server.Version}}"
v20.10.1
```
which trigger this error:
```
Traceback (most recent call last):
  File "/home/romain/pro/aubonticket/.venv/lib/python3.8/site-packages/ansible/executor/task_executor.py", line 158, in run
    res = self._execute()
  File "/home/romain/pro/aubonticket/.venv/lib/python3.8/site-packages/ansible/executor/task_executor.py", line 613, in _execute
    self._connection = self._get_connection(cvars, templar)
  File "/home/romain/pro/aubonticket/.venv/lib/python3.8/site-packages/ansible/executor/task_executor.py", line 908, in _get_connection
    connection, plugin_load_context = self._shared_loader_obj.connection_loader.get_with_context(
  File "/home/romain/pro/aubonticket/.venv/lib/python3.8/site-packages/ansible/plugins/loader.py", line 826, in get_with_context
    obj.__init__(instance, *args, **kwargs)
  File "/home/romain/pro/aubonticket/.venv/lib/python3.8/site-packages/ansible_collections/community/general/plugins/connection/docker.py", line 93, in __init__
    if docker_version != u'dev' and LooseVersion(docker_version) < LooseVersion(u'1.3'):
  File "/usr/host/lib/python3.8/distutils/version.py", line 52, in __lt__
    c = self._cmp(other)
  File "/usr/host/lib/python3.8/distutils/version.py", line 337, in _cmp
    if self.version < other.version:
TypeError: '<' not supported between instances of 'str' and 'int'
fatal: [server]: FAILED! => {
    "msg": "Unexpected failure during module execution.",
    "stdout": ""
}
```

##### SUMMARY
I modified the `_sanitize_version` method to handle this case.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
 plugins/connection/docker.py

