### PR TITLE
docker_compose - Remove compatibility statement related to compose file version

### DIFF
--- a/plugins/modules/docker_compose.py
+++ b/plugins/modules/docker_compose.py
@@ -18,7 +18,6 @@ author: "Chris Houseknecht (@chouseknecht)"
 
 description:
   - Uses Docker Compose to start, shutdown and scale services.
-  - Works with compose versions 1 and 2.
   - Configuration can be read from a C(docker-compose.yml) or C(docker-compose.yaml) file or inline using the I(definition) option.
   - See the examples for more details.
   - Supports check mode.

--- a/tests/integration/targets/docker_compose/tasks/tests/options.yml
+++ b/tests/integration/targets/docker_compose/tasks/tests/options.yml
@@ -13,7 +13,7 @@
     - name: Define service
       set_fact:
         test_service: |
-          version: '2'
+          version: '3'
           services:
             {{ cname_1 }}:
               image: "{{ docker_test_image_alpine }}"
@@ -111,7 +111,7 @@
         new_env_file: "{{ output_dir }}/new.env"
         new_env_sleep_cmd: sleep 20m
         test_service: |
-          version: '2'
+          version: '3'
           services:
             {{ cname_1 }}:
               image: "{{ docker_test_image_alpine }}"

--- a/tests/integration/targets/docker_compose/tasks/tests/start-stop.yml
+++ b/tests/integration/targets/docker_compose/tasks/tests/start-stop.yml
@@ -11,14 +11,14 @@
 - name: Define service
   set_fact:
     test_service: |
-      version: '2'
+      version: '3'
       services:
         {{ cname }}:
           image: "{{ docker_test_image_alpine }}"
           command: '/bin/sh -c "sleep 10m"'
           stop_grace_period: 1s
     test_service_mod: |
-      version: '2'
+      version: '3'
       services:
         {{ cname }}:
           image: "{{ docker_test_image_alpine }}"


### PR DESCRIPTION
##### SUMMARY
Removes documentation lines specifying supported compose file versions in `docker_compose` as support is primarily determined by the target's `docker-engine` and `docker-compose` version. Integration tests have also been bumped up to version 3 to identify potential issues for tested OS's.

Closes #206

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/docker_compose.py

##### ADDITIONAL INFORMATION
I prefer removing the compatibility statement altogether to avoid potentially false information (or heavily qualified statements). If issues/feature requests are reported related to compose file version 3 they can be addressed as needed. 