### PR TITLE
docker_swarm_service: flag secrets option as not secret

### DIFF
--- a/changelogs/fragments/102-no_log-false.yml
+++ b/changelogs/fragments/102-no_log-false.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_swarm_service - mark ``secrets`` module option with ``no_log=False`` since it does not leak secrets (https://github.com/ansible-collections/community.general/pull/2001)."

--- a/plugins/modules/docker_swarm_service.py
+++ b/plugins/modules/docker_swarm_service.py
@@ -2598,9 +2598,9 @@ def main():
             gid=dict(type='str'),
             mode=dict(type='int'),
         )),
-        secrets=dict(type='list', elements='dict', options=dict(
-            secret_id=dict(type='str'),
-            secret_name=dict(type='str', required=True),
+        secrets=dict(type='list', elements='dict', no_log=False, options=dict(
+            secret_id=dict(type='str', no_log=False),
+            secret_name=dict(type='str', required=True, no_log=False),
             filename=dict(type='str'),
             uid=dict(type='str'),
             gid=dict(type='str'),


### PR DESCRIPTION
##### SUMMARY
There is a new sanity test which reports potentially secret-leaking module options. It flagged the `secrets` option of docker_swarm_service.

I'm pretty sure that this option does not leak any secrets, so I'm marking it (and `secret_id` and `secret_filename` in it) as `no_log=False`.

@dariko @jwitko @hannseman @WojciechowskiPiotr please take a look whether this is correct :)

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
docker_swarm_service
