### PR TITLE
Minor fixes to nsenter connection plugin

### DIFF
--- a/changelogs/fragments/249-nsenter-fixes.yml
+++ b/changelogs/fragments/249-nsenter-fixes.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - "nsenter connection plugin - Ensure the ``nsenter_pid`` option is retrieved in ``_connect`` instead of ``__init__`` to prevent a crasher due to bad initialization order"
-  - "nsenter connection plugin - Replace the use of ``--all-namespaces`` with specific namespaces to support compatibility with Busybox nsenter (used on, for example, Alpine containers)"
+  - "nsenter connection plugin - ensure the ``nsenter_pid`` option is retrieved in ``_connect`` instead of ``__init__`` to prevent a crasher due to bad initialization order (https://github.com/ansible-collections/community.docker/pull/249)."
+  - "nsenter connection plugin - replace the use of ``--all-namespaces`` with specific namespaces to support compatibility with Busybox nsenter (used on, for example, Alpine containers) (https://github.com/ansible-collections/community.docker/pull/249)."

--- a/changelogs/fragments/249-nsenter-fixes.yml
+++ b/changelogs/fragments/249-nsenter-fixes.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "nsenter connection plugin - Ensure the ``nsenter_pid`` option is retrieved in ``_connect`` instead of ``__init__`` to prevent a crasher due to bad initialization order"
+  - "nsenter connection plugin - Replace the use of ``--all-namespaces`` with specific namespaces to support compatibility with Busybox nsenter (used on, for example, Alpine containers)"

--- a/plugins/connection/nsenter.py
+++ b/plugins/connection/nsenter.py
@@ -70,9 +70,10 @@ class Connection(ConnectionBase):
     def __init__(self, *args, **kwargs):
         super(Connection, self).__init__(*args, **kwargs)
         self.cwd = None
-        self._nsenter_pid = self.get_option("nsenter_pid")
 
     def _connect(self):
+        self._nsenter_pid = self.get_option("nsenter_pid")
+
         # Because nsenter requires very high privileges, our remote user
         # is always assumed to be root.
         self._play_context.remote_user = "root"
@@ -100,12 +101,26 @@ class Connection(ConnectionBase):
 
         # Rewrite the provided command to prefix it with nsenter
         if isinstance(cmd, (text_type, binary_type)):
-            nsenter_cmd = "nsenter --all --preserve-credentials --target={0} -- ".format(self._nsenter_pid)
+            nsenter_cmd = (
+                "nsenter "
+                "--ipc "
+                "--mount "
+                "--net "
+                "--pid "
+                "--uts "
+                "--preserve-credentials "
+                "--target={0} "
+                "-- "
+            ).format(self._nsenter_pid)
             cmd = to_bytes(nsenter_cmd) + to_bytes(cmd)
         else:
             nsenter_cmd = [
                 "nsenter",
-                "--all",
+                "--ipc",
+                "--mount",
+                "--net",
+                "--pid",
+                "--uts",
                 "--preserve-credentials",
                 "--target={0}".format(self._nsenter_pid),
                 "--",

--- a/plugins/connection/nsenter.py
+++ b/plugins/connection/nsenter.py
@@ -101,16 +101,16 @@ class Connection(ConnectionBase):
 
         # Rewrite the provided command to prefix it with nsenter
         nsenter_cmd_parts = [
-                "nsenter",
-                "--ipc",
-                "--mount",
-                "--net",
-                "--pid",
-                "--uts",
-                "--preserve-credentials",
-                "--target={0}".format(self._nsenter_pid),
-                "--",
-            ]
+            "nsenter",
+            "--ipc",
+            "--mount",
+            "--net",
+            "--pid",
+            "--uts",
+            "--preserve-credentials",
+            "--target={0}".format(self._nsenter_pid),
+            "--",
+        ]
 
         if isinstance(cmd, (text_type, binary_type)):
             cmd_parts = nsenter_cmd_parts + [cmd]


### PR DESCRIPTION
##### SUMMARY
Two fixes to the nsenter connection plugin:

- Ensure the `nsenter_pid` option is retrieved in `_connect` instead of `__init__` to prevent a crasher due to bad initialization order
- Replace the use of `--all-namespaces` with specific namespaces to support compatibility with Busybox nsenter (used on for example, Alpine containers)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nsenter connection plugin

##### ADDITIONAL INFORMATION
N/A