### PR TITLE
Improve CI: make sure the nginx config and password files are readable by everyone in setup_docker_registry

### DIFF
--- a/tests/integration/targets/setup_docker_registry/tasks/setup-frontend.yml
+++ b/tests/integration/targets/setup_docker_registry/tasks/setup-frontend.yml
@@ -29,6 +29,7 @@
   copy:
     src: "{{ item }}"
     dest: "{{ remote_tmp_dir }}/{{ item }}"
+    mode: "0644"
   loop:
   - nginx.conf
   - nginx.htpasswd


### PR DESCRIPTION
##### SUMMARY
This caused the split-controller tests to fail on CentOS 8, as nginx couldn't read the password file.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
setup_docker_registry
