### PR TITLE
Improve exception handling

### DIFF
--- a/changelogs/fragments/121-exception-handling.yml
+++ b/changelogs/fragments/121-exception-handling.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "all modules - use ``to_native`` to convert exceptions to strings (https://github.com/ansible-collections/community.docker/pull/121)."

--- a/plugins/modules/docker_config.py
+++ b/plugins/modules/docker_config.py
@@ -290,9 +290,11 @@ def main():
         ConfigManager(client, results)()
         client.module.exit_json(**results)
     except DockerException as e:
-        client.fail('An unexpected docker error occurred: {0}'.format(e), exception=traceback.format_exc())
+        client.fail('An unexpected docker error occurred: {0}'.format(to_native(e)), exception=traceback.format_exc())
     except RequestException as e:
-        client.fail('An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(e), exception=traceback.format_exc())
+        client.fail(
+            'An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(to_native(e)),
+            exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -1416,7 +1416,7 @@ class TaskParameters(DockerBaseClass):
                 try:
                     setattr(self, param_name, human_to_bytes(client.module.params.get(param_name)))
                 except ValueError as exc:
-                    self.fail("Failed to convert %s to bytes: %s" % (param_name, exc))
+                    self.fail("Failed to convert %s to bytes: %s" % (param_name, to_native(exc)))
 
         self.publish_all_ports = False
         self.published_ports = self._parse_publish_ports()
@@ -1728,7 +1728,7 @@ class TaskParameters(DockerBaseClass):
                         break
                 except NotFound as nfe:
                     self.client.fail(
-                        "Cannot inspect the network '{0}' to determine the default IP: {1}".format(net['name'], nfe),
+                        "Cannot inspect the network '{0}' to determine the default IP: {1}".format(net['name'], to_native(nfe)),
                         exception=traceback.format_exc()
                     )
         return ip
@@ -1898,7 +1898,7 @@ class TaskParameters(DockerBaseClass):
             try:
                 results.append(Ulimit(**limits))
             except ValueError as exc:
-                self.fail("Error parsing ulimits value %s - %s" % (limit, exc))
+                self.fail("Error parsing ulimits value %s - %s" % (limit, to_native(exc)))
         return results
 
     def _parse_sysctls(self):
@@ -1935,7 +1935,7 @@ class TaskParameters(DockerBaseClass):
         try:
             return LogConfig(**options)
         except ValueError as exc:
-            self.fail('Error parsing logging options - %s' % (exc))
+            self.fail('Error parsing logging options - %s' % (to_native(exc), ))
 
     def _parse_tmpfs(self):
         '''
@@ -2019,7 +2019,7 @@ class TaskParameters(DockerBaseClass):
                 try:
                     mount_dict['tmpfs_size'] = human_to_bytes(mount_dict['tmpfs_size'])
                 except ValueError as exc:
-                    self.fail('Failed to convert tmpfs_size of mount "{0}" to bytes: {1}'.format(target, exc))
+                    self.fail('Failed to convert tmpfs_size of mount "{0}" to bytes: {1}'.format(target, to_native(exc)))
             if mount_dict.get('tmpfs_mode') is not None:
                 try:
                     mount_dict['tmpfs_mode'] = int(mount_dict['tmpfs_mode'], 8)
@@ -3164,7 +3164,7 @@ class ContainerManager(DockerBaseClass):
                 else:
                     response = self.client.kill(container_id)
             except Exception as exc:
-                self.fail("Error killing container %s: %s" % (container_id, exc))
+                self.fail("Error killing container %s: %s" % (container_id, to_native(exc)))
         return response
 
     def container_restart(self, container_id):
@@ -3608,9 +3608,11 @@ def main():
         cm = ContainerManager(client)
         client.module.exit_json(**sanitize_result(cm.results))
     except DockerException as e:
-        client.fail('An unexpected docker error occurred: {0}'.format(e), exception=traceback.format_exc())
+        client.fail('An unexpected docker error occurred: {0}'.format(to_native(e)), exception=traceback.format_exc())
     except RequestException as e:
-        client.fail('An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(e), exception=traceback.format_exc())
+        client.fail(
+            'An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(to_native(e)),
+            exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/plugins/modules/docker_container_exec.py
+++ b/plugins/modules/docker_container_exec.py
@@ -126,7 +126,7 @@ rc:
 import shlex
 import traceback
 
-from ansible.module_utils._text import to_text, to_bytes
+from ansible.module_utils._text import to_text, to_bytes, to_native
 
 from ansible_collections.community.docker.plugins.module_utils.common import (
     AnsibleDockerClient,
@@ -244,12 +244,14 @@ def main():
         client.fail('Could not find container "{0}"'.format(container))
     except APIError as e:
         if e.response and e.response.status_code == 409:
-            client.fail('The container "{0}" has been paused ({1})'.format(container, e))
-        client.fail('An unexpected docker error occurred: {0}'.format(e), exception=traceback.format_exc())
+            client.fail('The container "{0}" has been paused ({1})'.format(container, to_native(e)))
+        client.fail('An unexpected docker error occurred: {0}'.format(to_native(e)), exception=traceback.format_exc())
     except DockerException as e:
-        client.fail('An unexpected docker error occurred: {0}'.format(e), exception=traceback.format_exc())
+        client.fail('An unexpected docker error occurred: {0}'.format(to_native(e)), exception=traceback.format_exc())
     except RequestException as e:
-        client.fail('An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(e), exception=traceback.format_exc())
+        client.fail(
+            'An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(to_native(e)),
+            exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/plugins/modules/docker_container_info.py
+++ b/plugins/modules/docker_container_info.py
@@ -104,6 +104,8 @@ container:
 
 import traceback
 
+from ansible.module_utils._text import to_native
+
 try:
     from docker.errors import DockerException
 except ImportError:
@@ -136,9 +138,11 @@ def main():
             container=container,
         )
     except DockerException as e:
-        client.fail('An unexpected docker error occurred: {0}'.format(e), exception=traceback.format_exc())
+        client.fail('An unexpected docker error occurred: {0}'.format(to_native(e)), exception=traceback.format_exc())
     except RequestException as e:
-        client.fail('An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(e), exception=traceback.format_exc())
+        client.fail(
+            'An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(to_native(e)),
+            exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/plugins/modules/docker_host_info.py
+++ b/plugins/modules/docker_host_info.py
@@ -334,9 +334,11 @@ def main():
         DockerHostManager(client, results)
         client.module.exit_json(**results)
     except DockerException as e:
-        client.fail('An unexpected docker error occurred: {0}'.format(e), exception=traceback.format_exc())
+        client.fail('An unexpected docker error occurred: {0}'.format(to_native(e)), exception=traceback.format_exc())
     except RequestException as e:
-        client.fail('An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(e), exception=traceback.format_exc())
+        client.fail(
+            'An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(to_native(e)),
+            exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/plugins/modules/docker_image_info.py
+++ b/plugins/modules/docker_image_info.py
@@ -165,6 +165,8 @@ images:
 
 import traceback
 
+from ansible.module_utils._text import to_native
+
 try:
     from docker import utils
     from docker.errors import DockerException, NotFound
@@ -235,7 +237,7 @@ class ImageManager(DockerBaseClass):
             except NotFound:
                 pass
             except Exception as exc:
-                self.fail("Error inspecting image %s - %s" % (image['Id'], str(exc)))
+                self.fail("Error inspecting image %s - %s" % (image['Id'], to_native(exc)))
             results.append(inspection)
         return results
 
@@ -260,9 +262,11 @@ def main():
         ImageManager(client, results)
         client.module.exit_json(**results)
     except DockerException as e:
-        client.fail('An unexpected docker error occurred: {0}'.format(e), exception=traceback.format_exc())
+        client.fail('An unexpected docker error occurred: {0}'.format(to_native(e)), exception=traceback.format_exc())
     except RequestException as e:
-        client.fail('An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(e), exception=traceback.format_exc())
+        client.fail(
+            'An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(to_native(e)),
+            exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/plugins/modules/docker_image_load.py
+++ b/plugins/modules/docker_image_load.py
@@ -73,6 +73,8 @@ images:
 import errno
 import traceback
 
+from ansible.module_utils._text import to_native
+
 from ansible_collections.community.docker.plugins.module_utils.common import (
     AnsibleDockerClient,
     DockerBaseClass,
@@ -126,10 +128,10 @@ class ImageManager(DockerBaseClass):
                     self._extract_output_line(line, load_output)
         except EnvironmentError as exc:
             if exc.errno == errno.ENOENT:
-                self.client.fail("Error opening archive {0} - {1}".format(self.path, str(exc)))
-            self.client.fail("Error loading archive {0} - {1}".format(self.path, str(exc)), stdout='\n'.join(load_output))
+                self.client.fail("Error opening archive {0} - {1}".format(self.path, to_native(exc)))
+            self.client.fail("Error loading archive {0} - {1}".format(self.path, to_native(exc)), stdout='\n'.join(load_output))
         except Exception as exc:
-            self.client.fail("Error loading archive {0} - {1}".format(self.path, str(exc)), stdout='\n'.join(load_output))
+            self.client.fail("Error loading archive {0} - {1}".format(self.path, to_native(exc)), stdout='\n'.join(load_output))
 
         # Collect loaded images
         loaded_images = []
@@ -177,10 +179,11 @@ def main():
         ImageManager(client, results)
         client.module.exit_json(**results)
     except DockerException as e:
-        client.fail('An unexpected docker error occurred: {0}'.format(e), exception=traceback.format_exc())
+        client.fail('An unexpected docker error occurred: {0}'.format(to_native(e)), exception=traceback.format_exc())
     except RequestException as e:
-        client.fail('An unexpected requests error occurred when docker-py tried to talk '
-                    'to the docker daemon: {0}'.format(e), exception=traceback.format_exc())
+        client.fail(
+            'An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(to_native(e)),
+            exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/plugins/modules/docker_login.py
+++ b/plugins/modules/docker_login.py
@@ -124,7 +124,8 @@ import json
 import os
 import re
 import traceback
-from ansible.module_utils._text import to_bytes, to_text
+
+from ansible.module_utils._text import to_bytes, to_text, to_native
 
 try:
     from docker.errors import DockerException
@@ -333,7 +334,7 @@ class LoginManager(DockerBaseClass):
                 dockercfg_path=self.config_path
             )
         except Exception as exc:
-            self.fail("Logging into %s for user %s failed - %s" % (self.registry_url, self.username, str(exc)))
+            self.fail("Logging into %s for user %s failed - %s" % (self.registry_url, self.username, to_native(exc)))
 
         # If user is already logged in, then response contains password for user
         if 'password' in response:
@@ -351,7 +352,7 @@ class LoginManager(DockerBaseClass):
                         dockercfg_path=self.config_path
                     )
                 except Exception as exc:
-                    self.fail("Logging into %s for user %s failed - %s" % (self.registry_url, self.username, str(exc)))
+                    self.fail("Logging into %s for user %s failed - %s" % (self.registry_url, self.username, to_native(exc)))
             response.pop('password', None)
         self.results['login_result'] = response
 
@@ -477,9 +478,11 @@ def main():
             del results['actions']
         client.module.exit_json(**results)
     except DockerException as e:
-        client.fail('An unexpected docker error occurred: {0}'.format(e), exception=traceback.format_exc())
+        client.fail('An unexpected docker error occurred: {0}'.format(to_native(e)), exception=traceback.format_exc())
     except RequestException as e:
-        client.fail('An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(e), exception=traceback.format_exc())
+        client.fail(
+            'An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(to_native(e)),
+            exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/plugins/modules/docker_network.py
+++ b/plugins/modules/docker_network.py
@@ -254,6 +254,8 @@ import traceback
 
 from distutils.version import LooseVersion
 
+from ansible.module_utils._text import to_native
+
 from ansible_collections.community.docker.plugins.module_utils.common import (
     AnsibleDockerClient,
     DockerBaseClass,
@@ -370,7 +372,7 @@ class DockerNetworkManager(object):
                 for ipam_config in self.parameters.ipam_config:
                     validate_cidr(ipam_config['subnet'])
             except ValueError as e:
-                self.client.fail(str(e))
+                self.client.fail(to_native(e))
 
         if self.parameters.driver_options:
             self.parameters.driver_options = clean_dict_booleans_for_docker_api(self.parameters.driver_options)
@@ -663,9 +665,11 @@ def main():
         cm = DockerNetworkManager(client)
         client.module.exit_json(**cm.results)
     except DockerException as e:
-        client.fail('An unexpected docker error occurred: {0}'.format(e), exception=traceback.format_exc())
+        client.fail('An unexpected docker error occurred: {0}'.format(to_native(e)), exception=traceback.format_exc())
     except RequestException as e:
-        client.fail('An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(e), exception=traceback.format_exc())
+        client.fail(
+            'An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(to_native(e)),
+            exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/plugins/modules/docker_network_info.py
+++ b/plugins/modules/docker_network_info.py
@@ -100,6 +100,8 @@ network:
 
 import traceback
 
+from ansible.module_utils._text import to_native
+
 try:
     from docker.errors import DockerException
 except ImportError:
@@ -132,9 +134,11 @@ def main():
             network=network,
         )
     except DockerException as e:
-        client.fail('An unexpected docker error occurred: {0}'.format(e), exception=traceback.format_exc())
+        client.fail('An unexpected docker error occurred: {0}'.format(to_native(e)), exception=traceback.format_exc())
     except RequestException as e:
-        client.fail('An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(e), exception=traceback.format_exc())
+        client.fail(
+            'An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(to_native(e)),
+            exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/plugins/modules/docker_node.py
+++ b/plugins/modules/docker_node.py
@@ -285,9 +285,11 @@ def main():
         SwarmNodeManager(client, results)
         client.module.exit_json(**results)
     except DockerException as e:
-        client.fail('An unexpected docker error occurred: {0}'.format(e), exception=traceback.format_exc())
+        client.fail('An unexpected docker error occurred: {0}'.format(to_native(e)), exception=traceback.format_exc())
     except RequestException as e:
-        client.fail('An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(e), exception=traceback.format_exc())
+        client.fail(
+            'An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(to_native(e)),
+            exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/plugins/modules/docker_node_info.py
+++ b/plugins/modules/docker_node_info.py
@@ -87,6 +87,8 @@ nodes:
 
 import traceback
 
+from ansible.module_utils._text import to_native
+
 from ansible_collections.community.docker.plugins.module_utils.common import (
     RequestException,
 )
@@ -147,9 +149,11 @@ def main():
             nodes=nodes,
         )
     except DockerException as e:
-        client.fail('An unexpected docker error occurred: {0}'.format(e), exception=traceback.format_exc())
+        client.fail('An unexpected docker error occurred: {0}'.format(to_native(e)), exception=traceback.format_exc())
     except RequestException as e:
-        client.fail('An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(e), exception=traceback.format_exc())
+        client.fail(
+            'An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(to_native(e)),
+            exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/plugins/modules/docker_prune.py
+++ b/plugins/modules/docker_prune.py
@@ -178,6 +178,8 @@ builder_cache_space_reclaimed:
 
 import traceback
 
+from ansible.module_utils._text import to_native
+
 try:
     from docker.errors import DockerException
 except ImportError:
@@ -256,9 +258,11 @@ def main():
 
         client.module.exit_json(**result)
     except DockerException as e:
-        client.fail('An unexpected docker error occurred: {0}'.format(e), exception=traceback.format_exc())
+        client.fail('An unexpected docker error occurred: {0}'.format(to_native(e)), exception=traceback.format_exc())
     except RequestException as e:
-        client.fail('An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(e), exception=traceback.format_exc())
+        client.fail(
+            'An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(to_native(e)),
+            exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/plugins/modules/docker_secret.py
+++ b/plugins/modules/docker_secret.py
@@ -293,9 +293,11 @@ def main():
         SecretManager(client, results)()
         client.module.exit_json(**results)
     except DockerException as e:
-        client.fail('An unexpected docker error occurred: {0}'.format(e), exception=traceback.format_exc())
+        client.fail('An unexpected docker error occurred: {0}'.format(to_native(e)), exception=traceback.format_exc())
     except RequestException as e:
-        client.fail('An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(e), exception=traceback.format_exc())
+        client.fail(
+            'An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(to_native(e)),
+            exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/plugins/modules/docker_swarm.py
+++ b/plugins/modules/docker_swarm.py
@@ -663,9 +663,11 @@ def main():
         SwarmManager(client, results)()
         client.module.exit_json(**results)
     except DockerException as e:
-        client.fail('An unexpected docker error occurred: {0}'.format(e), exception=traceback.format_exc())
+        client.fail('An unexpected docker error occurred: {0}'.format(to_native(e)), exception=traceback.format_exc())
     except RequestException as e:
-        client.fail('An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(e), exception=traceback.format_exc())
+        client.fail(
+            'An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(to_native(e)),
+            exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/plugins/modules/docker_swarm_info.py
+++ b/plugins/modules/docker_swarm_info.py
@@ -375,9 +375,11 @@ def main():
         results.update(client.fail_results)
         client.module.exit_json(**results)
     except DockerException as e:
-        client.fail('An unexpected docker error occurred: {0}'.format(e), exception=traceback.format_exc())
+        client.fail('An unexpected docker error occurred: {0}'.format(to_native(e)), exception=traceback.format_exc())
     except RequestException as e:
-        client.fail('An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(e), exception=traceback.format_exc())
+        client.fail(
+            'An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(to_native(e)),
+            exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/plugins/modules/docker_swarm_service.py
+++ b/plugins/modules/docker_swarm_service.py
@@ -934,7 +934,7 @@ from ansible_collections.community.docker.plugins.module_utils.common import (
 
 from ansible.module_utils.basic import human_to_bytes
 from ansible.module_utils.six import string_types
-from ansible.module_utils._text import to_text
+from ansible.module_utils._text import to_text, to_native
 
 try:
     from docker import types
@@ -2419,7 +2419,7 @@ class DockerServiceManager(object):
         except DockerException as e:
             self.client.fail(
                 'Error looking for an image named %s: %s'
-                % (image, e)
+                % (image, to_native(e))
             )
 
         try:
@@ -2427,7 +2427,7 @@ class DockerServiceManager(object):
         except Exception as e:
             self.client.fail(
                 'Error looking for service named %s: %s'
-                % (module.params['name'], e)
+                % (module.params['name'], to_native(e))
             )
         try:
             secret_ids = self.get_missing_secret_ids()
@@ -2445,7 +2445,7 @@ class DockerServiceManager(object):
             )
         except Exception as e:
             return self.client.fail(
-                'Error parsing module parameters: %s' % e
+                'Error parsing module parameters: %s' % to_native(e)
             )
 
         changed = False
@@ -2822,9 +2822,11 @@ def main():
 
         client.module.exit_json(**results)
     except DockerException as e:
-        client.fail('An unexpected docker error occurred: {0}'.format(e), exception=traceback.format_exc())
+        client.fail('An unexpected docker error occurred: {0}'.format(to_native(e)), exception=traceback.format_exc())
     except RequestException as e:
-        client.fail('An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(e), exception=traceback.format_exc())
+        client.fail(
+            'An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(to_native(e)),
+            exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/plugins/modules/docker_swarm_service_info.py
+++ b/plugins/modules/docker_swarm_service_info.py
@@ -62,6 +62,8 @@ service:
 
 import traceback
 
+from ansible.module_utils._text import to_native
+
 try:
     from docker.errors import DockerException
 except ImportError:
@@ -106,9 +108,11 @@ def main():
             exists=bool(service)
         )
     except DockerException as e:
-        client.fail('An unexpected docker error occurred: {0}'.format(e), exception=traceback.format_exc())
+        client.fail('An unexpected docker error occurred: {0}'.format(to_native(e)), exception=traceback.format_exc())
     except RequestException as e:
-        client.fail('An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(e), exception=traceback.format_exc())
+        client.fail(
+            'An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(to_native(e)),
+            exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/plugins/modules/docker_volume_info.py
+++ b/plugins/modules/docker_volume_info.py
@@ -77,6 +77,8 @@ volume:
 
 import traceback
 
+from ansible.module_utils._text import to_native
+
 try:
     from docker.errors import DockerException, NotFound
 except ImportError:
@@ -95,7 +97,7 @@ def get_existing_volume(client, volume_name):
     except NotFound as dummy:
         return None
     except Exception as exc:
-        client.fail("Error inspecting volume: %s" % exc)
+        client.fail("Error inspecting volume: %s" % to_native(exc))
 
 
 def main():
@@ -119,9 +121,11 @@ def main():
             volume=volume,
         )
     except DockerException as e:
-        client.fail('An unexpected docker error occurred: {0}'.format(e), exception=traceback.format_exc())
+        client.fail('An unexpected docker error occurred: {0}'.format(to_native(e)), exception=traceback.format_exc())
     except RequestException as e:
-        client.fail('An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(e), exception=traceback.format_exc())
+        client.fail(
+            'An unexpected requests error occurred when docker-py tried to talk to the docker daemon: {0}'.format(to_native(e)),
+            exception=traceback.format_exc())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
Use `to_native()` to convert exceptions to strings, not `str()`, nothing, or `text_type()`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
all modules
