### PR TITLE
Add nsenter connection plugin

### DIFF
--- a/plugins/connection/nsenter.py
+++ b/plugins/connection/nsenter.py
@@ -234,7 +234,7 @@ class Connection(ConnectionBase):
             rc, out, err = self.exec_command(cmd=["cat", in_path])
             display.vvv(u"FETCH {0} TO {1}".format(in_path, out_path), host=self._play_context.remote_addr)
             if rc != 0:
-                raise AnsibleError('Failed to fetch file `{0}`: {1}'.format(in_path, err))
+                raise AnsibleError("failed to transfer file to {0}: {1}".format(in_path, err))
             with open(to_bytes(out_path, errors='surrogate_or_strict'), 'wb') as out_file:
                 out_file.write(out)
         except IOError as e:

--- a/plugins/connection/nsenter.py
+++ b/plugins/connection/nsenter.py
@@ -1,0 +1,250 @@
+# (c) 2021 Jeff Goldschrafe <jeff@holyhandgrenade.org>
+# Based on Ansible local connection plugin by:
+# (c) 2012 Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2015, 2017 Toshio Kuratomi <tkuratomi@ansible.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    name: nsenter
+    short_description: execute on host running controller container
+    description:
+        - This connection plugin allows Ansible, running in a privileged container, to execute tasks on the container
+          host instead of in the container itself.
+        - This is useful for running Ansible in a pull model, while still keeping the Ansible control node
+          containerized.
+        - It relies on having privileged access to run nsenter in the host's PID namespace, allowing it to enter the
+          namespace of PID 1.
+    author: Jeff Goldschrafe (@jgoldschrafe)
+    options:
+        host_volume_mount:
+            description:
+                - Host volume mount to read and write host files through
+            default: /host
+            vars:
+                - name: ansible_host_volume_mount
+            env:
+                - name: ANSIBLE_HOST_VOLUME_MOUNT
+            ini:
+                - section: nsenter_connection
+                  key: host_volume_mount
+        nsenter_pid:
+            description:
+                - PID to attach with using nsenter.
+                - The default should be fine unless you're attaching as a non-root user.
+            default: '1'
+            vars:
+                - name: ansible_nsenter_pid
+            env:
+                - name: ANSIBLE_NSENTER_PID
+            ini:
+                - section: nsenter_connection
+                  key: nsenter_pid
+        pipelining:
+            default: ANSIBLE_PIPELINING
+            description:
+                - Pipelining reduces the number of connection operations required to execute a module on the remote
+                  server, by executing many Ansible modules without actual file transfers.
+                - This can result in a very significant performance improvement when enabled.
+                - However this can conflict with privilege escalation (become).
+                  For example, when using sudo operations you must first disable 'requiretty' in the sudoers file for
+                  the target hosts, which is why this feature is disabled by default.
+            env:
+                - name: ANSIBLE_PIPELINING
+            ini:
+                - section: defaults
+                  key: pipelining
+            type: boolean
+            vars:
+                - name: ansible_pipelining
+    notes:
+        - The remote user is ignored; this plugin always runs as root.
+        - This plugin requires the container to be launched in the following way:
+            - The container image contains the C(nsenter) program
+            - C(/) on the host is mounted read-write to C(/host) in the container
+            - The container is launched in privileged mode
+            - The container is launched in the host's PID namespace using C(--pid host)
+'''
+
+import os
+import pty
+import shutil
+import subprocess
+import fcntl
+
+import ansible.constants as C
+from ansible.errors import AnsibleError, AnsibleFileNotFound
+from ansible.module_utils.compat import selectors
+from ansible.module_utils.six import text_type, binary_type
+from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.plugins.connection import ConnectionBase
+from ansible.utils.display import Display
+from ansible.utils.path import unfrackpath
+
+display = Display()
+
+
+class Connection(ConnectionBase):
+    '''Connections to a container host using nsenter
+    '''
+
+    transport = 'nsenter'
+    has_pipelining = True
+
+    def __init__(self, *args, **kwargs):
+        super(Connection, self).__init__(*args, **kwargs)
+        self.cwd = None
+        self._host_volume_mount = self.get_option("host_volume_mount")
+        self._nsenter_pid = self.get_option("nsenter_pid")
+
+        if not os.path.exists(self._host_volume_mount):
+            raise AnsibleError("nsenter: host volume mount does not exist: " + self._host_volume_mount)
+
+    def _connect(self):
+        # Because nsenter requires very high privileges, our remote user
+        # is always assumed to be root.
+        self._play_context.remote_user = "root"
+
+        if not self._connected:
+            display.vvv(
+                u"ESTABLISH NSENTER CONNECTION FOR USER: {0}".format(
+                    self._play_context.remote_user
+                ),
+                host=self._play_context.remote_addr,
+            )
+            self._connected = True
+        return self
+
+    def exec_command(self, cmd, in_data=None, sudoable=True):
+        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
+
+        display.debug("in nsenter.exec_command()")
+
+        executable = C.DEFAULT_EXECUTABLE.split()[0] if C.DEFAULT_EXECUTABLE else None
+
+        if not os.path.exists(to_bytes(executable, errors='surrogate_or_strict')):
+            raise AnsibleError("failed to find the executable specified %s."
+                               " Please verify if the executable exists and re-try." % executable)
+
+        # Rewrite the provided command to prefix it with nsenter
+        if isinstance(cmd, (text_type, binary_type)):
+            nsenter_cmd = "nsenter --all --preserve-credentials --target={0} -- ".format(self._nsenter_pid)
+            cmd = to_bytes(nsenter_cmd + cmd)
+        else:
+            nsenter_cmd = ["nsenter", "--all", "--preserve-credentials", "--target", self._nsenter_pid, "--"]
+            cmd = map(to_bytes, nsenter_cmd + cmd)
+
+        display.vvv(u"EXEC {0}".format(to_text(cmd)), host=self._play_context.remote_addr)
+        display.debug("opening command with Popen()")
+
+        master = None
+        stdin = subprocess.PIPE
+        if sudoable and self.become and self.become.expect_prompt() and not self.get_option('pipelining'):
+            # Create a pty if sudoable for privlege escalation that needs it.
+            # Falls back to using a standard pipe if this fails, which may
+            # cause the command to fail in certain situations where we are escalating
+            # privileges or the command otherwise needs a pty.
+            try:
+                master, stdin = pty.openpty()
+            except (IOError, OSError) as e:
+                display.debug("Unable to open pty: %s" % to_native(e))
+
+        p = subprocess.Popen(
+            cmd,
+            shell=isinstance(cmd, (text_type, binary_type)),
+            executable=executable,
+            cwd=self.cwd,
+            stdin=stdin,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        # if we created a master, we can close the other half of the pty now, otherwise master is stdin
+        if master is not None:
+            os.close(stdin)
+
+        display.debug("done running command with Popen()")
+
+        if self.become and self.become.expect_prompt() and sudoable:
+            fcntl.fcntl(p.stdout, fcntl.F_SETFL, fcntl.fcntl(p.stdout, fcntl.F_GETFL) | os.O_NONBLOCK)
+            fcntl.fcntl(p.stderr, fcntl.F_SETFL, fcntl.fcntl(p.stderr, fcntl.F_GETFL) | os.O_NONBLOCK)
+            selector = selectors.DefaultSelector()
+            selector.register(p.stdout, selectors.EVENT_READ)
+            selector.register(p.stderr, selectors.EVENT_READ)
+
+            become_output = b''
+            try:
+                while not self.become.check_success(become_output) and not self.become.check_password_prompt(become_output):
+                    events = selector.select(self._play_context.timeout)
+                    if not events:
+                        stdout, stderr = p.communicate()
+                        raise AnsibleError('timeout waiting for privilege escalation password prompt:\n' + to_native(become_output))
+
+                    for key, event in events:
+                        if key.fileobj == p.stdout:
+                            chunk = p.stdout.read()
+                        elif key.fileobj == p.stderr:
+                            chunk = p.stderr.read()
+
+                    if not chunk:
+                        stdout, stderr = p.communicate()
+                        raise AnsibleError('privilege output closed while waiting for password prompt:\n' + to_native(become_output))
+                    become_output += chunk
+            finally:
+                selector.close()
+
+            if not self.become.check_success(become_output):
+                become_pass = self.become.get_option('become_pass', playcontext=self._play_context)
+                if master is None:
+                    p.stdin.write(to_bytes(become_pass, errors='surrogate_or_strict') + b'\n')
+                else:
+                    os.write(master, to_bytes(become_pass, errors='surrogate_or_strict') + b'\n')
+
+            fcntl.fcntl(p.stdout, fcntl.F_SETFL, fcntl.fcntl(p.stdout, fcntl.F_GETFL) & ~os.O_NONBLOCK)
+            fcntl.fcntl(p.stderr, fcntl.F_SETFL, fcntl.fcntl(p.stderr, fcntl.F_GETFL) & ~os.O_NONBLOCK)
+
+        display.debug("getting output with communicate()")
+        stdout, stderr = p.communicate(in_data)
+        display.debug("done communicating")
+
+        # finally, close the other half of the pty, if it was created
+        if master:
+            os.close(master)
+
+        display.debug("done with nsenter.exec_command()")
+        return (p.returncode, stdout, stderr)
+
+    def put_file(self, in_path, out_path):
+        super(Connection, self).put_file(in_path, out_path)
+
+        # Rewrite out_path into host volume mount
+        in_path = unfrackpath(in_path, basedir=self.cwd)
+        out_path = self._host_volume_mount + unfrackpath(out_path, basedir=self.cwd)
+
+        return self._transfer_file("fetch", in_path, out_path)
+
+    def fetch_file(self, in_path, out_path):
+        super(Connection, self).fetch_file(in_path, out_path)
+
+        # Rewrite in_path into host volume mount
+        in_path = self._host_volume_mount + unfrackpath(in_path, basedir=self.cwd)
+        out_path = unfrackpath(out_path, basedir=self.cwd)
+
+        return self._transfer_file("fetch", in_path, out_path)
+
+    def close(self):
+        ''' terminate the connection; nothing to do here '''
+        self._connected = False
+
+    def _transfer_file(self, action, in_path, out_path):
+        display.vvv(u"{0} {1} TO {2}".format(action.upper(), in_path, out_path), host=self._play_context.remote_addr)
+        if not os.path.exists(to_bytes(in_path, errors='surrogate_or_strict')):
+            raise AnsibleFileNotFound("file or module does not exist: {0}".format(to_native(in_path)))
+        try:
+            shutil.copyfile(to_bytes(in_path, errors='surrogate_or_strict'), to_bytes(out_path, errors='surrogate_or_strict'))
+        except shutil.Error:
+            raise AnsibleError("failed to copy: {0} and {1} are the same".format(to_native(in_path), to_native(out_path)))
+        except IOError as e:
+            raise AnsibleError("failed to transfer file to {0}: {1}".format(to_native(out_path), to_native(e)))

--- a/plugins/connection/nsenter.py
+++ b/plugins/connection/nsenter.py
@@ -22,7 +22,7 @@ DOCUMENTATION = '''
     options:
         host_volume_mount:
             description:
