### PR TITLE
Add 'new' modules to the action group

### DIFF
--- a/changelogs/fragments/209-action-group.yml
+++ b/changelogs/fragments/209-action-group.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "Add the modules docker_container_exec, docker_image_load and docker_plugin to the ``docker`` module defaults group (https://github.com/ansible-collections/community.docker/pull/209)."

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -5,15 +5,18 @@ action_groups:
   - docker_compose
   - docker_config
   - docker_container
+  - docker_container_exec
   - docker_container_info
   - docker_host_info
   - docker_image
   - docker_image_info
+  - docker_image_load
   - docker_login
   - docker_network
   - docker_network_info
   - docker_node
   - docker_node_info
+  - docker_plugin
   - docker_prune
   - docker_secret
   - docker_swarm


### PR DESCRIPTION
##### SUMMARY
Looks like we forgot to add the new modules to the action_group (called ["module defaults group"](https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html) before ansible-core 2.12).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
meta/runtime.yml
