### PR TITLE
Update CI matrix to include ansible-core's stable-2.12 branch

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -55,6 +55,17 @@ stages:
               test: 'devel/sanity/extra'
             - name: Units
               test: 'devel/units/1'
+  - stage: Ansible_2.12
+    displayName: Sanity & Units 2.12
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: Sanity
+              test: '2.12/sanity/1'
+            - name: Units
+              test: '2.12/units/1'
   - stage: Ansible_2_11
     displayName: Sanity & Units 2.11
     dependsOn: []
@@ -116,6 +127,25 @@ stages:
           groups:
             - 4
             - 5
+  - stage: Docker_2.12
+    displayName: Docker 2.12
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.12/linux/{0}
+          targets:
+            - name: CentOS 8
+              test: centos8
+            - name: Fedora 34
+              test: fedora34
+            - name: openSUSE 15 py3
+              test: opensuse15
+            - name: Ubuntu 20.04
+              test: ubuntu2004
+          groups:
+            - 4
+            - 5
   - stage: Docker_2_11
     displayName: Docker 2.11
     dependsOn: []
@@ -124,14 +154,14 @@ stages:
         parameters:
           testFormat: 2.11/linux/{0}
           targets:
-            - name: CentOS 8
-              test: centos8
+            - name: CentOS 7
+              test: centos7
             - name: Fedora 33
               test: fedora33
-            - name: openSUSE 15 py3
-              test: opensuse15
-            - name: Ubuntu 20.04
-              test: ubuntu2004
+            - name: openSUSE 15 py2
+              test: opensuse15py2
+            - name: Ubuntu 18.04
+              test: ubuntu1804
           groups:
             - 4
             - 5
@@ -145,16 +175,10 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 32
               test: fedora32
-            - name: openSUSE 15 py2
-              test: opensuse15py2
-            - name: openSUSE 15 py3
-              test: opensuse15
-            - name: Ubuntu 18.04
-              test: ubuntu1804
+            - name: Ubuntu 16.04
+              test: ubuntu1604
           groups:
             - 4
             - 5
@@ -166,8 +190,6 @@ stages:
         parameters:
           testFormat: 2.9/linux/{0}
           targets:
-            - name: CentOS 7
-              test: centos7
             - name: Fedora 31
               test: fedora31
             - name: openSUSE 15 py2
@@ -188,6 +210,22 @@ stages:
           testFormat: devel/rhel/{0}
           targets:
             - test: '7.9'
+            - test: '8.4'
+          groups:
+            - 1
+            - 2
+            - 3
+            - 4
+            - 5
+  - stage: Remote_2.12
+    displayName: Remote 2.12
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: RHEL {0}
+          testFormat: 2.12/rhel/{0}
+          targets:
             - test: '8.4'
           groups:
             - 1
@@ -248,16 +286,19 @@ stages:
     condition: succeededOrFailed()
     dependsOn:
       - Ansible_devel
+      - Ansible_2_12
       - Ansible_2_11
       - Ansible_2_10
       - Ansible_2_9
       - Remote_devel
-      - Docker_devel
+      - Remote_2_12
       - Remote_2_11
-      - Docker_2_11
       - Remote_2_10
-      - Docker_2_10
       - Remote_2_9
+      - Docker_devel
+      - Docker_2_12
+      - Docker_2_11
+      - Docker_2_10
       - Docker_2_9
     jobs:
       - template: templates/coverage.yml

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -55,7 +55,7 @@ stages:
               test: 'devel/sanity/extra'
             - name: Units
               test: 'devel/units/1'
-  - stage: Ansible_2.12
+  - stage: Ansible_2_12
     displayName: Sanity & Units 2.12
     dependsOn: []
     jobs:
@@ -127,7 +127,7 @@ stages:
           groups:
             - 4
             - 5
-  - stage: Docker_2.12
+  - stage: Docker_2_12
     displayName: Docker 2.12
     dependsOn: []
     jobs:
@@ -217,7 +217,7 @@ stages:
             - 3
             - 4
             - 5
-  - stage: Remote_2.12
+  - stage: Remote_2_12
     displayName: Remote 2.12
     dependsOn: []
     jobs:

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -158,8 +158,6 @@ stages:
               test: centos7
             - name: Fedora 33
               test: fedora33
-            - name: openSUSE 15 py2
-              test: opensuse15py2
             - name: Ubuntu 18.04
               test: ubuntu1804
           groups:
@@ -173,8 +171,6 @@ stages:
         parameters:
           testFormat: 2.10/linux/{0}
           targets:
-            - name: CentOS 7
-              test: centos7
             - name: Fedora 32
               test: fedora32
             - name: Ubuntu 16.04
@@ -194,8 +190,6 @@ stages:
               test: fedora31
             - name: openSUSE 15 py2
               test: opensuse15py2
-            - name: Ubuntu 16.04
-              test: ubuntu1604
           groups:
             - 4
             - 5

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Please note that this collection does **not** support Windows targets. The conne
 
 ## Tested with Ansible
 
-Tested with the current Ansible 2.9, ansible-base 2.10 and ansible-core 2.11 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
+Tested with the current Ansible 2.9, ansible-base 2.10, ansible-core 2.11 and ansible-core 2.12 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
 
 ## External requirements
 


### PR DESCRIPTION
##### SUMMARY
Update CI matrix to include ansible-core's stable-2.12 branch. Reduces testing for older Ansible versions to avoid increasing CI load (too much).

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