-                - Host volume mount to read and write host files through
+                - Host volume mount to read and write host files through.
             type: string
             default: /host
             vars:
@@ -45,23 +45,23 @@ DOCUMENTATION = '''
             ini:
                 - section: nsenter_connection
                   key: nsenter_pid
-    #     pipelining:
-    #         default: ANSIBLE_PIPELINING
-    #         description:
-    #             - Pipelining reduces the number of connection operations required to execute a module on the remote
-    #               server, by executing many Ansible modules without actual file transfers.
-    #             - This can result in a very significant performance improvement when enabled.
-    #             - However this can conflict with privilege escalation (become).
-    #               For example, when using sudo operations you must first disable 'requiretty' in the sudoers file for
-    #               the target hosts, which is why this feature is disabled by default.
-    #         env:
-    #             - name: ANSIBLE_PIPELINING
-    #         ini:
-    #             - section: defaults
-    #               key: pipelining
-    #         type: boolean
-    #         vars:
-    #             - name: ansible_pipelining
+        pipelining:
+            default: ANSIBLE_PIPELINING
+            description:
+                - Pipelining reduces the number of connection operations required to execute a module on the remote
+                  server, by executing many Ansible modules without actual file transfers.
+                - This can result in a very significant performance improvement when enabled.
+                - However this can conflict with privilege escalation (become).
+                  For example, when using sudo operations you must first disable 'requiretty' in the sudoers file for
+                  the target hosts, which is why this feature is disabled by default.
+            env:
+                - name: ANSIBLE_PIPELINING
+            ini:
+                - section: defaults
+                  key: pipelining
+            type: boolean
+            vars:
+                - name: ansible_pipelining
     notes:
         - The remote user is ignored; this plugin always runs as root.
         - "This plugin requires the Ansible controller container to be launched in the following way:"

--- a/plugins/connection/nsenter.py
+++ b/plugins/connection/nsenter.py
@@ -80,7 +80,7 @@ class Connection(ConnectionBase):
     '''Connections to a container host using nsenter
     '''
 
-    transport = 'nsenter'
+    transport = 'community.docker.nsenter'
     has_pipelining = True
 
     def __init__(self, *args, **kwargs):

--- a/plugins/connection/nsenter.py
+++ b/plugins/connection/nsenter.py
@@ -117,7 +117,7 @@ class Connection(ConnectionBase):
         # Rewrite the provided command to prefix it with nsenter
         if isinstance(cmd, string_types):
             nsenter_cmd = "nsenter --all --preserve-credentials --target={0} -- ".format(self._nsenter_pid)
-            cmd = to_bytes(nsenter_cmd + cmd)
+            cmd = to_bytes(nsenter_cmd) + to_bytes(cmd)
         else:
             nsenter_cmd = [
                 "nsenter",

--- a/plugins/connection/nsenter.py
+++ b/plugins/connection/nsenter.py
@@ -56,7 +56,7 @@ DOCUMENTATION = '''
             This plugin requires the Ansible controller container to be launched in the following way:
             (1) The container image contains the nsenter program;
             (2) The container is launched in privileged mode;
