### PR TITLE
Set minimal Docker API version for chdir to 1.35

### DIFF
--- a/changelogs/fragments/253-chdir-min-version.yml
+++ b/changelogs/fragments/253-chdir-min-version.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "docker_container_exec - disallow using the ``chdir`` option for Docker API before 1.35 (https://github.com/ansible-collections/community.docker/pull/253)."

--- a/plugins/modules/docker_container_exec.py
+++ b/plugins/modules/docker_container_exec.py
@@ -164,7 +164,7 @@ def main():
     )
 
     option_minimal_versions = dict(
-        chdir=dict(docker_py_version='3.0.0'),
+        chdir=dict(docker_py_version='3.0.0', docker_api_version='1.35'),
     )
 
     client = AnsibleDockerClient(


### PR DESCRIPTION
##### SUMMARY
See https://github.com/docker/docker-py/blob/master/docker/api/exec_api.py#L67.

This basically makes the error message nicer, so there's no hurry to get this out.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container_exec
