### PR TITLE
docker-compose - Adding validated state and no_interpolate option

### DIFF
--- a/162-docker_container_publish_all_option.yml
+++ b/162-docker_container_publish_all_option.yml
@@ -1,4 +1,0 @@
----
-minor_changes:
-  - docker_container - added ``publish_all_ports`` option to publish all exposed ports to random ports except those
-    explicitly bound with ``published_ports`` (https://github.com/ansible-collections/community.docker/pull/162).

--- a/changelogs/fragments/169-docker_compose-validate-config.yml
+++ b/changelogs/fragments/169-docker_compose-validate-config.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - docker_compose - added ``no-interpolate`` option and new state ``validated`` to proivde behavior similar to
+    ``docker-compose config`` (https://github.com/ansible-collections/community.docker/pull/169).

--- a/changelogs/fragments/169-docker_compose-validate-config.yml
+++ b/changelogs/fragments/169-docker_compose-validate-config.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
-  - docker_compose - added ``no-interpolate`` option and new state ``validated`` to proivde behavior similar to
+  - docker_compose - added ``no-interpolate`` option and new state ``validated`` to provide behavior similar to
     ``docker-compose config`` (https://github.com/ansible-collections/community.docker/pull/169).

--- a/plugins/modules/docker_compose.py
+++ b/plugins/modules/docker_compose.py
@@ -465,11 +465,11 @@ actions:
                           returned: always
                           type: str
 config:
-description:
-  - The resulting configuration from one or more compose files.
-  - Equivalent to the output of C(docker-compose config).
-returned: when success and I(state=validated)
-type: complex
+  description:
+    - The resulting configuration from one or more compose files.
+    - Equivalent to the output of C(docker-compose config).
+  returned: when success and I(state=validated)
+  type: dict
 '''
 
 import os

--- a/tests/integration/targets/docker_compose/tasks/tests/options.yml
+++ b/tests/integration/targets/docker_compose/tasks/tests/options.yml
@@ -95,3 +95,49 @@
         cname_1_name: "{{ pname + '_' + cname_1 + '_1' }}"
         cname_2_name: "{{ pname + '_' + cname_2 + '_1' }}"
   when: docker_compose_version is version('1.28.0', '>=')
+
+####################################################################
+## no_interpolate ##################################################
+####################################################################
+
+- name: Define service
+  set_fact:
+    sleep_time: 10m
+    test_service: |
+      version: '2'
+      services:
+        {{ cname_1 }}:
+          image: "{{ docker_test_image_alpine }}"
+          command: '/bin/sh -c "sleep ${SLEEP_TIME}"'
+          stop_grace_period: 1s
+    test_cases:
+      - test_name: unspecified
+      - test_name: "false"
+        no_interpolate_value: false
+      - test_name: "true"
+        no_interpolate_value: true
+
+- name: no_interpolate tests
+  environment:
+    SLEEP_TIME: "{{ sleep_time }}"
+  docker_compose:
+    project_name: "{{ pname }}"
+    definition: "{{ test_service | from_yaml }}"
+    state: validated
+    no_interpolate: "{{ test_case.no_interpolate_value | default(omit) }}"
+  register: no_interpolate_outputs
+  loop_control:
+    loop_var: test_case
+  loop: "{{ test_cases }}"
+
+- name: Cleanup
+  docker_compose:
+    project_name: "{{ pname }}"
+    state: absent
+    definition: "{{ test_service | from_yaml }}"
+
+- assert:
+    that:
+      - sleep_time in no_interpolate_outputs.results[0].config.services[cname_1].command
+      - sleep_time in no_interpolate_outputs.results[1].config.services[cname_1].command
+      - "'${SLEEP_TIME}' in no_interpolate_outputs.results[2].config.services[cname_1].command"

--- a/tests/integration/targets/docker_compose/tasks/tests/options.yml
+++ b/tests/integration/targets/docker_compose/tasks/tests/options.yml
@@ -100,44 +100,46 @@
 ## no_interpolate ##################################################
 ####################################################################
 
-- name: Define service
-  set_fact:
-    sleep_time: 10m
-    test_service: |
-      version: '2'
-      services:
-        {{ cname_1 }}:
-          image: "{{ docker_test_image_alpine }}"
-          command: '/bin/sh -c "sleep ${SLEEP_TIME}"'
-          stop_grace_period: 1s
-    test_cases:
-      - test_name: unspecified
-      - test_name: "false"
-        no_interpolate_value: false
-      - test_name: "true"
-        no_interpolate_value: true
+- block:
+    - name: Define service
+      set_fact:
+        sleep_time: 10m
+        test_service: |
+          version: '2'
+          services:
+            {{ cname_1 }}:
+              image: "{{ docker_test_image_alpine }}"
+              command: '/bin/sh -c "sleep ${SLEEP_TIME}"'
+              stop_grace_period: 1s
+        test_cases:
+          - test_name: unspecified
+          - test_name: "false"
+            no_interpolate_value: false
+          - test_name: "true"
+            no_interpolate_value: true
 
-- name: no_interpolate tests
-  environment:
-    SLEEP_TIME: "{{ sleep_time }}"
-  docker_compose:
-    project_name: "{{ pname }}"
-    definition: "{{ test_service | from_yaml }}"
-    state: validated
-    no_interpolate: "{{ test_case.no_interpolate_value | default(omit) }}"
-  register: no_interpolate_outputs
-  loop_control:
-    loop_var: test_case
-  loop: "{{ test_cases }}"
+    - name: no_interpolate tests
+      environment:
+        SLEEP_TIME: "{{ sleep_time }}"
+      docker_compose:
+        project_name: "{{ pname }}"
+        definition: "{{ test_service | from_yaml }}"
+        state: validated
+        no_interpolate: "{{ test_case.no_interpolate_value | default(omit) }}"
+      register: no_interpolate_outputs
+      loop_control:
+        loop_var: test_case
+      loop: "{{ test_cases }}"
 
-- name: Cleanup
-  docker_compose:
-    project_name: "{{ pname }}"
-    state: absent
-    definition: "{{ test_service | from_yaml }}"
+    - name: Cleanup
+      docker_compose:
+        project_name: "{{ pname }}"
+        state: absent
+        definition: "{{ test_service | from_yaml }}"
 
-- assert:
-    that:
-      - sleep_time in no_interpolate_outputs.results[0].config.services[cname_1].command
-      - sleep_time in no_interpolate_outputs.results[1].config.services[cname_1].command
-      - "'${SLEEP_TIME}' in no_interpolate_outputs.results[2].config.services[cname_1].command"
+    - assert:
+        that:
+          - sleep_time in no_interpolate_outputs.results[0].config.services[cname_1].command
+          - sleep_time in no_interpolate_outputs.results[1].config.services[cname_1].command
+          - "'${SLEEP_TIME}' in no_interpolate_outputs.results[2].config.services[cname_1].command"
+  when: docker_compose_version is version('1.25.0', '>=')

--- a/tests/integration/targets/docker_compose/tasks/tests/start-stop.yml
+++ b/tests/integration/targets/docker_compose/tasks/tests/start-stop.yml
@@ -24,6 +24,13 @@
           image: "{{ docker_test_image_alpine }}"
           command: '/bin/sh -c "sleep 15m"'
           stop_grace_period: 1s
+    broken_service: |
+      version: '2'
+      services:
+        broken:
+      image
+        command:
+        stop_grace_period: 1s
 
 ####################################################################
 ## Present #########################################################
@@ -227,3 +234,28 @@
     - started_4 is not changed
     - stopped_1 is changed
     - stopped_2 is changed
+
+####################################################################
+## Validated  ######################################################
+####################################################################
+
+- name: Validated success
+  docker_compose:
+    project_name: "{{ pname }}"
+    state: validated
+    definition: "{{ test_service | from_yaml }}"
+  register: validated_success
+
+- name: Validated failure
+  docker_compose:
+    project_name: "{{ pname }}"
+    state: validated
+    definition: "{{ broken_service | from_yaml }}"
+  ignore_errors: true
+  register: validated_failure
+
+- assert:
+    that:
+      - validated_success is success
+      - validated_success.config != {}
+      - validated_failure is failed


### PR DESCRIPTION
##### SUMMARY
Adds a new state `validated` along with a new option `no_interpolate` which is the equivalent of `docker-compose config`
Implements #24
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME
plugins/modules/docker-compose.py
##### ADDITIONAL INFORMATION
- Original request was just for validating configs with no output which is already covered by `check_mode` so the `validated` state was extended to actually display output like `docker-compose config`.
- `no-interpolate` adds the ability to show unsubstituted environment variables in the `config` output.