### PR TITLE
Add default value if 'registry_url' is provided and its empty

### DIFF
--- a/plugins/modules/docker_login.py
+++ b/plugins/modules/docker_login.py
@@ -288,7 +288,7 @@ class LoginManager(DockerBaseClass):
         parameters = self.client.module.params
         self.check_mode = self.client.check_mode
 
-        self.registry_url = parameters.get('registry_url')
+        self.registry_url = parameters.get('registry_url') or 'https://index.docker.io/v1/'
         self.username = parameters.get('username')
         self.password = parameters.get('password')
         self.email = parameters.get('email')


### PR DESCRIPTION
##### SUMMARY

Add default value if 'registry_url' is provided and its empty.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_login

##### ADDITIONAL INFORMATION
    
Currently If 'registry_url' is provided and its an empty string:

```
- name: Log into default docker registry
  docker_login:
    registry: 
    username: my_good_username
    password: my_good_temporary_token
    reauthorize: yes
  become: true
```

 it will cause below `~/.docker/config.json`:
    
```
     {
        "auths": {
            "": {
                "auth": "my_good_temporary_token"
            }
        }
    }
```

Which will prevent ulterior commands such as `docker pull`.