### PR TITLE
[security] docker_swarm: mark join_token as no_log

### DIFF
--- a/changelogs/fragments/103-docker_swarm-join_token.yml
+++ b/changelogs/fragments/103-docker_swarm-join_token.yml
@@ -1,0 +1,4 @@
+security_fixes:
+- "docker_swarm - the ``join_token`` option is now marked as ``no_log`` so it is no longer written into logs (https://github.com/ansible-collections/community.docker/pull/103)."
+breaking_changes:
+- "docker_swarm - if ``join_token`` is specified, a returned join token with the same value will be replaced by ``VALUE_SPECIFIED_IN_NO_LOG_PARAMETER``. Make sure that you do not blindly use the join tokens from the return value of this module when the module is invoked with ``join_token`` specified! This breaking change appears in a minor release since it is necessary to fix a security issue (https://github.com/ansible-collections/community.docker/pull/103)."

--- a/plugins/modules/docker_swarm.py
+++ b/plugins/modules/docker_swarm.py
@@ -83,6 +83,8 @@ options:
     description:
       - Swarm token used to join a swarm cluster.
       - Used with I(state=join).
+      - If this value is specified, the corresponding value in the return values will be censored by Ansible.
+        This is a side-effect of this value not being logged.
     type: str
   remote_addrs:
     description:
@@ -230,12 +232,20 @@ swarm_facts:
           type: dict
           contains:
               Worker:
-                  description: Token to create a new *worker* node
+                  description:
+                    - Token to create a new *worker* node.
+                    - "B(Note:) if this value has been specified as I(join_token), the value here will not
+                       be the token, but C(VALUE_SPECIFIED_IN_NO_LOG_PARAMETER). If you pass I(join_token),
+                       make sure your playbook/role does not depend on this return value!"
                   returned: success
                   type: str
                   example: SWMTKN-1--xxxxx
               Manager:
-                  description: Token to create a new *manager* node
+                  description:
+                    - Token to create a new *manager* node.
+                    - "B(Note:) if this value has been specified as I(join_token), the value here will not
+                       be the token, but C(VALUE_SPECIFIED_IN_NO_LOG_PARAMETER). If you pass I(join_token),
+                       make sure your playbook/role does not depend on this return value!"
                   returned: success
                   type: str
                   example: SWMTKN-1--xxxxx
@@ -591,7 +601,7 @@ def main():
         force=dict(type='bool', default=False),
         listen_addr=dict(type='str', default='0.0.0.0:2377'),
         remote_addrs=dict(type='list', elements='str'),
-        join_token=dict(type='str'),
+        join_token=dict(type='str', no_log=True),
         snapshot_interval=dict(type='int'),
         task_history_retention_limit=dict(type='int'),
         keep_old_snapshots=dict(type='int'),

--- a/plugins/modules/docker_swarm.py
+++ b/plugins/modules/docker_swarm.py
@@ -233,7 +233,7 @@ swarm_facts:
           contains:
               Worker:
                   description:
-                    - Token to create a new *worker* node.
+                    - Token to join the cluster as a new *worker* node.
                     - "B(Note:) if this value has been specified as I(join_token), the value here will not
                        be the token, but C(VALUE_SPECIFIED_IN_NO_LOG_PARAMETER). If you pass I(join_token),
                        make sure your playbook/role does not depend on this return value!"
@@ -242,7 +242,7 @@ swarm_facts:
                   example: SWMTKN-1--xxxxx
               Manager:
                   description:
-                    - Token to create a new *manager* node.
+                    - Token to join the cluster as a new *manager* node.
                     - "B(Note:) if this value has been specified as I(join_token), the value here will not
                        be the token, but C(VALUE_SPECIFIED_IN_NO_LOG_PARAMETER). If you pass I(join_token),
                        make sure your playbook/role does not depend on this return value!"


### PR DESCRIPTION
##### SUMMARY
The `join_token` parameter of `docker_swarm` is currently not marked as `no_log`, which causes its value to be written to syslog during module invocation. This PR changes that.

An unfortunate side-effect is that if `join_token` is specified, the value there will be censored from the return values (i.e. replaced by `VALUE_SPECIFIED_IN_NO_LOG_PARAMETER`). This can potentially break playbooks/roles which store the return value.

This **only** affects the situation when `join_token` is provided; I think that usually in that case, the return values are not used, so it should break relatively few things (if any).

CC @WojciechowskiPiotr @relrod

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm
