### PR TITLE
Restrict PyNaCL to 1.4.x on RHEL8 when using Python 3.6

### DIFF
--- a/tests/utils/shippable/remote.sh
+++ b/tests/utils/shippable/remote.sh
@@ -17,6 +17,10 @@ fi
 stage="${S:-prod}"
 provider="${P:-default}"
 
+if [ "${platform}" == "rhel" ] && [[ "${version}" =~ ^8 ]]; then
+    echo "pynacl >= 1.4.0, < 1.5.0; python_version == '3.6'" >> tests/util/constraints.txt
+fi
+
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
     --remote "${platform}/${version}" --remote-terminate always --remote-stage "${stage}" --remote-provider "${provider}"

--- a/tests/utils/shippable/remote.sh
+++ b/tests/utils/shippable/remote.sh
@@ -18,7 +18,7 @@ stage="${S:-prod}"
 provider="${P:-default}"
 
 if [ "${platform}" == "rhel" ] && [[ "${version}" =~ ^8 ]]; then
-    echo "pynacl >= 1.4.0, < 1.5.0; python_version == '3.6'" >> tests/util/constraints.txt
+    echo "pynacl >= 1.4.0, < 1.5.0; python_version == '3.6'" >> tests/utils/constraints.txt
 fi
 
 # shellcheck disable=SC2086


### PR DESCRIPTION
##### SUMMARY
Hopefully fixes CI. The latest [PyNaCL release 1.5.0](https://github.com/pyca/pynacl/blob/main/CHANGELOG.rst#150-2022-01-07) no longer ships `manylinux1` wheels, which are the wheel type supported by pip 9.x that comes with Python 3.6 on RHEL8 (see also https://github.com/pypa/manylinux#manylinux).

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
