### PR TITLE
CI: Stop using ansible-galaxy collection install to install a collection

### DIFF
--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -76,14 +76,20 @@ fi
 if [ "${script}" != "sanity" ] || [ "${test}" == "sanity/extra" ]; then
     # Nothing further should be added to this list.
     # This is to prevent modules or plugins in this collection having a runtime dependency on other collections.
-    retry ansible-galaxy -vvv collection install community.internal_test_tools
+    retry git clone --depth=1 --single-branch https://github.com/ansible-collections/community.internal_test_tools.git "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/community/internal_test_tools"
+    # NOTE: we're installing with git to work around Galaxy being a huge PITA (https://github.com/ansible/galaxy/issues/2429)
+    # retry ansible-galaxy -vvv collection install community.internal_test_tools
 fi
 
 if [ "${script}" != "sanity" ] && [ "${script}" != "units" ]; then
     # To prevent Python dependencies on other collections only install other collections for integration tests
-    retry ansible-galaxy -vvv collection install ansible.posix
-    retry ansible-galaxy -vvv collection install community.crypto
-    retry ansible-galaxy -vvv collection install community.general
+    retry git clone --depth=1 --single-branch https://github.com/ansible-collections/ansible.posix.git "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/ansible/posix"
+    retry git clone --depth=1 --single-branch https://github.com/ansible-collections/community.crypto.git "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/community/crypto"
+    retry git clone --depth=1 --single-branch https://github.com/ansible-collections/community.general.git "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/community/general"
+    # NOTE: we're installing with git to work around Galaxy being a huge PITA (https://github.com/ansible/galaxy/issues/2429)
+    # retry ansible-galaxy -vvv collection install ansible.posix
+    # retry ansible-galaxy -vvv collection install community.crypto
+    # retry ansible-galaxy -vvv collection install community.general
 fi
 
 # END: HACK


### PR DESCRIPTION
##### SUMMARY
ansible/galaxy#2429 is getting to a point where it is a huge PITA. To work around it, we directly clone the corresponding git repositories.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI
