### PR TITLE
Fix CI: explicitly install iptables on RHEL 8

### DIFF
--- a/tests/integration/targets/setup_docker/vars/RedHat-8.yml
+++ b/tests/integration/targets/setup_docker/vars/RedHat-8.yml
@@ -4,6 +4,7 @@ docker_prereq_packages:
   - device-mapper-persistent-data
   - lvm2
   - libseccomp
+  - iptables
 
 docker_packages:
   - docker-ce-19.03.13


### PR DESCRIPTION
##### SUMMARY
This is apparently now needed. Thanks for the fix to @sivel (https://github.com/ansible/ansible/pull/76212)!

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
