### PR TITLE
Remove deprecated features, bump version to 2.0.0

### DIFF
--- a/changelogs/fragments/210-deprecations.yml
+++ b/changelogs/fragments/210-deprecations.yml
@@ -1,0 +1,7 @@
+removed_features:
+  - "docker_container - the default value of ``container_default_behavior`` changed to ``no_defaults`` (https://github.com/ansible-collections/community.docker/pull/210)."
+  - "docker_container - the special value ``all`` can no longer be used in ``published_ports`` next to other values. Please use ``publish_all_ports=true`` instead (https://github.com/ansible-collections/community.docker/pull/210)."
+  - "docker_container - the default value of ``network_mode`` is now the name of the first network specified in ``networks`` if such are specified and ``networks_cli_compatible=true`` (https://github.com/ansible-collections/community.docker/pull/210)."
+  - "docker_login - removed the ``email`` option (https://github.com/ansible-collections/community.docker/pull/210)."
+deprecated_features:
+  - "docker_container - using the special value ``all`` in ``published_ports`` has been deprecated. Use ``publish_all_ports=true`` instead (https://github.com/ansible-collections/community.docker/pull/210)."

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: community
 name: docker
-version: 1.10.1
+version: 2.0.0
 readme: README.md
 authors:
   - Ansible Docker Working Group

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -113,7 +113,6 @@ DOCKER_REQUIRED_TOGETHER = [
 ]
 
 DEFAULT_DOCKER_REGISTRY = 'https://index.docker.io/v1/'
-EMAIL_REGEX = r'[^@]+@[^@]+\.[^@]+'
 BYTE_SUFFIXES = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
 
 

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -691,7 +691,8 @@ options:
         is different from the C(docker) command line utility. Use the L(dig lookup,../lookup/dig.html)
         to resolve hostnames."
       - A value of C(all) will publish all exposed container ports to random host ports, ignoring
-        any other mappings. Use I(publish_all_ports) instead as the use of C(all) will be deprecated in version 2.0.0.
+        any other mappings. This is deprecated since version 2.0.0 and will be disallowed in
+        community.docker 3.0.0. Use the I(publish_all_ports) option instead.
       - If I(networks) parameter is provided, will inspect each network to see if there exists
         a bridge network with optional parameter C(com.docker.network.bridge.host_binding_ipv4).
         If such a network is found, then published ports where no host IP address is specified
@@ -1803,12 +1804,13 @@ class TaskParameters(DockerBaseClass):
 
         if 'all' in self.published_ports:
             if len(self.published_ports) > 1:
-                self.client.module.deprecate(
-                    'Specifying "all" in published_ports together with port mappings is not properly '
-                    'supported by the module. The port mappings are currently ignored. Set publish_all_ports '
-                    'to "true" to randomly assign port mappings for those not specified by published_ports. '
-                    'The use of "all" in published_ports next to other values will be removed in version 2.0.0.',
-                    collection_name='community.docker', version='2.0.0')
+                self.client.module.fail_json(msg='"all" can no longer be specified in published_ports next to '
+                                                 'other values. Set publish_all_ports to "true" to randomly '
+                                                 'assign port mappings for those not specified by published_ports.')
+            self.client.module.deprecate(
+                'Specifying "all" in published_ports is deprecated. Set publish_all_ports to "true" instead '
+                'to randomly assign port mappings for those not specified by published_ports',
+                collection_name='community.docker', version='3.0.0')
             return 'all'
 
         default_ip = self.get_default_host_ip()

--- a/plugins/modules/docker_login.py
+++ b/plugins/modules/docker_login.py
@@ -40,11 +40,6 @@ options:
       - The plaintext password for the registry account.
       - Required when I(state) is C(present).
     type: str
-  email:
-    description:
-      - Does nothing, do not use.
-      - Will be removed in community.docker 2.0.0.
-    type: str
   reauthorize:
     description:
       - Refresh existing authentication found in the configuration file.
@@ -147,7 +142,6 @@ from ansible_collections.community.docker.plugins.module_utils.common import (
     HAS_DOCKER_PY,
     DEFAULT_DOCKER_REGISTRY,
     DockerBaseClass,
-    EMAIL_REGEX,
     RequestException,
 )
 
@@ -291,7 +285,6 @@ class LoginManager(DockerBaseClass):
         self.registry_url = parameters.get('registry_url')
         self.username = parameters.get('username')
         self.password = parameters.get('password')
-        self.email = parameters.get('email')
         self.reauthorize = parameters.get('reauthorize')
         self.config_path = parameters.get('config_path')
         self.state = parameters.get('state')
@@ -318,17 +311,12 @@ class LoginManager(DockerBaseClass):
         :return: None
         '''
 
-        if self.email and not re.match(EMAIL_REGEX, self.email):
-            self.fail("Parameter error: the email address appears to be incorrect. Expecting it to match "
-                      "/%s/" % (EMAIL_REGEX))
-
         self.results['actions'].append("Logged into %s" % (self.registry_url))
         self.log("Log into %s with username %s" % (self.registry_url, self.username))
         try:
             response = self.client.login(
                 self.username,
                 password=self.password,
-                email=self.email,
                 registry=self.registry_url,
                 reauth=self.reauthorize,
                 dockercfg_path=self.config_path
@@ -346,7 +334,6 @@ class LoginManager(DockerBaseClass):
                     response = self.client.login(
                         self.username,
                         password=self.password,
-                        email=self.email,
                         registry=self.registry_url,
                         reauth=True,
                         dockercfg_path=self.config_path
@@ -446,8 +433,6 @@ def main():
         registry_url=dict(type='str', default=DEFAULT_DOCKER_REGISTRY, aliases=['registry', 'url']),
         username=dict(type='str'),
         password=dict(type='str', no_log=True),
-        # Was Ansible 2.14 / community.general 3.0.0:
-        email=dict(type='str', removed_in_version='2.0.0', removed_from_collection='community.docker'),
         reauthorize=dict(type='bool', default=False, aliases=['reauth']),
         state=dict(type='str', default='present', choices=['present', 'absent']),
         config_path=dict(type='path', default='~/.docker/config.json', aliases=['dockercfg_path']),

--- a/tests/integration/targets/docker_container/tasks/tests/network.yml
+++ b/tests/integration/targets/docker_container/tasks/tests/network.yml
@@ -465,6 +465,7 @@
       - name: "{{ nname_2 }}"
       networks_cli_compatible: yes
       comparisons:
+        network_mode: ignore  # otherwise we'd have to set network_mode to nname_1
         networks: ignore
     register: networks_2
 
@@ -502,6 +503,7 @@
       - name: "{{ nname_2 }}"
       networks_cli_compatible: yes
       comparisons:
+        network_mode: ignore  # otherwise we'd have to set network_mode to nname_1
         networks: allow_more_present
       force_kill: yes
     register: networks_5


### PR DESCRIPTION
##### SUMMARY
Remove deprecated features in docker_container and docker_login that were scheduled for removal in 2.0.0. Also deprecates a feature in docker_container that was announced to be deprecated in 2.0.0.

This must not be merged until we start preparing 2.0.0, and stable-1 has been branched.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docker_container
docker_login