-            (3) The container is launched in the host's PID namespace (i.e. C(--pid host)).
+            (3) The container is launched in the host's PID namespace (C(--pid host)).
 '''
 
 import os

--- a/plugins/connection/nsenter.py
+++ b/plugins/connection/nsenter.py
@@ -115,7 +115,7 @@ class Connection(ConnectionBase):
                                " Please verify if the executable exists and re-try." % executable)
 
         # Rewrite the provided command to prefix it with nsenter
-        if isinstance(cmd, (text_type, binary_type)):
+        if isinstance(cmd, string_types):
             nsenter_cmd = "nsenter --all --preserve-credentials --target={0} -- ".format(self._nsenter_pid)
             cmd = to_bytes(nsenter_cmd + cmd)
         else:

--- a/plugins/connection/nsenter.py
+++ b/plugins/connection/nsenter.py
@@ -68,7 +68,7 @@ import fcntl
 import ansible.constants as C
 from ansible.errors import AnsibleError, AnsibleFileNotFound
 from ansible.module_utils.compat import selectors
-from ansible.module_utils.six import string_types
+from ansible.module_utils.six import binary_type, text_type
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.plugins.connection import ConnectionBase
 from ansible.utils.display import Display
@@ -116,7 +116,7 @@ class Connection(ConnectionBase):
                                " Please verify if the executable exists and re-try." % executable)
 
         # Rewrite the provided command to prefix it with nsenter
-        if isinstance(cmd, string_types):
+        if isinstance(cmd, (text_type, binary_type)):
             nsenter_cmd = "nsenter --all --preserve-credentials --target={0} -- ".format(self._nsenter_pid)
             cmd = to_bytes(nsenter_cmd) + to_bytes(cmd)
         else:

--- a/plugins/connection/nsenter.py
+++ b/plugins/connection/nsenter.py
@@ -52,10 +52,11 @@ DOCUMENTATION = '''
                 - name: ansible_pipelining
     notes:
         - The remote user is ignored; this plugin always runs as root.
