### PR TITLE
put example addresses in actual RFC1918 range

### DIFF
--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -981,7 +981,7 @@ EXAMPLES = '''
     image: ubuntu:14.04
     networks:
       - name: TestingNet
-        ipv4_address: "172.1.1.100"
+        ipv4_address: "172.16.1.100"
         aliases:
           - sleepyzz
         links:
@@ -999,11 +999,11 @@ EXAMPLES = '''
     name: sleepy
     networks:
       - name: TestingNet
-        ipv4_address: 172.1.1.18
+        ipv4_address: 172.16.1.18
         links:
           - sleeper
       - name: TestingNet2
-        ipv4_address: 172.1.10.20
+        ipv4_address: 172.16.10.20
 
 - name: Update network with aliases
   community.docker.docker_container:

--- a/plugins/modules/docker_network.py
+++ b/plugins/modules/docker_network.py
@@ -204,12 +204,12 @@ EXAMPLES = '''
   community.docker.docker_network:
     name: network_three
     ipam_config:
-      - subnet: 172.3.27.0/24
-        gateway: 172.3.27.2
-        iprange: 172.3.27.0/26
+      - subnet: 172.23.27.0/24
+        gateway: 172.23.27.2
+        iprange: 172.23.27.0/26
         aux_addresses:
-          host1: 172.3.27.3
-          host2: 172.3.27.4
+          host1: 172.23.27.3
+          host2: 172.23.27.4
 
 - name: Create a network with labels
   community.docker.docker_network:
@@ -230,7 +230,7 @@ EXAMPLES = '''
     name: network_ipv6_two
     enable_ipv6: yes
     ipam_config:
-      - subnet: 172.4.27.0/24
+      - subnet: 172.24.27.0/24
       - subnet: fdd1:ac8c:0557:7ce2::/64
 
 - name: Delete a network, disconnecting all containers

--- a/tests/integration/targets/docker_network/tasks/tests/ipam.yml
+++ b/tests/integration/targets/docker_network/tasks/tests/ipam.yml
@@ -17,12 +17,12 @@
   docker_network:
     name: "{{ nname_ipam_1 }}"
     ipam_config:
-      - subnet: 172.3.27.0/24
-        gateway: 172.3.27.2
-        iprange: 172.3.27.0/26
+      - subnet: 172.23.27.0/24
+        gateway: 172.23.27.2
+        iprange: 172.23.27.0/26
         aux_addresses:
-          host1: 172.3.27.3
-          host2: 172.3.27.4
+          host1: 172.23.27.3
+          host2: 172.23.27.4
   register: network
 
 - assert:
@@ -33,12 +33,12 @@
   docker_network:
     name: "{{ nname_ipam_1 }}"
     ipam_config:
-      - subnet: 172.3.27.0/24
-        gateway: 172.3.27.2
-        iprange: 172.3.27.0/26
+      - subnet: 172.23.27.0/24
+        gateway: 172.23.27.2
+        iprange: 172.23.27.0/26
         aux_addresses:
-          host1: 172.3.27.3
-          host2: 172.3.27.4
+          host1: 172.23.27.3
+          host2: 172.23.27.4
   register: network
 
 - assert:
@@ -49,11 +49,11 @@
   docker_network:
     name: "{{ nname_ipam_1 }}"
     ipam_config:
-      - subnet: 172.3.28.0/24
-        gateway: 172.3.28.2
-        iprange: 172.3.28.0/26
+      - subnet: 172.23.28.0/24
+        gateway: 172.23.28.2
+        iprange: 172.23.28.0/26
         aux_addresses:
-          host1: 172.3.28.3
+          host1: 172.23.28.3
   register: network
   diff: yes
 
@@ -70,7 +70,7 @@
   docker_network:
     name: "{{ nname_ipam_1 }}"
     ipam_config:
-      - subnet: 172.3.28.0/24
+      - subnet: 172.23.28.0/24
   register: network
 
 - assert:
@@ -151,7 +151,7 @@
     name: "{{ nname_ipam_3 }}"
     enable_ipv6: yes
     ipam_config:
-      - subnet: 172.4.27.0/24
+      - subnet: 172.24.27.0/24
       - subnet: fdd1:ac8c:0557:7ce2::/64
   register: network
 
@@ -165,7 +165,7 @@
     enable_ipv6: yes
     ipam_config:
       - subnet: fdd1:ac8c:0557:7ce2::/64
-      - subnet: 172.4.27.0/24
+      - subnet: 172.24.27.0/24
   register: network
 
 - assert:
@@ -177,7 +177,7 @@
     name: "{{ nname_ipam_3 }}"
     enable_ipv6: no
     ipam_config:
-      - subnet: 172.4.27.0/24
+      - subnet: 172.24.27.0/24
   register: network
   diff: yes
 
@@ -203,8 +203,8 @@
       driver_options:
         parent: "{{ ansible_default_ipv4.alias }}"
       ipam_config:
-        - subnet: 172.4.27.0/24
-        - subnet: 172.4.28.0/24
+        - subnet: 172.24.27.0/24
+        - subnet: 172.24.28.0/24
     register: network
 
   - assert:
@@ -218,8 +218,8 @@
       driver_options:
         parent: "{{ ansible_default_ipv4.alias }}"
       ipam_config:
-        - subnet: 172.4.28.0/24
-        - subnet: 172.4.27.0/24
+        - subnet: 172.24.28.0/24
+        - subnet: 172.24.27.0/24
     register: network
 
   - assert:
@@ -233,8 +233,8 @@
       driver_options:
         parent: "{{ ansible_default_ipv4.alias }}"
       ipam_config:
-        - subnet: 172.4.27.0/24
-        - subnet: 172.4.29.0/24
+        - subnet: 172.24.27.0/24
+        - subnet: 172.24.29.0/24
     register: network
     diff: yes
 
@@ -250,7 +250,7 @@
       driver_options:
         parent: "{{ ansible_default_ipv4.alias }}"
       ipam_config:
-        - subnet: 172.4.29.0/24
+        - subnet: 172.24.29.0/24
     register: network
 
   - assert:


### PR DESCRIPTION
172.1/16, 172.3/16 and 172.4/16 are not in the 172.16/12 range.

https://datatracker.ietf.org/doc/html/rfc1918#section-3

##### SUMMARY
The docker_network & docker_container examples threw me off since they were using non-private IPv4 address spaces. This seems like a mistake, so replace them with actual private address spaces.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docker_container
docker_network