### PR TITLE
Drop CentOS 8 from CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -168,8 +168,6 @@ stages:
         parameters:
           testFormat: 2.12/linux/{0}
           targets:
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 34
               test: fedora34
             - name: Ubuntu 18.04


### PR DESCRIPTION
##### SUMMARY
Let's merge this once CentOS 8 starts breaking CI again without an easy fix in sight, or once a new major release of commuinty.docker is coming up. Whatever comes first.

See also ansible-collections/news-for-maintainers#3.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
