### PR TITLE
docker_compose - Fix timeout defaulting behavior

### DIFF
--- a/changelogs/fragments/163-docker_compose-timeout-fix.yml
+++ b/changelogs/fragments/163-docker_compose-timeout-fix.yml
@@ -1,4 +1,4 @@
 ---
-bugfixes:
+breaking_changes:
   - docker_compose - fixed ``timeout`` defaulting behavior so that ``stop_grace_period``, if defined in the compose
-    file, will be used if no ``timeout`` is defined (https://github.com/ansible-collections/community.docker/pull/163).
+    file, will be used if `timeout`` is not specified (https://github.com/ansible-collections/community.docker/pull/163).

--- a/changelogs/fragments/163-docker_compose-timeout-fix.yml
+++ b/changelogs/fragments/163-docker_compose-timeout-fix.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - docker_compose - fixed ``timeout`` defaulting behavior so that ``stop_grace_period``, if defined in the compose
+    file, will be used if no ``timeout`` is defined (https://github.com/ansible-collections/community.docker/pull/163).

--- a/plugins/modules/docker_compose.py
+++ b/plugins/modules/docker_compose.py
@@ -144,8 +144,10 @@ options:
   timeout:
     description:
       - Timeout in seconds for container shutdown when attached or when containers are already running.
+      - By default C(compose) will use a C(10s) timeout unless C(default_grace_period) is defined for a
+        particular service in the I(project_src).
     type: int
-    default: 10
+    default: null
   use_ssh_client:
     description:
       - Currently ignored for this module, but might suddenly be supported later on.
@@ -476,14 +478,13 @@ try:
     from compose.cli.command import project_from_options
     from compose.service import NoSuchImageError
     from compose.cli.main import convergence_strategy_from_opts, build_action_from_opts, image_type_from_opt
-    from compose.const import DEFAULT_TIMEOUT, LABEL_SERVICE, LABEL_PROJECT, LABEL_ONE_OFF
+    from compose.const import LABEL_SERVICE, LABEL_PROJECT, LABEL_ONE_OFF
     HAS_COMPOSE = True
     HAS_COMPOSE_EXC = None
     MINIMUM_COMPOSE_VERSION = '1.7.0'
 except ImportError as dummy:
     HAS_COMPOSE = False
     HAS_COMPOSE_EXC = traceback.format_exc()
-    DEFAULT_TIMEOUT = 10
 
 from ansible.module_utils._text import to_native
 
@@ -1130,7 +1131,7 @@ def main():
         pull=dict(type='bool', default=False),
         nocache=dict(type='bool', default=False),
         debug=dict(type='bool', default=False),
-        timeout=dict(type='int', default=DEFAULT_TIMEOUT)
+        timeout=dict(type='int')
     )
 
     mutually_exclusive = [


### PR DESCRIPTION
##### SUMMARY
Removed overwriting of default timeout so `stop_grace_period` can be correctly read from `compose` files.
Fixes #25 
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME
plugins/modules/docker_compose.py

##### ADDITIONAL INFORMATION
- `timeout` documentation required `default: null` since a doc fragment this module extends already defines `timeout` with `default: 60`.

After the change the following example from #25 :
```yaml
 tasks:
     - name: remove pre-existing container to clear logs from previous run
       docker_compose:
         project_src: "{{ project_src }}"
         services:
           - foo
         state: absent

     - name: start service
       docker_compose:
         project_src: "{{ project_src }}"
         services:
           - foo
         state: present

     - name: stop service
       docker_compose:
         project_src: "{{ project_src }}"
         services:
           - foo
         state: present
         stopped: yes

     - command: docker logs applications_foo_1
       register: output

     - debug:
         msg: "{{ output.stdout }}"
```
results in:
```bash
PLAY [localhost] ************************************************************************************************************************************************************************************************

TASK [remove pre-existing container to clear logs from previous run] ********************************************************************************************************************************************
changed: [localhost]

TASK [start service] ********************************************************************************************************************************************************************************************
changed: [localhost]

TASK [stop service] *********************************************************************************************************************************************************************************************
changed: [localhost]

TASK [command] **************************************************************************************************************************************************************************************************
changed: [localhost]

TASK [debug] ****************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "script has started\nreceived SIGTERM\nexited cleanly"
}

PLAY RECAP ******************************************************************************************************************************************************************************************************
localhost                  : ok=5    changed=4    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```