-        - "This plugin requires the Ansible controller container to be launched in the following way:"
-        - (1) The container image contains the nsenter program;
-        - (2) The container is launched in privileged mode;
-        - (3) The container is launched in the host's PID namespace (i.e. C(--pid host)).
+        - >-
+            This plugin requires the Ansible controller container to be launched in the following way:
+            (1) The container image contains the nsenter program;
+            (2) The container is launched in privileged mode;
+            (3) The container is launched in the host's PID namespace (i.e. C(--pid host)).
 '''
 
 import os

--- a/plugins/connection/nsenter.py
+++ b/plugins/connection/nsenter.py
@@ -218,7 +218,7 @@ class Connection(ConnectionBase):
         try:
             with open(to_bytes(in_path, errors="surrogate_or_strict"), "rb") as in_file:
                 in_data = in_file.read()
-            rc, _, err = self.exec_command(cmd=["tee", out_path], in_data=in_data)
+            rc, out, err = self.exec_command(cmd=["tee", out_path], in_data=in_data)
             if rc != 0:
                 raise AnsibleError("failed to transfer file to {0}: {1}".format(out_path, err))
         except IOError as e:

--- a/plugins/connection/nsenter.py
+++ b/plugins/connection/nsenter.py
@@ -67,7 +67,7 @@ import fcntl
 import ansible.constants as C
 from ansible.errors import AnsibleError, AnsibleFileNotFound
 from ansible.module_utils.compat import selectors
-from ansible.module_utils.six import text_type, binary_type
+from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.plugins.connection import ConnectionBase
 from ansible.utils.display import Display

--- a/plugins/connection/nsenter.py
+++ b/plugins/connection/nsenter.py
@@ -54,7 +54,7 @@ DOCUMENTATION = '''
         - The remote user is ignored; this plugin always runs as root.
         - >-
             This plugin requires the Ansible controller container to be launched in the following way:
