### PR TITLE
Fix update_failure_action KeyError in docker_swarm_service

### DIFF
--- a/changelogs/fragments/100-fix-update_failture_action-keyerror-in-docker_swarm_service.yaml
+++ b/changelogs/fragments/100-fix-update_failture_action-keyerror-in-docker_swarm_service.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "``docker_swarm_service`` - fix KeyError on caused by reference to 
+    deprecated option ``update_failure_action`` (https://github.com/ansible-collections/community.docker/pull/100)."

--- a/plugins/modules/docker_swarm_service.py
+++ b/plugins/modules/docker_swarm_service.py
@@ -2551,11 +2551,7 @@ def _detect_update_config_failure_action_rollback(client):
     rollback_config_failure_action = (
         (client.module.params['update_config'] or {}).get('failure_action')
     )
-    update_failure_action = (
-        client.module.params.get('update_failure_action')
-    )
-    failure_action = rollback_config_failure_action or update_failure_action
-    return failure_action == 'rollback'
+    return rollback_config_failure_action == 'rollback'
 
 
 def main():

--- a/plugins/modules/docker_swarm_service.py
+++ b/plugins/modules/docker_swarm_service.py
@@ -2551,7 +2551,9 @@ def _detect_update_config_failure_action_rollback(client):
     rollback_config_failure_action = (
         (client.module.params['update_config'] or {}).get('failure_action')
     )
-    update_failure_action = client.module.params['update_failure_action']
+    update_failure_action = (
+        client.module.params.get('update_failure_action')
+    )
     failure_action = rollback_config_failure_action or update_failure_action
     return failure_action == 'rollback'
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

I get this error in `docker_swarm_service` module with python docker `3.4.1` and docker 20:

```
    Traceback (most recent call last):
      File \"/home/admin/.ansible/tmp/ansible-tmp-1615509171.9495375-199788209305166/AnsiballZ_docker_swarm_service.py\", line 102, in <module>
        _ansiballz_main()
      File \"/home/admin/.ansible/tmp/ansible-tmp-1615509171.9495375-199788209305166/AnsiballZ_docker_swarm_service.py\", line 94, in _ansiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File \"/home/admin/.ansible/tmp/ansible-tmp-1615509171.9495375-199788209305166/AnsiballZ_docker_swarm_service.py\", line 40, in invoke_module
        runpy.run_module(mod_name='ansible_collections.community.docker.plugins.modules.docker_swarm_service', init_globals=None, run_name='__main__', alter_sys=True)
      File \"/usr/lib/python2.7/runpy.py\", line 188, in run_module
        fname, loader, pkg_name)
      File \"/usr/lib/python2.7/runpy.py\", line 82, in _run_module_code
        mod_name, mod_fname, mod_loader, pkg_name)
      File \"/usr/lib/python2.7/runpy.py\", line 72, in _run_code
        exec code in run_globals
      File \"/tmp/ansible_community.docker.docker_swarm_service_payload__rn1HO/ansible_community.docker.docker_swarm_service_payload.zip/ansible_collections/community/docker/plugins/modules/docker_swarm_service.py\", line 2833, in <module>
      File \"/tmp/ansible_community.docker.docker_swarm_service_payload__rn1HO/ansible_community.docker.docker_swarm_service_payload.zip/ansible_collections/community/docker/plugins/modules/docker_swarm_service.py\", line 2807, in main
      File \"/tmp/ansible_community.docker.docker_swarm_service_payload__rn1HO/ansible_community.docker.docker_swarm_service_payload.zip/ansible_collections/community/docker/plugins/module_utils/common.py\", line 678, in __init__
      File \"/tmp/ansible_community.docker.docker_swarm_service_payload__rn1HO/ansible_community.docker.docker_swarm_service_payload.zip/ansible_collections/community/docker/plugins/module_utils/common.py\", line 709, in _get_minimal_versions
      File \"/tmp/ansible_community.docker.docker_swarm_service_payload__rn1HO/ansible_community.docker.docker_swarm_service_payload.zip/ansible_collections/community/docker/plugins/modules/docker_swarm_service.py\", line 2555, in _detect_update_config_failure_action_rollback
    KeyError: 'update_failure_action'
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
To reproduce the error in a playbook:

```
- hosts: swarm-master
  tasks:
    - name: add swarm service
      community.docker.docker_swarm_service:
        state: present
        name: my-test-service
        replicas: 1
        force_update: yes
        debug: yes
        image: nginx
        publish:
          - target_port: 8080
          - published_port: 8080
      register: result
    - debug: var=result
```

Where swarm-master is configure swarm master.

After change above exception goes away.
