### PR TITLE
common: correct error message for docker sdk version

### DIFF
--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -258,11 +258,15 @@ class AnsibleDockerClientBase(Client):
 
         if not HAS_DOCKER_PY:
             if NEEDS_DOCKER_PY2:
-                msg = missing_required_lib("Docker SDK for Python: docker")
-                msg = msg + ", for example via `pip install docker`. The error was: %s"
+                msg = missing_required_lib("Docker SDK for Python: docker above 5.0.0 (Python >= 3.6) or "
+                                           "docker before 5.0.0 (Python 2.7)")
+                msg = msg + ", for example via `pip install docker` (Python >= 3.6) or " \
+                    + "`pip install docker==4.4.4` (Python 2.7). The error was: %s"
             else:
-                msg = missing_required_lib("Docker SDK for Python: docker (Python >= 2.7) or docker-py (Python 2.6)")
-                msg = msg + ", for example via `pip install docker` or `pip install docker-py` (Python 2.6). The error was: %s"
+                msg = missing_required_lib("Docker SDK for Python: docker above 5.0.0 (Python >= 3.6) or "
+                                           "docker before 5.0.0 (Python 2.7) or docker-py (Python 2.6)")
+                msg = msg + ", for example via `pip install docker` (Python >= 3.6) or `pip install docker==4.4.4` (Python 2.7) " \
+                    + "or `pip install docker-py` (Python 2.6). The error was: %s"
             self.fail(msg % HAS_DOCKER_ERROR)
 
         if self.docker_py_version < LooseVersion(min_docker_version):


### PR DESCRIPTION
##### SUMMARY
Annouced that 5.0.0 in Docker SDK for Python do not support Python 2.7 anymore.
When the system use Python 2.7, and run "pip install docker" command to
install Docker SDK for Python module. Then the 5.0.0 will be installed.

When occurred the error for mismatching version for Python 2.7, the user
could not feature it out why it failed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
common

##### ADDITIONAL INFORMATION
please check the PR on ansible.
https://github.com/ansible/ansible/pull/74288