### PR TITLE
Replace ansible.module_utils._text by ansible.module_utils.common.text.converters

### DIFF
--- a/changelogs/fragments/ansible-core-_text.yml
+++ b/changelogs/fragments/ansible-core-_text.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "Avoid internal ansible-core module_utils in favor of equivalent public API available since at least Ansible 2.9 (https://github.com/ansible-collections/community.docker/pull/164)."

--- a/plugins/connection/docker.py
+++ b/plugins/connection/docker.py
@@ -54,7 +54,7 @@ import ansible.constants as C
 from ansible.compat import selectors
 from ansible.errors import AnsibleError, AnsibleFileNotFound
 from ansible.module_utils.six.moves import shlex_quote
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
 from ansible.utils.display import Display
 

--- a/plugins/connection/docker_api.py
+++ b/plugins/connection/docker_api.py
@@ -46,7 +46,7 @@ import shutil
 import tarfile
 
 from ansible.errors import AnsibleFileNotFound, AnsibleConnectionFailure
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.plugins.connection import ConnectionBase
 from ansible.utils.display import Display
 

--- a/plugins/inventory/docker_containers.py
+++ b/plugins/inventory/docker_containers.py
@@ -143,7 +143,7 @@ keyed_groups:
 import re
 
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
 
 from ansible_collections.community.docker.plugins.module_utils.common import (

--- a/plugins/inventory/docker_machine.py
+++ b/plugins/inventory/docker_machine.py
@@ -84,8 +84,8 @@ compose:
 '''
 
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_native
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_native
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.common.process import get_bin_path
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 from ansible.utils.display import Display

--- a/plugins/inventory/docker_swarm.py
+++ b/plugins/inventory/docker_swarm.py
@@ -146,7 +146,7 @@ keyed_groups:
 '''
 
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.community.docker.plugins.module_utils.common import update_tls_hostname, get_connect_params
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
 from ansible.parsing.utils.addresses import parse_address

--- a/plugins/module_utils/swarm.py
+++ b/plugins/module_utils/swarm.py
@@ -15,7 +15,7 @@ except ImportError:
     # missing Docker SDK for Python handled in ansible.module_utils.docker.common
     pass
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.community.docker.plugins.module_utils.common import (
     AnsibleDockerClient,
     LooseVersion,

--- a/plugins/modules/docker_compose.py
+++ b/plugins/modules/docker_compose.py
@@ -485,7 +485,7 @@ except ImportError as dummy:
     HAS_COMPOSE_EXC = traceback.format_exc()
     DEFAULT_TIMEOUT = 10
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.docker.plugins.module_utils.common import (
     AnsibleDockerClient,

--- a/plugins/modules/docker_config.py
+++ b/plugins/modules/docker_config.py
@@ -161,7 +161,7 @@ from ansible_collections.community.docker.plugins.module_utils.common import (
     compare_generic,
     RequestException,
 )
-from ansible.module_utils._text import to_native, to_bytes
+from ansible.module_utils.common.text.converters import to_native, to_bytes
 
 
 class ConfigManager(DockerBaseClass):

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -1189,7 +1189,7 @@ from time import sleep
 
 from ansible.module_utils.common.text.formatters import human_to_bytes
 from ansible.module_utils.six import string_types
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native, to_text
 
 from ansible_collections.community.docker.plugins.module_utils.common import (
     AnsibleDockerClient,

--- a/plugins/modules/docker_container_exec.py
+++ b/plugins/modules/docker_container_exec.py
@@ -126,7 +126,7 @@ rc:
 import shlex
 import traceback
 
-from ansible.module_utils._text import to_text, to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_text, to_bytes, to_native
 
 from ansible_collections.community.docker.plugins.module_utils.common import (
     AnsibleDockerClient,

--- a/plugins/modules/docker_container_info.py
+++ b/plugins/modules/docker_container_info.py
@@ -104,7 +104,7 @@ container:
 
 import traceback
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from docker.errors import DockerException

--- a/plugins/modules/docker_host_info.py
+++ b/plugins/modules/docker_host_info.py
@@ -208,7 +208,7 @@ from ansible_collections.community.docker.plugins.module_utils.common import (
     DockerBaseClass,
     RequestException,
 )
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from docker.errors import DockerException, APIError

--- a/plugins/modules/docker_image.py
+++ b/plugins/modules/docker_image.py
@@ -337,7 +337,7 @@ from ansible_collections.community.docker.plugins.module_utils.common import (
     is_valid_tag,
     RequestException,
 )
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 if docker_version is not None:
     try:

--- a/plugins/modules/docker_image_info.py
+++ b/plugins/modules/docker_image_info.py
@@ -165,7 +165,7 @@ images:
 
 import traceback
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from docker import utils

--- a/plugins/modules/docker_image_load.py
+++ b/plugins/modules/docker_image_load.py
@@ -73,7 +73,7 @@ images:
 import errno
 import traceback
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.docker.plugins.module_utils.common import (
     AnsibleDockerClient,

--- a/plugins/modules/docker_login.py
+++ b/plugins/modules/docker_login.py
@@ -125,7 +125,7 @@ import os
 import re
 import traceback
 
-from ansible.module_utils._text import to_bytes, to_text, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_text, to_native
 
 try:
     from docker.errors import DockerException

--- a/plugins/modules/docker_network.py
+++ b/plugins/modules/docker_network.py
@@ -254,7 +254,7 @@ import traceback
 
 from distutils.version import LooseVersion
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.docker.plugins.module_utils.common import (
     AnsibleDockerClient,

--- a/plugins/modules/docker_network_info.py
+++ b/plugins/modules/docker_network_info.py
@@ -100,7 +100,7 @@ network:
 
 import traceback
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from docker.errors import DockerException

--- a/plugins/modules/docker_node.py
+++ b/plugins/modules/docker_node.py
@@ -139,7 +139,7 @@ from ansible_collections.community.docker.plugins.module_utils.common import (
     RequestException,
 )
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.docker.plugins.module_utils.swarm import AnsibleDockerSwarmClient
 

--- a/plugins/modules/docker_node_info.py
+++ b/plugins/modules/docker_node_info.py
@@ -87,7 +87,7 @@ nodes:
 
 import traceback
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.docker.plugins.module_utils.common import (
     RequestException,

--- a/plugins/modules/docker_prune.py
+++ b/plugins/modules/docker_prune.py
@@ -178,7 +178,7 @@ builder_cache_space_reclaimed:
 
 import traceback
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from docker.errors import DockerException

--- a/plugins/modules/docker_secret.py
+++ b/plugins/modules/docker_secret.py
@@ -160,7 +160,7 @@ from ansible_collections.community.docker.plugins.module_utils.common import (
     compare_generic,
     RequestException,
 )
-from ansible.module_utils._text import to_native, to_bytes
+from ansible.module_utils.common.text.converters import to_native, to_bytes
 
 
 class SecretManager(DockerBaseClass):

--- a/plugins/modules/docker_swarm.py
+++ b/plugins/modules/docker_swarm.py
@@ -282,7 +282,7 @@ from ansible_collections.community.docker.plugins.module_utils.common import (
 
 from ansible_collections.community.docker.plugins.module_utils.swarm import AnsibleDockerSwarmClient
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class TaskParameters(DockerBaseClass):

--- a/plugins/modules/docker_swarm_info.py
+++ b/plugins/modules/docker_swarm_info.py
@@ -199,7 +199,7 @@ except ImportError:
     # missing Docker SDK for Python handled in ansible.module_utils.docker_common
     pass
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.docker.plugins.module_utils.swarm import AnsibleDockerSwarmClient
 from ansible_collections.community.docker.plugins.module_utils.common import (

--- a/plugins/modules/docker_swarm_service.py
+++ b/plugins/modules/docker_swarm_service.py
@@ -933,7 +933,7 @@ from ansible_collections.community.docker.plugins.module_utils.common import (
 
 from ansible.module_utils.basic import human_to_bytes
 from ansible.module_utils.six import string_types
-from ansible.module_utils._text import to_text, to_native
+from ansible.module_utils.common.text.converters import to_text, to_native
 
 try:
     from docker import types

--- a/plugins/modules/docker_swarm_service_info.py
+++ b/plugins/modules/docker_swarm_service_info.py
@@ -62,7 +62,7 @@ service:
 
 import traceback
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from docker.errors import DockerException

--- a/plugins/modules/docker_volume.py
+++ b/plugins/modules/docker_volume.py
@@ -109,7 +109,7 @@ volume:
 
 import traceback
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from docker.errors import DockerException, APIError

--- a/plugins/modules/docker_volume_info.py
+++ b/plugins/modules/docker_volume_info.py
@@ -77,7 +77,7 @@ volume:
 
 import traceback
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from docker.errors import DockerException, NotFound


### PR DESCRIPTION
##### SUMMARY
While the private API `ansible.module_utils._text` was the default place to get `to_text`, `to_bytes` and `to_native` for a long time, at least since Ansible 2.9 there's a non-private alternative: `ansible.module_utils.common.text.converters`. So let's use it :)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
various plugins
