### PR TITLE
common: correct bad default value for tls_hostname

### DIFF
--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -77,7 +77,7 @@ except ImportError:
 DEFAULT_DOCKER_HOST = 'unix://var/run/docker.sock'
 DEFAULT_TLS = False
 DEFAULT_TLS_VERIFY = False
-DEFAULT_TLS_HOSTNAME = 'localhost'
+DEFAULT_TLS_HOSTNAME = None
 MIN_DOCKER_VERSION = "1.8.0"
 DEFAULT_TIMEOUT_SECONDS = 60
 


### PR DESCRIPTION
`module_utils.docker.common` set `DEFAULT_TLS_HOSTNAME = 'localhost'`.
This means that when `tls_hostname` is unset in a playbook, we would
simply use `localhost` rather than calling `update_tls_hostname`
(which extracts the hostname from the docker URL).

This would cause connection failures when TLS certificate verification
is enabled because the hostname would not match the certificate.

This commit sets `DEFAULT_TLS_HOSTNAME = None` so that we properly
extract the hostname from the Docker URL when it is not provided
explicitly.
