### PR TITLE
Fix CI: use ipaddress vendored in community.crypto

### DIFF
--- a/tests/integration/targets/docker_container/filter_plugins/ipaddr_tools.py
+++ b/tests/integration/targets/docker_container/filter_plugins/ipaddr_tools.py
@@ -18,7 +18,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.compat import ipaddress
+from ansible_collections.community.crypto.plugins.module_utils.compat import ipaddress
 
 
 def _normalize_ipaddr(ipaddr):


### PR DESCRIPTION
##### SUMMARY
CI fails since two days - since the community.general 2.0.0 release - as community.general no longer depends on ansible.netcommon.

Since we install community.crypto for tests, use ipaddress from there for now. If it's removed there, we have to either vendor it, or install it early on during the integration tests.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
