### PR TITLE
Allowing anonymous volumes via mounts option

### DIFF
--- a/changelogs/fragments/181-docker_container-allow-anonymous-volume-mounts.yml
+++ b/changelogs/fragments/181-docker_container-allow-anonymous-volume-mounts.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - docker_container - lifted restriction preventing the creation of anonymous volumes with the ``mounts`` option
+    (https://github.com/ansible-collections/community.docker/pull/181).

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -486,6 +486,7 @@ options:
       source:
         description:
           - Mount source (e.g. a volume name or a host path).
+          - If not supplied when I(type=volume) an anonymous volume will be created.
         type: str
       type:
         description:
@@ -2004,7 +2005,7 @@ class TaskParameters(DockerBaseClass):
             datatype = mount['type']
             mount_dict = dict(mount)
             # Sanity checks (so we don't wait for docker-py to barf on input)
-            if mount_dict.get('source') is None and datatype != 'tmpfs':
+            if mount_dict.get('source') is None and datatype not in ('tmpfs', 'volume'):
                 self.client.fail('source must be specified for mount "{0}" of type "{1}"'.format(target, datatype))
             mount_option_types = dict(
                 volume_driver='volume',

--- a/tests/integration/targets/docker_container/tasks/tests/mounts-volumes.yml
+++ b/tests/integration/targets/docker_container/tasks/tests/mounts-volumes.yml
@@ -119,6 +119,30 @@
   register: mounts_6
   ignore_errors: yes
 
+- name: mounts (anonymous volume)
+  docker_container:
+    image: "{{ docker_test_image_alpine }}"
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    mounts:
+      - target: /tmp
+        type: volume
+    force_kill: true
+  register: mounts_7
+
+- name: mounts (anonymous volume idempotency)
+  docker_container:
+    image: "{{ docker_test_image_alpine }}"
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    mounts:
+      - target: /tmp
+        type: volume
+    force_kill: true
+  register: mounts_8
+
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
@@ -135,6 +159,8 @@
     - mounts_5 is changed
     - mounts_6 is failed
     - "'The mount point \"/x\" appears twice in the mounts option' == mounts_6.msg"
+    - mounts_7 is changed
+    - mounts_8 is not changed
   when: docker_py_version is version('2.6.0', '>=')
 - assert:
     that:


### PR DESCRIPTION
##### SUMMARY
Lifting restriction that `source` be required as a key for `mounts` when `type: volume` so that anonymous volumes can be created.

Requested in #175 [here](https://github.com/ansible-collections/community.docker/issues/175#issuecomment-885588738).

##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME
plugins/modules/docker_container.py

##### ADDITIONAL INFORMATION
- Added integration tests for idempotency.