### PR TITLE
first shot at building docs on PRs with shared workflow

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -1,0 +1,51 @@
+name: Collection Docs
+concurrency:
+  group: docs-${{ github.head_ref }}
+  cancel-in-progress: true
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  build-docs:
+    permissions:
+      contents: read
+    name: Build Ansible Docs
+    uses: ansible-collections/community.hashi_vault/.github/workflows/_shared-docs-build-pr.yml@main
+
+  comment:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    needs: build-docs
+    name: PR comments
+    steps:
+      - name: PR comment
+        uses: ansible-collections/community.hashi_vault/.github/actions/docs/ansible-docs-build-comment@main
+        with:
+          body-includes: '##Docs Build'
+          reactions: heart
+          action: ${{ needs.build-docs.outputs.changed != 'true' && 'remove' || '' }}
+          on-closed-body: |
+            ##Docs Build 📝
+
+            This PR is closed and any previously published docsite has been unpublished.
+          on-merged-body: |
+            ##Docs Build 📝
+
+            Thank you for contribution!✨
+
+            This PR has been merged and your docs changes will be incorporated when they are next published.
+          body: |
+            ##Docs Build 📝
+
+            Thank you for contribution!✨
+
+            The docsite for **this PR** is available for download as an artifact from this run:
+            ${{ needs.build-docs.outputs.artifact-url }}
+
+            File changes:
+
+            ${{ needs.build-docs.outputs.diff-files-rendered }}
+
+            ${{ needs.build-docs.outputs.diff-rendered }}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I've spent my holiday [reimplementing the docs build process](https://github.com/ansible-collections/community.hashi_vault/pull/202) so it can be shared with other collections in a way that's straightforward.

What I'm proposing here is a first step at re-using that stuff to have a docs build in this collection, on PRs.

It's quite short, because it's using the basics of the shared workflows/actions I created, with mostly default parameters.

There's no publishing step here, because that will need you to sign up with some other service and put any relevant secrets you need into GitHub.

[However, you can see what that looks like in the workflow I'm using](https://github.com/ansible-collections/community.hashi_vault/blob/main/.github/workflows/docs.yml) where I publish to Surge. I made that as a shared workflow, so that if anyone else wants to use it, it's super straightforward to do so.

Maybe we'll see some shared workflows or other publishing destinations like RTD.

---

So here's a few things about this PR:
* The workflow uses the `pull_request_target` trigger, so it will not be run in this PR. Unfortunately this means it can't be tested in this PR either; it will have to be landed to `main` first before we can test against changes to it. After that, the process of testing changes is a little complicated, to see more details about that, read https://github.com/ansible-collections/community.hashi_vault/issues/138 (perhaps skip to `Put workflow changes on a direct branch, open other PRs against the branch`).
* The result of merging this will be that PRs will have their changes run through this process and have docs built for the base and head of the PR, and if the content differs, a comment will be posted linking to the build artifacts for the run so that the one can download the archive with the rendered HTML.
* Once merged to `main`, it can be tested immediately by putting up a test PR (from a fork works too).
* If there are problems with the workflow that can't be addressed quickly, and you want to avoid a "failing" build on PRs, the workflow can be disabled directly from the Actions page, without needing to move/delete the file or make any new commits.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible collection docs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
N/A