### PR TITLE
docker_container_exec: improve handling of chdir option

### DIFF
--- a/changelogs/fragments/243-docker_container_exec-chdir.yml
+++ b/changelogs/fragments/243-docker_container_exec-chdir.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - "docker_container_exec - ``chdir`` is only supported since Docker SDK for Python 3.0.0. Make sure that this option can only use when 3.0.0 or later is installed, and prevent passing this parameter on when ``chdir`` is not provided to this module (https://github.com/ansible-collections/community.docker/pull/243, https://github.com/ansible-collections/community.docker/issues/242)."
+  - "docker_api connection plugin - avoid passing an unnecessary argument to a Docker SDK for Python call that is only supported by version 3.0.0 or later (https://github.com/ansible-collections/community.docker/pull/243)."

--- a/changelogs/fragments/243-docker_container_exec-chdir.yml
+++ b/changelogs/fragments/243-docker_container_exec-chdir.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "docker_container_exec - ``chdir`` is only supported since Docker SDK for Python 3.0.0. Make sure that this option can only use when 3.0.0 or later is installed, and prevent passing this parameter on when ``chdir`` is not provided to this module (https://github.com/ansible-collections/community.docker/pull/243, https://github.com/ansible-collections/community.docker/issues/242)."

--- a/plugins/connection/docker_api.py
+++ b/plugins/connection/docker_api.py
@@ -164,7 +164,7 @@ class Connection(ConnectionBase):
             stderr=True,
             stdin=need_stdin,
             user=self._play_context.remote_user or '',
-            workdir=None,
+            # workdir=None,  - only works for Docker SDK for Python 3.0.0 and later
         ))
         exec_id = exec_data['Id']
 

--- a/plugins/modules/docker_container_exec.py
+++ b/plugins/modules/docker_container_exec.py
@@ -163,8 +163,13 @@ def main():
         tty=dict(type='bool', default=False),
     )
 
+    option_minimal_versions = dict(
+        chdir=dict(docker_py_version='3.0.0'),
+    )
+
     client = AnsibleDockerClient(
         argument_spec=argument_spec,
+        option_minimal_versions=option_minimal_versions,
         min_docker_api_version='1.20',
         mutually_exclusive=[('argv', 'command')],
         required_one_of=[('argv', 'command')],
@@ -190,6 +195,9 @@ def main():
         selectors = find_selectors(client.module)
 
     try:
+        kwargs = {}
+        if chdir is not None:
+            kwargs['workdir'] = chdir
         exec_data = client.exec_create(
             container,
             argv,
@@ -197,7 +205,7 @@ def main():
             stderr=True,
             stdin=bool(stdin),
             user=user or '',
-            workdir=chdir,
+            **kwargs
         )
         exec_id = exec_data['Id']
 


### PR DESCRIPTION
##### SUMMARY
Only pass chdir on when it is provided, and prevent this option from being used for Docker SDK for Python < 3.0.0

The `workdir` option was added to `exec_create` in 3.0.0: https://github.com/docker/docker-py/commit/abd60aedc7e3df813006919222d86717eb8c6fc2

Fixes #242.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container_exec
