### PR TITLE
docker_host_info - Allow filters which are passed as lists

### DIFF
--- a/changelogs/fragments/160-docker_host_info-label-fitler-lists.yml
+++ b/changelogs/fragments/160-docker_host_info-label-fitler-lists.yml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
-  - docker_host_info - allow values for keys in ``containers_filters`` to be passed as YAML lists (https://github.com/ansible-collections/community.docker/pull/160).   
+  - docker_host_info - allow values for keys in ``containers_filters``, ``images_filters``, ``networks_filters``, and
+    ``volumes_filters`` to be passed as YAML lists (https://github.com/ansible-collections/community.docker/pull/160).

--- a/changelogs/fragments/160-docker_host_info-label-fitler-lists.yml
+++ b/changelogs/fragments/160-docker_host_info-label-fitler-lists.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - docker_host_info - allow values for keys in ``containers_filters`` to be passed as YAML lists (https://github.com/ansible-collections/community.docker/pull/160).   

--- a/plugins/modules/docker_host_info.py
+++ b/plugins/modules/docker_host_info.py
@@ -33,6 +33,8 @@ options:
     description:
       - A dictionary of filter values used for selecting containers to list.
       - "For example, C(until: 24h)."
+      - C(label) is a special case of filter which can be a string C(<key>) matching when a label is present, a string
+        C(<key>=<value>) matching when a label has a particular value, or a list of strings C(<key>)/C(<key>=<value).
       - See L(the docker documentation,https://docs.docker.com/engine/reference/commandline/container_prune/#filtering)
         for more information on possible filters.
     type: dict
@@ -45,6 +47,8 @@ options:
     description:
       - A dictionary of filter values used for selecting images to list.
       - "For example, C(dangling: true)."
+      - C(label) is a special case of filter which can be a string C(<key>) matching when a label is present, a string
+        C(<key>=<value>) matching when a label has a particular value, or a list of strings C(<key>)/C(<key>=<value).
       - See L(the docker documentation,https://docs.docker.com/engine/reference/commandline/image_prune/#filtering)
         for more information on possible filters.
     type: dict
@@ -56,6 +60,8 @@ options:
   networks_filters:
     description:
       - A dictionary of filter values used for selecting networks to list.
+      - C(label) is a special case of filter which can be a string C(<key>) matching when a label is present, a string
+        C(<key>=<value>) matching when a label has a particular value, or a list of strings C(<key>)/C(<key>=<value).
       - See L(the docker documentation,https://docs.docker.com/engine/reference/commandline/network_prune/#filtering)
         for more information on possible filters.
     type: dict
@@ -67,6 +73,8 @@ options:
   volumes_filters:
     description:
       - A dictionary of filter values used for selecting volumes to list.
+      - C(label) is a special case of filter which can be a string C(<key>) matching when a label is present, a string
+        C(<key>=<value>) matching when a label has a particular value, or a list of strings C(<key>)/C(<key>=<value).
       - See L(the docker documentation,https://docs.docker.com/engine/reference/commandline/volume_prune/#filtering)
         for more information on possible filters.
     type: dict

--- a/plugins/modules/docker_host_info.py
+++ b/plugins/modules/docker_host_info.py
@@ -126,6 +126,15 @@ EXAMPLES = '''
     disk_usage: yes
   register: result
 
+- name: Get info on docker host and list containers matching the filter
+  community.docker.docker_host_info:
+    containers: yes
+    containers_filters:
+      label:
+        - key1=value1
+        - key2=value2
+  register: result
+
 - ansible.builtin.debug:
     var: result.host_info
 

--- a/plugins/modules/docker_host_info.py
+++ b/plugins/modules/docker_host_info.py
@@ -223,7 +223,7 @@ class DockerHostManager(DockerBaseClass):
             if self.client.module.params[docker_object]:
                 returned_name = docker_object
                 filter_name = docker_object + "_filters"
-                filters = clean_dict_booleans_for_docker_api(client.module.params.get(filter_name))
+                filters = clean_dict_booleans_for_docker_api(client.module.params.get(filter_name), True)
                 self.results[returned_name] = self.get_docker_items_list(docker_object, filters)
 
     def get_docker_host_info(self):

--- a/tests/integration/targets/docker_host_info/tasks/test_host_info.yml
+++ b/tests/integration/targets/docker_host_info/tasks/test_host_info.yml
@@ -31,6 +31,9 @@
       image: "{{ docker_test_image_alpine }}"
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
+      labels:
+        key1: value1
+        key2: value2
       state: started
     register: container_output
 
@@ -62,6 +65,44 @@
          - 'output.disk_usage is not defined'
          - 'output.containers[0].Image is string'
          - 'output.containers[0].ImageID is not defined'
+
+  - name: Get info on Docker host and list containers matching filters (single label)
+    docker_host_info:
+      containers: yes
+      containers_filters:
+        label: key1=value1
+    register: output
+
+  - name: assert container is returned when filters are matched (single label)
+    assert:
+      that: "{{ output.containers | length }} == 1"
+
+  - name: Get info on Docker host and list containers matching filters (multiple labels)
+    docker_host_info:
+      containers: yes
+      containers_filters:
+        label:
+          - key1=value1
+          - key2=value2
+    register: output
+
+  - name: assert container is returned when filters are matched (multiple labels)
+    assert:
+      that: "{{ output.containers | length }} == 1"
+
+  - name: Get info on Docker host and do not list containers which do not match filters
+    docker_host_info:
+      containers: yes
+      containers_filters:
+        label:
+          - key1=value1
+          - key2=value2
+          - key3=value3
+    register: output
+
+  - name: assert no container is returned when filters are not matched
+    assert:
+      that: "{{ output.containers | length }} == 0"
 
   - name: Get info on Docker host and list containers with verbose output
     docker_host_info:


### PR DESCRIPTION
##### SUMMARY
Allows filter values which accept lists to be passed as lists to the docker API.
Fixes #18 
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME
plugins/modules/docker_host_info.py

##### ADDITIONAL INFORMATION
- Required an update to the common function `clean_dict_booleans_for_docker_api`, but previous behavior is defaulted so other modules are unaffected.
- integration tests for filters were added as well.