### PR TITLE
Fix URL to docker inventory script

### DIFF
--- a/docs/docsite/rst/scenario_guide.rst
+++ b/docs/docsite/rst/scenario_guide.rst
@@ -126,7 +126,7 @@ For working with a plain Docker daemon, that is without Swarm, there are connect
     docker_containers inventory plugin
         The :ref:`community.docker.docker_containers inventory plugin <ansible_collections.community.docker.docker_containers_inventory>` allows you to dynamically add Docker containers from a Docker Daemon to your Ansible inventory. See :ref:`dynamic_inventory` for details on dynamic inventories.
 
-        The `docker inventory script <https://github.com/ansible-collections/community.general/blob/main/scripts/inventory/docker.py>`_ is deprecated. Please use the inventory plugin instead. The inventory plugin has several compatibility options. If you need to collect Docker containers from multiple Docker daemons, you need to add every Docker daemon as an individual inventory source.
+        The `docker inventory script <https://github.com/ansible-community/contrib-scripts/blob/main/inventory/docker.py>`_ is deprecated. Please use the inventory plugin instead. The inventory plugin has several compatibility options. If you need to collect Docker containers from multiple Docker daemons, you need to add every Docker daemon as an individual inventory source.
 
     docker_host_info module
         The :ref:`community.docker.docker_host_info module <ansible_collections.community.docker.docker_host_info_module>` allows you to retrieve information on a Docker daemon, such as all containers, images, volumes, networks and so on.


### PR DESCRIPTION
##### SUMMARY
The scripts now live in https://github.com/ansible-community/contrib-scripts.

(See https://github.com/ansible-community/community-topics/issues/16 for details.)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
scenario guide
