### PR TITLE
docker_plugin - adding alias option and general cleanup

### DIFF
--- a/changelogs/fragments/161-docker_plugin-alias-option.yml
+++ b/changelogs/fragments/161-docker_plugin-alias-option.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - docker_plugin - added ``alias`` option to specify local names for docker plugins (https://github.com/ansible-collections/community.docker/pull/161).

--- a/tests/integration/targets/docker_plugin/tasks/tests/basic_with_alias.yml
+++ b/tests/integration/targets/docker_plugin/tasks/tests/basic_with_alias.yml
@@ -1,0 +1,79 @@
+---
+- name: Register plugin name and alias
+  set_fact:
+    plugin_name: "{{ name_prefix }}"
+    alias: "test"
+
+- name: Create a plugin with an alias
+  docker_plugin:
+    plugin_name: "{{ plugin_name }}"
+    alias: "{{ alias }}"
+    state: present
+  register: create_1
+
+- name: Create a plugin  with an alias (Idempotent)
+  docker_plugin:
+    plugin_name: "{{ plugin_name }}"
+    alias: "{{ alias }}"
+    state: present
+  register: create_2
+
+- name: Enable a plugin with an alias
+  docker_plugin:
+    plugin_name: "{{ plugin_name }}"
+    alias: "{{ alias }}"
+    state: enable
+  register: create_3
+
+- name: Enable a plugin with an alias (Idempotent)
+  docker_plugin:
+    plugin_name: "{{ plugin_name }}"
+    alias: "{{ alias }}"
+    state: enable
+  register: create_4
+
+- name: Disable a plugin with an alias
+  docker_plugin:
+    plugin_name: "{{ plugin_name }}"
+    alias: "{{ alias }}"
+    state: disable
+  register: absent_1
+
+- name: Disable a plugin with an alias (Idempotent)
+  docker_plugin:
+    plugin_name: "{{ plugin_name }}"
+    alias: "{{ alias }}"
+    state: disable
+  register: absent_2
+
+- name: Remove a plugin with an alias
+  docker_plugin:
+    plugin_name: "{{ plugin_name }}"
+    alias: "{{ alias }}"
+    state: absent
+  register: absent_3
+
+- name: Remove a plugin with an alias (Idempotent)
+  docker_plugin:
+    plugin_name: "{{ plugin_name }}"
+    alias: "{{ alias }}"
+    state: absent
+  register: absent_4
+
+- assert:
+    that:
+    - create_1 is changed
+    - create_2 is not changed
+    - create_3 is changed
+    - create_4 is not changed
+    - absent_1 is changed
+    - absent_2 is not changed
+    - absent_3 is changed
+    - absent_4 is not changed
+
+- name: Cleanup plugin with an alias
+  docker_plugin:
+    plugin_name: "{{ plugin_name }}"
+    alias: "{{ alias }}"
+    state: absent
+    force_remove: true


### PR DESCRIPTION
##### SUMMARY
Adding an `alias` option to define a `local name` for a plugin.

Partial implementation of #145

##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME
plugins/modules/docker_plugin.py

##### ADDITIONAL INFORMATION
- Found some minor bugs when calling `client.fail` and addressed them
- Updated the `RETURN` documentation with `actions` which was missing and implemented the `plugin` return value
- Added integration tests.