### PR TITLE
Only emit tls_hostname deprecation warning if TLS is actually used

### DIFF
--- a/changelogs/fragments/143-tls_hostname-deprecation.yml
+++ b/changelogs/fragments/143-tls_hostname-deprecation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_* modules and plugins, except ``docker_swarm`` connection plugin and ``docker_compose`` and ``docker_stack*` modules - only emit ``tls_hostname`` deprecation message if TLS is actually used (https://github.com/ansible-collections/community.docker/pull/143)."

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -203,6 +203,7 @@ def _get_tls_config(fail_function, **kwargs):
 def is_using_tls(auth):
     return auth['tls_verify'] or auth['tls']
 
+
 def get_connect_params(auth, fail_function):
     if is_using_tls(auth):
         auth['docker_host'] = auth['docker_host'].replace('tcp://', 'https://')

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -172,11 +172,11 @@ class DockerBaseClass(object):
         #         log_file.write(msg + u'\n')
 
 
-def update_tls_hostname(result, old_behavior=False, deprecate_function=None):
+def update_tls_hostname(result, old_behavior=False, deprecate_function=None, uses_tls=True):
     if result['tls_hostname'] is None:
         if old_behavior:
             result['tls_hostname'] = DEFAULT_TLS_HOSTNAME
-            if deprecate_function is not None:
+            if uses_tls and deprecate_function is not None:
                 deprecate_function(
                     'The default value "localhost" for tls_hostname is deprecated and will be removed in community.docker 2.0.0.'
                     ' From then on, docker_host will be used to compute tls_hostname. If you want to keep using "localhost",'
@@ -200,8 +200,11 @@ def _get_tls_config(fail_function, **kwargs):
         fail_function("TLS config error: %s" % exc)
 
 
+def is_using_tls(auth):
+    return auth['tls_verify'] or auth['tls']
+
 def get_connect_params(auth, fail_function):
-    if auth['tls'] or auth['tls_verify']:
+    if is_using_tls(auth):
         auth['docker_host'] = auth['docker_host'].replace('tcp://', 'https://')
 
     result = dict(
@@ -391,7 +394,7 @@ class AnsibleDockerClientBase(Client):
         def depr(*args, **kwargs):
             self.deprecate(*args, **kwargs)
 
-        update_tls_hostname(result, old_behavior=True, deprecate_function=depr)
+        update_tls_hostname(result, old_behavior=True, deprecate_function=depr, uses_tls=is_using_tls(result))
 
         return result
 


### PR DESCRIPTION
##### SUMMARY
Right now it is also emitted if TLS is not used to talk to Docker daemon.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/common.py
