### PR TITLE
Make docker_swarm_service option publish.published_port optional

### DIFF
--- a/changelogs/fragments/101-make-service-published-port-optional.yaml
+++ b/changelogs/fragments/101-make-service-published-port-optional.yaml
@@ -1,3 +1,3 @@
 minor_changes:
-  - docker_swarm_service - change publish.published_port option from mandatory
+  - docker_swarm_service - change ``publish.published_port`` option from mandatory
     to optional. Docker will assign random high port if not specified (https://github.com/ansible-collections/community.docker/issues/99).

--- a/changelogs/fragments/101-make-service-published-port-optional.yaml
+++ b/changelogs/fragments/101-make-service-published-port-optional.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - docker_swarm_service - change publish.published_port option from mandatory
+    to optional. Docker will assign random high port if not specified (https://github.com/ansible-collections/community.docker/issues/99).

--- a/plugins/modules/docker_swarm_service.py
+++ b/plugins/modules/docker_swarm_service.py
@@ -365,7 +365,7 @@ options:
         description:
           - The port to make externally available.
         type: int
-        required: yes
+        required: no
       target_port:
         description:
           - The port inside the container to expose.
@@ -2066,9 +2066,10 @@ class DockerService(DockerBaseClass):
             for port in self.publish:
                 port_spec = {
                     'Protocol': port['protocol'],
-                    'PublishedPort': port['published_port'],
                     'TargetPort': port['target_port']
                 }
+                if port.get('published_port'):
+                    port_spec['PublishedPort'] = port['published_port']
                 if port.get('mode'):
                     port_spec['PublishMode'] = port['mode']
                 ports.append(port_spec)
@@ -2214,7 +2215,7 @@ class DockerServiceManager(object):
                     ds.publish.append({
                         'protocol': port['Protocol'],
                         'mode': port.get('PublishMode', None),
-                        'published_port': int(port['PublishedPort']),
+                        'published_port': port.get('PublishedPort', None),
                         'target_port': int(port['TargetPort'])
                     })
 
@@ -2618,7 +2619,7 @@ def main():
             options=dict(type='dict'),
         )),
         publish=dict(type='list', elements='dict', options=dict(
-            published_port=dict(type='int', required=True),
+            published_port=dict(type='int', required=False),
             target_port=dict(type='int', required=True),
             protocol=dict(type='str', default='tcp', choices=['tcp', 'udp']),
             mode=dict(type='str', choices=['ingress', 'host']),


### PR DESCRIPTION
##### SUMMARY
Change docker_swarm_service option publish.published_ported to optional. If not specified random high port is assigned by docker. Fixes #99.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
docker_swarm_service

##### ADDITIONAL INFORMATION
This now works A free high port above 30000 will be assigned by docker:

```
- hosts: swarm-master
  tasks:
    - name: add swarm service
      community.docker.docker_swarm_service:
        state: present
        name: my-test-service
        replicas: 1
        image: nginx
        publish:
          - target_port: 80
```

