### PR TITLE
Fix check_mode for some _info modules

### DIFF
--- a/changelogs/fragments/183-info-check_mode.yml
+++ b/changelogs/fragments/183-info-check_mode.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - docker_stack_info - make sure that module isn't skipped in check mode (https://github.com/ansible-collections/community.docker/pull/183).
+  - docker_stack_task_info - make sure that module isn't skipped in check mode (https://github.com/ansible-collections/community.docker/pull/183).

--- a/plugins/modules/docker_stack_info.py
+++ b/plugins/modules/docker_stack_info.py
@@ -55,7 +55,7 @@ def main():
     module = AnsibleModule(
         argument_spec={
         },
-        supports_check_mode=False
+        supports_check_mode=True
     )
 
     rc, out, err = docker_stack_list(module)

--- a/plugins/modules/docker_stack_task_info.py
+++ b/plugins/modules/docker_stack_task_info.py
@@ -64,7 +64,7 @@ def main():
         argument_spec={
             'name': dict(type='str', required=True)
         },
-        supports_check_mode=False
+        supports_check_mode=True
     )
 
     name = module.params['name']


### PR DESCRIPTION
##### SUMMARY
See https://github.com/ansible-collections/community.general/pull/3101 and https://github.com/ansible/ansible/pull/75324.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_stack_info
docker_stack_task_info
