### PR TITLE
Fix CI for docker-py 5.0.0

### DIFF
--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -51,3 +51,6 @@ mccabe == 0.6.1
 pylint == 2.3.1
 typed-ast == 1.4.0  # 1.4.0 is required to compile on Python 3.8
 wrapt == 1.11.1
+
+# Restrict docker versions depending on Python version
+docker < 5.0.0 ; python_version <= '3.6'


### PR DESCRIPTION
##### SUMMARY
5.0.0 has been released today: https://github.com/docker/docker-py/releases/tag/5.0.0

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
collection