-            (1) The container image contains the nsenter program;
+            (1) The container image contains the C(nsenter) program;
             (2) The container is launched in privileged mode;
             (3) The container is launched in the host's PID namespace (C(--pid host)).
 '''

--- a/plugins/connection/nsenter.py
+++ b/plugins/connection/nsenter.py
@@ -69,7 +69,7 @@ import ansible.constants as C
 from ansible.errors import AnsibleError, AnsibleFileNotFound
 from ansible.module_utils.compat import selectors
 from ansible.module_utils.six import binary_type, text_type
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.plugins.connection import ConnectionBase
 from ansible.utils.display import Display
 from ansible.utils.path import unfrackpath

--- a/plugins/connection/nsenter.py
+++ b/plugins/connection/nsenter.py
@@ -123,7 +123,7 @@ class Connection(ConnectionBase):
                 "nsenter",
                 "--all",
                 "--preserve-credentials",
-                "--target=" + str(self._nsenter_pid),
+                "--target={0}".format(self._nsenter_pid),
                 "--",
             ]
             cmd = [to_bytes(arg) for arg in nsenter_cmd + cmd]

--- a/plugins/connection/nsenter.py
+++ b/plugins/connection/nsenter.py
@@ -16,7 +16,7 @@ DOCUMENTATION = '''
           host instead of in the container itself.
         - This is useful for running Ansible in a pull model, while still keeping the Ansible control node
           containerized.
-        - It relies on having privileged access to run nsenter in the host's PID namespace, allowing it to enter the
+        - It relies on having privileged access to run C(nsenter) in the host's PID namespace, allowing it to enter the
           namespaces of the provided PID (default PID 1, or init/systemd).
     author: Jeff Goldschrafe (@jgoldschrafe)
     options:

