### PR TITLE
Add extended output for community.internal_test_tools runner

### DIFF
--- a/tests/utils/shippable/sanity.sh
+++ b/tests/utils/shippable/sanity.sh
@@ -14,7 +14,7 @@ else
 fi
 
 if [ "${group}" == "extra" ]; then
-    ../internal_test_tools/tools/run.py --color
+    ../internal_test_tools/tools/run.py --color --bot --junit
     exit
 fi
 

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -73,6 +73,11 @@ else
     export ANSIBLE_COLLECTIONS_PATHS="${PWD}/../../../"
 fi
 
+if [ "${test}" == "sanity/extra" ]; then
+    retry pip install junit-xml --disable-pip-version-check
+fi
+
+# START: HACK
 if [ "${script}" != "sanity" ] || [ "${test}" == "sanity/extra" ]; then
     # Nothing further should be added to this list.
     # This is to prevent modules or plugins in this collection having a runtime dependency on other collections.
@@ -91,8 +96,8 @@ if [ "${script}" != "sanity" ] && [ "${script}" != "units" ]; then
     # retry ansible-galaxy -vvv collection install community.crypto
     # retry ansible-galaxy -vvv collection install community.general
 fi
-
 # END: HACK
+
 
 export PYTHONIOENCODING='utf-8'
 


### PR DESCRIPTION
##### SUMMARY
Make the output of the extended test runner more useful by adding ansibullbot and JUnit (for AZP) output (https://github.com/ansible-collections/community.internal_test_tools/pull/41).

##### ISSUE TYPE
- CI Pull Request

##### COMPONENT NAME
CI
