### PR TITLE
Added cap_add to the documentation for capabilities for easier search

### DIFF
--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -38,7 +38,7 @@ options:
     type: int
   capabilities:
     description:
-      - List of capabilities to add to the container (equivalent to docker cap_add).
+      - List of capabilities to add to the container.
       - This is equivalent to C(docker run --cap-add), or the docker-compose option C(cap_add).
     type: list
     elements: str

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -38,7 +38,7 @@ options:
     type: int
   capabilities:
     description:
-      - List of capabilities to add to the container.
+      - List of capabilities to add to the container (equivalent to docker cap_add).
     type: list
     elements: str
   cap_drop:

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -39,6 +39,7 @@ options:
   capabilities:
     description:
       - List of capabilities to add to the container (equivalent to docker cap_add).
+      - This is equivalent to C(docker run --cap-add), or the docker-compose option C(cap_add).
     type: list
     elements: str
   cap_drop:


### PR DESCRIPTION
##### SUMMARY

Added `cap_add` to the documentation for `capabilities` to make it easier to find the capabilities option if searching based on the docker name for this parameter.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docker container