--- a/plugins/connection/nsenter.py
+++ b/plugins/connection/nsenter.py
@@ -23,7 +23,7 @@ DOCUMENTATION = '''
         nsenter_pid:
             description:
                 - PID to attach with using nsenter.
-                - The default should be fine unless you're attaching as a non-root user.
+                - The default should be fine unless you are attaching as a non-root user.
             type: int
             default: 1
             vars:

--- a/tests/integration/targets/connection_nsenter/aliases
+++ b/tests/integration/targets/connection_nsenter/aliases
@@ -1,0 +1,3 @@
+skip/docker  # this requires unfettered access to the container host
+destructive
+unsupported

--- a/tests/integration/targets/connection_nsenter/aliases
+++ b/tests/integration/targets/connection_nsenter/aliases
@@ -1,3 +1,3 @@
+shippable/posix/group5
 skip/docker  # this requires unfettered access to the container host
 destructive
-unsupported

--- a/tests/integration/targets/connection_nsenter/aliases
+++ b/tests/integration/targets/connection_nsenter/aliases
@@ -1,3 +1,4 @@
 shippable/posix/group5
 skip/docker  # this requires unfettered access to the container host
+skip/rhel7.9  # nsenter does not work out of the box
 destructive

--- a/tests/integration/targets/connection_nsenter/meta/main.yml
+++ b/tests/integration/targets/connection_nsenter/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_docker

--- a/tests/integration/targets/connection_nsenter/runme-connection.sh
+++ b/tests/integration/targets/connection_nsenter/runme-connection.sh
@@ -1,0 +1,1 @@
+../connection_posix/test.sh

--- a/tests/integration/targets/connection_nsenter/runme.sh
+++ b/tests/integration/targets/connection_nsenter/runme.sh
@@ -56,7 +56,6 @@ docker run \
     --pid host \
     "${envs[@]}" \
     --volume "${COLLECTION_ROOT}:${COLLECTION_ROOT}" \
-    --volume /:/host \
     --workdir "$(pwd)" \
     "${IMAGE}" \
     ./runme-connection.sh "$@"

--- a/tests/integration/targets/connection_nsenter/runme.sh
+++ b/tests/integration/targets/connection_nsenter/runme.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+[[ -n "${DEBUG:-}" || -n "${ANSIBLE_DEBUG:-}" ]] && set -x
+
+readonly IMAGE="quay.io/ansible/toolset:latest"
+readonly COLLECTION_ROOT="$(git rev-parse --show-toplevel)"
+readonly PYTHON="$(command -v python3 python | head -n1)"
+
+# Setup phase
+echo "Setup"
+ANSIBLE_ROLES_PATH=.. ansible-playbook setup.yml
+
+# If docker wasn't installed, don't run the tests
+if [ "$(command -v docker)" == "" ]; then
+    exit
+fi
+
+cleanup() {
+    echo "Cleanup"
+    echo "Shutdown"
+    ANSIBLE_ROLES_PATH=.. ansible-playbook shutdown.yml
+    echo "Done"
+    exit 0
+}
+
+envs=(--env "HOME=${HOME:-}")
+while IFS=$'\0' read -d '' -r line; do
+    key="$(echo "$line" | cut -d= -f1)"
+    value="$(echo "$line" | cut -d= -f2-)"
+    if [[ "${key}" =~ ^(ANSIBLE_|JUNIT_OUTPUT_DIR$|OUTPUT_DIR$|PYTHONPATH$) ]]; then
+        envs+=(--env "${key}=${value}")
+    fi
+done < <(printenv -0)
+
+# Test phase
+cat > test_connection.inventory << EOF
+[nsenter]
+nsenter-no-pipelining ansible_pipelining=false
+nsenter-pipelining    ansible_pipelining=true
+
+[nsenter:vars]
+ansible_host=localhost
+ansible_connection=community.docker.nsenter
+ansible_host_volume_mount=/host
+ansible_nsenter_pid=1
+ansible_python_interpreter=${PYTHON}
+EOF
+
+echo "Run tests"
+docker run \
+    -it \
+    --rm \
+    --privileged \
+    --pid host \
+    "${envs[@]}" \
+    --volume "${COLLECTION_ROOT}:${COLLECTION_ROOT}" \
+    --volume /:/host \
+    --workdir "$(pwd)" \
+    "${IMAGE}" \
+    ./runme-connection.sh "$@"

--- a/tests/integration/targets/connection_nsenter/runme.sh
+++ b/tests/integration/targets/connection_nsenter/runme.sh
@@ -36,10 +36,10 @@ while IFS=$'\0' read -d '' -r line; do
 done < <(printenv -0)
 
 # Make sure the directory containing ansible_collections is in Ansible's search path
-if [ "${ANSIBLE_COLLECTIONS_PATHS}" == "" ]; then
-    envs+=(--env "ANSIBLE_COLLECTIONS_PATHS=${COLLECTIONS_PATH}")
-else
+if [ -v ANSIBLE_COLLECTIONS_PATHS ]; then
     envs+=(--env "ANSIBLE_COLLECTIONS_PATHS=${COLLECTIONS_PATH}:${ANSIBLE_COLLECTIONS_PATHS}")
+else
+    envs+=(--env "ANSIBLE_COLLECTIONS_PATHS=${COLLECTIONS_PATH}")
 fi
 
 # Test phase

--- a/tests/integration/targets/connection_nsenter/runme.sh
+++ b/tests/integration/targets/connection_nsenter/runme.sh
@@ -57,6 +57,7 @@ ansible_python_interpreter=${PYTHON}
 EOF
 
 echo "Run tests"
+set -x
 docker run \
     -it \
     --rm \

--- a/tests/integration/targets/connection_nsenter/runme.sh
+++ b/tests/integration/targets/connection_nsenter/runme.sh
@@ -6,7 +6,6 @@ set -euo pipefail
 
 readonly IMAGE="quay.io/ansible/toolset:latest"
 readonly COLLECTION_ROOT="$(cd ../../../.. ; pwd)"
-readonly COLLECTIONS_PATH="$(cd ../../../../../../.. ; pwd)"
 readonly PYTHON="$(command -v python3 python | head -n1)"
 
 # Setup phase
@@ -34,13 +33,6 @@ while IFS=$'\0' read -d '' -r line; do
         envs+=(--env "${key}=${value}")
     fi
 done < <(printenv -0)
-
-# Make sure the directory containing ansible_collections is in Ansible's search path
-if [ -v ANSIBLE_COLLECTIONS_PATHS ]; then
-    envs+=(--env "ANSIBLE_COLLECTIONS_PATHS=${COLLECTIONS_PATH}:${ANSIBLE_COLLECTIONS_PATHS}")
-else
-    envs+=(--env "ANSIBLE_COLLECTIONS_PATHS=${COLLECTIONS_PATH}")
-fi
 
 # Test phase
 cat > test_connection.inventory << EOF

--- a/tests/integration/targets/connection_nsenter/runme.sh
+++ b/tests/integration/targets/connection_nsenter/runme.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 [[ -n "${DEBUG:-}" || -n "${ANSIBLE_DEBUG:-}" ]] && set -x
 
 readonly IMAGE="quay.io/ansible/toolset:latest"
-readonly COLLECTION_ROOT="$(git rev-parse --show-toplevel)"
+readonly COLLECTION_ROOT="$(cd ../../../.. ; pwd)"
 readonly PYTHON="$(command -v python3 python | head -n1)"
 
 # Setup phase

--- a/tests/integration/targets/connection_nsenter/runme.sh
+++ b/tests/integration/targets/connection_nsenter/runme.sh
@@ -5,8 +5,17 @@ set -euo pipefail
 [[ -n "${DEBUG:-}" || -n "${ANSIBLE_DEBUG:-}" ]] && set -x
 
 readonly IMAGE="quay.io/ansible/toolset:latest"
-readonly COLLECTION_ROOT="$(cd ../../../.. ; pwd)"
 readonly PYTHON="$(command -v python3 python | head -n1)"
+
+# Determine collection root
+COLLECTION_ROOT=./
+while true; do
+    if [ -e ${COLLECTION_ROOT}galaxy.yml ] || [ -e ${COLLECTION_ROOT}MANIFEST.json ]; then
+        break
+    fi
+    COLLECTION_ROOT="${COLLECTION_ROOT}../"
+done
+readonly COLLECTION_ROOT="$(cd ${COLLECTION_ROOT} ; pwd)"
 
 # Setup phase
 echo "Setup"

--- a/tests/integration/targets/connection_nsenter/runme.sh
+++ b/tests/integration/targets/connection_nsenter/runme.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 readonly IMAGE="quay.io/ansible/toolset:latest"
 readonly COLLECTION_ROOT="$(cd ../../../.. ; pwd)"
+readonly COLLECTIONS_PATH="$(cd ../../../../../../.. ; pwd)"
 readonly PYTHON="$(command -v python3 python | head -n1)"
 
 # Setup phase
@@ -33,6 +34,13 @@ while IFS=$'\0' read -d '' -r line; do
         envs+=(--env "${key}=${value}")
     fi
 done < <(printenv -0)
+
+# Make sure the directory containing ansible_collections is in Ansible's search path
+if [ "${ANSIBLE_COLLECTIONS_PATHS}" == "" ]; then
+    envs+=(--env "ANSIBLE_COLLECTIONS_PATHS=${COLLECTIONS_PATH}")
+else
+    envs+=(--env "ANSIBLE_COLLECTIONS_PATHS=${COLLECTIONS_PATH}:${ANSIBLE_COLLECTIONS_PATHS}")
+fi
 
 # Test phase
 cat > test_connection.inventory << EOF

--- a/tests/integration/targets/connection_nsenter/setup.yml
+++ b/tests/integration/targets/connection_nsenter/setup.yml
@@ -1,0 +1,10 @@
+---
+- hosts: localhost
+  connection: local
+  vars:
+    docker_skip_cleanup: yes
+
+  tasks:
+    - name: Setup docker
+      import_role:
+        name: setup_docker

--- a/tests/integration/targets/connection_nsenter/shutdown.yml
+++ b/tests/integration/targets/connection_nsenter/shutdown.yml
@@ -1,0 +1,15 @@
+---
+- hosts: localhost
+  connection: local
+  vars:
+    docker_skip_cleanup: yes
+
+  tasks:
+    - name: Remove docker packages
+      action: "{{ ansible_facts.pkg_mgr }}"
+      args:
+        name:
+          - docker
+          - docker-ce
+          - docker-ce-cli
+        state: absent


### PR DESCRIPTION
##### SUMMARY
Add a new `nsenter` connection plugin, which uses the `nsenter` utility to run commands in the context of another namespace.

Currently, if you are running Ansible in a pull capacity (i.e. a host downloads Ansible content and executes plays against itself), it is difficult to run the Ansible controller in a Docker container; the `local` connection type is not effective as the container is an isolated, ephemeral environment. If you are very insistent, you may do something like grant the container access to the host OS over SSH. This can be complicated and error-prone, especially with complex Docker networking configurations.

This connection plugin allows a containerized Ansible controller, if launched in a specific way, to escape the container (if it is granted those privileges) and manage the host it is running on, dramatically simplifying the process of managing Ansible versions and their dependencies, especially for hosts running Python < 3.8 (such as Ubuntu 18.04).

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
nsenter

##### ADDITIONAL INFORMATION
The plugin is largely based on the `local` connection plugin from Ansible core, with some small changes.

An example invocation of the container might look like:

```
docker run \
    --rm \
    --privileged \
    --pid host \
    --volume /:/host \
    --volume /my/ansible/content:/my/ansible/content \
    --workdir /my/ansible/content \
    my-ansible-image:latest \
    ansible-playbook playbooks/my-playbook.yml
```

It is hypothetically possible for this to work running as a non-root user in the container. It has not been tested.

The test suite is currently marked as `unsupported` because invocation is a mess and `runme.sh` directly invokes a container to run ansible-playbook. `ansible-test` allows suites to be marked as privileged via the `needs/privileged` integration alias, but does not currently support namespace options (i.e. `--pid host`) or volume mounts.