### PR TITLE
docker_network: improve test failure debugging

### DIFF
--- a/tests/integration/targets/docker_network/tasks/main.yml
+++ b/tests/integration/targets/docker_network/tasks/main.yml
@@ -4,6 +4,16 @@
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 
+- name: List inspection results for all docker networks
+  docker_host_info:
+    networks: true
+    verbose_output: true
+  register: all_networks
+
+- name: Show inspection results for all docker networks
+  debug:
+    var: all_networks
+
 - name: Create random name prefix
   set_fact:
     name_prefix: "{{ 'ansible-docker-test-%0x' % ((2**32) | random) }}"

--- a/tests/integration/targets/docker_network/tasks/main.yml
+++ b/tests/integration/targets/docker_network/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Show inspection results for all docker networks
   debug:
-    var: all_networks
+    var: all_networks.networks
 
 - name: Create random name prefix
   set_fact:

--- a/tests/integration/targets/docker_network/tasks/tests/ipam.yml
+++ b/tests/integration/targets/docker_network/tasks/tests/ipam.yml
@@ -17,12 +17,12 @@
   docker_network:
     name: "{{ nname_ipam_1 }}"
     ipam_config:
-      - subnet: 172.25.120.0/24
-        gateway: 172.25.120.2
-        iprange: 172.25.120.0/26
+      - subnet: 10.25.120.0/24
+        gateway: 10.25.120.2
+        iprange: 10.25.120.0/26
         aux_addresses:
-          host1: 172.25.120.3
-          host2: 172.25.120.4
+          host1: 10.25.120.3
+          host2: 10.25.120.4
   register: network
 
 - assert:
@@ -33,12 +33,12 @@
   docker_network:
     name: "{{ nname_ipam_1 }}"
     ipam_config:
-      - subnet: 172.25.120.0/24
-        gateway: 172.25.120.2
-        iprange: 172.25.120.0/26
+      - subnet: 10.25.120.0/24
+        gateway: 10.25.120.2
+        iprange: 10.25.120.0/26
         aux_addresses:
-          host1: 172.25.120.3
-          host2: 172.25.120.4
+          host1: 10.25.120.3
+          host2: 10.25.120.4
   register: network
 
 - assert:
@@ -49,11 +49,11 @@
   docker_network:
     name: "{{ nname_ipam_1 }}"
     ipam_config:
-      - subnet: 172.25.121.0/24
-        gateway: 172.25.121.2
-        iprange: 172.25.121.0/26
+      - subnet: 10.25.121.0/24
+        gateway: 10.25.121.2
+        iprange: 10.25.121.0/26
         aux_addresses:
-          host1: 172.25.121.3
+          host1: 10.25.121.3
   register: network
   diff: yes
 
@@ -70,7 +70,7 @@
   docker_network:
     name: "{{ nname_ipam_1 }}"
     ipam_config:
-      - subnet: 172.25.121.0/24
+      - subnet: 10.25.121.0/24
   register: network
 
 - assert:
@@ -151,7 +151,7 @@
     name: "{{ nname_ipam_3 }}"
     enable_ipv6: yes
     ipam_config:
-      - subnet: 172.26.120.0/24
+      - subnet: 10.26.120.0/24
       - subnet: fdd1:ac8c:0557:7ce2::/64
   register: network
 
@@ -165,7 +165,7 @@
     enable_ipv6: yes
     ipam_config:
       - subnet: fdd1:ac8c:0557:7ce2::/64
-      - subnet: 172.26.120.0/24
+      - subnet: 10.26.120.0/24
   register: network
 
 - assert:
@@ -177,7 +177,7 @@
     name: "{{ nname_ipam_3 }}"
     enable_ipv6: no
     ipam_config:
-      - subnet: 172.26.120.0/24
+      - subnet: 10.26.120.0/24
   register: network
   diff: yes
 
@@ -203,8 +203,8 @@
       driver_options:
         parent: "{{ ansible_default_ipv4.alias }}"
       ipam_config:
-        - subnet: 172.26.120.0/24
-        - subnet: 172.26.121.0/24
+        - subnet: 10.26.120.0/24
+        - subnet: 10.26.121.0/24
     register: network
 
   - assert:
@@ -218,8 +218,8 @@
       driver_options:
         parent: "{{ ansible_default_ipv4.alias }}"
       ipam_config:
-        - subnet: 172.26.121.0/24
-        - subnet: 172.26.120.0/24
+        - subnet: 10.26.121.0/24
+        - subnet: 10.26.120.0/24
     register: network
 
   - assert:
@@ -233,8 +233,8 @@
       driver_options:
         parent: "{{ ansible_default_ipv4.alias }}"
       ipam_config:
-        - subnet: 172.26.120.0/24
-        - subnet: 172.26.122.0/24
+        - subnet: 10.26.120.0/24
+        - subnet: 10.26.122.0/24
     register: network
     diff: yes
 
@@ -250,7 +250,7 @@
       driver_options:
         parent: "{{ ansible_default_ipv4.alias }}"
       ipam_config:
-        - subnet: 172.26.122.0/24
+        - subnet: 10.26.122.0/24
     register: network
 
   - assert:

--- a/tests/integration/targets/setup_docker_registry/handlers/cleanup.yml
+++ b/tests/integration/targets/setup_docker_registry/handlers/cleanup.yml
@@ -50,6 +50,6 @@
   until: result is success
 
 - name: "Make sure all volumes are removed"
-  command: "docker rm -f {{ item }}"
+  command: "docker volume rm -f {{ item }}"
   with_items: "{{ docker_registry_setup_vnames }}"
   ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
On AZP the docker_network tests fail a lot with collisions between existing networks (maybe associated to the AZP infrastructure?) with the test networks created in the docker_network tests. To make it easier to debug this, I've added some commands at the beginning of the docker_network tests which will dump inspection results of all existing Docker networks.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
docker_network integration tests
