### PR TITLE
Add support for rotating docker secrets

### DIFF
--- a/changelogs/fragments/270-rolling-secrets.yml
+++ b/changelogs/fragments/270-rolling-secrets.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - docker_secret - Add support for rolling update, set ``rolling_versions`` to ``true`` to enable
+  - docker_secret - add support for rolling update, set ``rolling_versions`` to ``true`` to enable (https://github.com/ansible-collections/community.docker/pull/293, https://github.com/ansible-collections/community.docker/issues/21).

--- a/changelogs/fragments/270-rolling-secrets.yml
+++ b/changelogs/fragments/270-rolling-secrets.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - docker_secret - Add support for rolling update, set ``rolling_versions`` to ``true`` to enable

--- a/plugins/modules/docker_secret.py
+++ b/plugins/modules/docker_secret.py
@@ -352,7 +352,7 @@ def main():
         labels=dict(type='dict'),
         force=dict(type='bool', default=False),
         rolling_versions=dict(type='bool', default=False),
-        versions_to_keep=dict(type='int', default=5)
+        versions_to_keep=dict(type='int', default=5),
     )
 
     required_if = [

--- a/plugins/modules/docker_secret.py
+++ b/plugins/modules/docker_secret.py
@@ -282,7 +282,7 @@ class SecretManager(DockerBaseClass):
         if self.rolling_versions:
             self.version += 1
             labels['ansible_version'] = str(self.version)
-            self.name = self.name + '_v' + str(self.version)
+            self.name = '{name}_v{version}'.format(name=self.name, version=self.version)
         if self.labels:
             labels.update(self.labels)
 

--- a/plugins/modules/docker_secret.py
+++ b/plugins/modules/docker_secret.py
@@ -167,6 +167,12 @@ secret_id:
   returned: success and I(state) is C(present)
   type: str
   sample: 'hzehrmyjigmcp2gb6nlhmjqcv'
+secret_name:
+  description:
+    - The name of the created secret object.
+  returned: success and I(state) is C(present)
+  type: str
+  sample: 'awesome_secret'
 '''
 
 import base64
@@ -298,6 +304,7 @@ class SecretManager(DockerBaseClass):
         ''' Handles state == 'present', creating or updating the secret '''
         if self.secrets:
             self.results['secret_id'] = self.secrets[-1]['ID']
+            self.results['secret_name'] = self.secrets[-1]['Spec']['Name']
             data_changed = False
             attrs = self.secrets[-1].get('Spec', {})
             if attrs.get('Labels', {}).get('ansible_key'):
@@ -316,9 +323,11 @@ class SecretManager(DockerBaseClass):
                 secret_id = self.create_secret()
                 self.results['changed'] = True
                 self.results['secret_id'] = secret_id
+                self.results['secret_name'] = self.name
         else:
             self.results['changed'] = True
             self.results['secret_id'] = self.create_secret()
+            self.results['secret_name'] = self.name
 
     def absent(self):
         ''' Handles state == 'absent', removing the secret '''
@@ -361,7 +370,8 @@ def main():
     try:
         results = dict(
             changed=False,
-            secret_id=''
+            secret_id='',
+            secret_name=''
         )
 
         SecretManager(client, results)()

--- a/plugins/modules/docker_secret.py
+++ b/plugins/modules/docker_secret.py
@@ -54,15 +54,18 @@ options:
   rolling_versions:
     description:
       - If set to C(true), secrets are created with an increasing version number appended to their name.
+      - Adds a label containing the version number to the managed secrets with the name C(ansible_version).
     type: bool
-    default: no
+    default: false
+    version_added: 2.2.0
   versions_to_keep:
     description:
       - When using I(rolling_versions), the number of old versions of the secret to keep.
       - Extraneous old secrets are deleted after the new one is created.
-      - Set to -1 to keep everything or to 0 or 1 to keep only the current one.
+      - Set to C(-1) to keep everything or to C(0) or C(1) to keep only the current one.
     type: int
     default: 5
+    version_added: 2.2.0
   name:
     description:
       - The name of the secret.
@@ -173,6 +176,7 @@ secret_name:
   returned: success and I(state) is C(present)
   type: str
   sample: 'awesome_secret'
+  version_added: 2.2.0
 '''
 
 import base64

--- a/plugins/modules/docker_secret.py
+++ b/plugins/modules/docker_secret.py
@@ -244,7 +244,7 @@ class SecretManager(DockerBaseClass):
             self.absent()
 
     def get_version(self, secret):
-        return secret.get('Spec', {}).get('Labels', {}).get('version', 0)
+        return int(secret.get('Spec', {}).get('Labels', {}).get('ansible_version', 0))
 
     def remove_old_versions(self):
         if self.versions_to_keep < 0:

--- a/plugins/modules/docker_secret.py
+++ b/plugins/modules/docker_secret.py
@@ -244,7 +244,10 @@ class SecretManager(DockerBaseClass):
             self.absent()
 
     def get_version(self, secret):
-        return int(secret.get('Spec', {}).get('Labels', {}).get('ansible_version', 0))
+        try:
+            return int(secret.get('Spec', {}).get('Labels', {}).get('ansible_version', 0))
+        except ValueError:
+            return 0
 
     def remove_old_versions(self):
         if not self.rolling_versions or self.versions_to_keep < 0:

--- a/plugins/modules/docker_secret.py
+++ b/plugins/modules/docker_secret.py
@@ -263,6 +263,13 @@ class SecretManager(DockerBaseClass):
 
         return secret_id
 
+    def remove_secret(self, secret):
+        try:
+            if not self.check_mode:
+                self.client.remove_secret(secret['ID'])
+        except APIError as exc:
+            self.client.fail("Error removing secret %s: %s" % (self.name, to_native(exc)))
+
     def present(self):
         ''' Handles state == 'present', creating or updating the secret '''
         secret = self.get_secret()
@@ -291,11 +298,7 @@ class SecretManager(DockerBaseClass):
         ''' Handles state == 'absent', removing the secret '''
         secret = self.get_secret()
         if secret:
-            try:
-                if not self.check_mode:
-                    self.client.remove_secret(secret['ID'])
-            except APIError as exc:
-                self.client.fail("Error removing secret %s: %s" % (self.name, to_native(exc)))
+            self.remove_secret(secret)
             self.results['changed'] = True
 
 

--- a/plugins/modules/docker_secret.py
+++ b/plugins/modules/docker_secret.py
@@ -253,7 +253,7 @@ class SecretManager(DockerBaseClass):
         if not self.rolling_versions or self.versions_to_keep < 0:
             return
         if not self.check_mode:
-            while len(self.secrets) >= max(self.versions_to_keep, 1):
+            while len(self.secrets) > max(self.versions_to_keep, 1):
                 self.remove_secret(self.secrets.pop(0))
 
     def get_secret(self):
@@ -292,6 +292,7 @@ class SecretManager(DockerBaseClass):
         try:
             if not self.check_mode:
                 secret_id = self.client.create_secret(self.name, self.data, labels=labels)
+                self.secrets += self.client.secrets(filters={'id': secret_id})
         except APIError as exc:
             self.client.fail("Error creating secret: %s" % to_native(exc))
 

--- a/plugins/modules/docker_secret.py
+++ b/plugins/modules/docker_secret.py
@@ -302,7 +302,7 @@ class SecretManager(DockerBaseClass):
             if not self.check_mode:
                 self.client.remove_secret(secret['ID'])
         except APIError as exc:
-            self.client.fail("Error removing secret %s: %s" % (self.name, to_native(exc)))
+            self.client.fail("Error removing secret %s: %s" % (secret['Spec']['Name'], to_native(exc)))
 
     def present(self):
         ''' Handles state == 'present', creating or updating the secret '''

--- a/plugins/modules/docker_secret.py
+++ b/plugins/modules/docker_secret.py
@@ -269,6 +269,10 @@ class SecretManager(DockerBaseClass):
         labels = {
             'ansible_key': self.data_key
         }
+        if self.rolling_versions:
+            self.version += 1
+            labels['ansible_version'] = str(self.version)
+            self.name = self.name + '_v' + str(self.version)
         if self.labels:
             labels.update(self.labels)
 
@@ -303,6 +307,8 @@ class SecretManager(DockerBaseClass):
                 if not self.force:
                     self.client.module.warn("'ansible_key' label not found. Secret will not be changed unless the force parameter is set to 'yes'")
             labels_changed = not compare_generic(self.labels, attrs.get('Labels'), 'allow_more_present', 'dict')
+            if self.rolling_versions:
+                self.version = int(attrs.get('Labels', {}).get('ansible_version', 0))
             if data_changed or labels_changed or self.force:
                 # if something changed or force, delete and re-create the secret
                 if not self.rolling_versions:

--- a/plugins/modules/docker_secret.py
+++ b/plugins/modules/docker_secret.py
@@ -247,7 +247,7 @@ class SecretManager(DockerBaseClass):
         return int(secret.get('Spec', {}).get('Labels', {}).get('ansible_version', 0))
 
     def remove_old_versions(self):
-        if self.versions_to_keep < 0:
+        if not self.rolling_versions or self.versions_to_keep < 0:
             return
         if not self.check_mode:
             while len(self.secrets) >= max(self.versions_to_keep, 1):

--- a/tests/integration/targets/docker_secret/tasks/test_secrets.yml
+++ b/tests/integration/targets/docker_secret/tasks/test_secrets.yml
@@ -135,6 +135,82 @@
       that:
         - output.failed
 
+# Rolling update
+
+  - name: Create rolling secret
+    docker_secret:
+      name: rolling_password
+      data: opensesame!
+      rolling_versions: true
+      state: present
+    register: original_output
+
+  - name: Create variable secret_id
+    set_fact:
+      secret_id: "{{ original_output.secret_id }}"
+
+  - name: Inspect secret
+    command: "docker secret inspect {{ secret_id }}"
+    register: inspect
+    ignore_errors: yes
+
+  - debug: var=inspect
+
+  - name: assert secret creation succeeded
+    assert:
+      that:
+         - "'rolling_password' in inspect.stdout"
+         - "'ansible_key' in inspect.stdout"
+         - "'ansible_version' in inspect.stdout"
+         - original_output.secret_name == 'rolling_password_v1'
+    when: inspect is not failed
+  - assert:
+      that:
+         - "'is too new. Maximum supported API version is' in inspect.stderr"
+    when: inspect is failed
+
+  - name: Create secret again
+    docker_secret:
+      name: rolling_password
+      data: newpassword!
+      rolling_versions: true
+      state: present
+    register: new_output
+
+  - name: assert that new version is created
+    assert:
+      that:
+         - new_output.changed
+         - new_output.secret_id != original_output.secret_id
+         - new_output.secret_name != original_output.secret_name
+         - new_output.secret_name == 'rolling_password_v2'
+
+  - name: Remove rolling secrets
+    docker_secret:
+      name: rolling_password
+      rolling_versions: true
+      state: absent
+
+  - name: Check that secret is removed
+    command: "docker secret inspect {{ original_output.secret_id }}"
+    register: output
+    ignore_errors: yes
+
+  - name: assert secret was removed
+    assert:
+      that:
+        - output.failed
+
+  - name: Check that secret is removed
+    command: "docker secret inspect {{ new_output.secret_id }}"
+    register: output
+    ignore_errors: yes
+
+  - name: assert secret was removed
+    assert:
+      that:
+        - output.failed
+
   always:
   - name: Remove Swarm cluster
     docker_swarm:

--- a/tests/integration/targets/docker_swarm_service/tasks/tests/secrets.yml
+++ b/tests/integration/targets/docker_swarm_service/tasks/tests/secrets.yml
@@ -5,6 +5,7 @@
     service_name: "{{ name_prefix ~ '-secrets' }}"
     secret_name_1: "{{ name_prefix ~ '-secret-1' }}"
     secret_name_2: "{{ name_prefix ~ '-secret-2' }}"
+    secret_name_3: "{{ name_prefix ~ '-secret-3' }}"
 
 - name: Registering container name
   set_fact:
@@ -22,6 +23,14 @@
     data: "secret2"
     state: "present"
   register: "secret_result_2"
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.1.0', '>=')
+
+- docker_secret:
+    name: "{{ secret_name_3 }}"
+    data: "secret3"
+    state: "present"
+    rolling_versions: true
+  register: "secret_result_3"
   when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.1.0', '>=')
 
 ####################################################################
@@ -131,6 +140,40 @@
   register: secrets_8
   ignore_errors: yes
 
+- name: rolling secrets
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: "{{ docker_test_image_alpine }}"
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets:
+      - secret_name: "{{ secret_name_3 }}_v1"
+        filename: "/run/secrets/{{ secret_name_3 }}.txt"
+  register: secrets_9
+  ignore_errors: yes
+
+- name: update rolling secret
+  docker_secret:
+    name: "{{ secret_name_3 }}"
+    data: "newsecret3"
+    state: "present"
+    rolling_versions: true
+  register: secrets_10
+  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.1.0', '>=')
+  ignore_errors: yes
+
+- name: rolling secrets service update
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: "{{ docker_test_image_alpine }}"
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets:
+      - secret_name: "{{ secret_name_3 }}_v2"
+        filename: "/run/secrets/{{ secret_name_3 }}.txt"
+  register: secrets_11
+  ignore_errors: yes
+
 - name: cleanup
   docker_swarm_service:
     name: "{{ service_name }}"
@@ -147,6 +190,9 @@
       - secrets_6 is not changed
       - secrets_7 is changed
       - secrets_8 is not changed
+      - secrets_9 is changed
+      - secrets_10 is not failed
+      - secrets_11 is changed
   when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.4.0', '>=')
 - assert:
     that:
@@ -405,6 +451,7 @@
   loop:
     - "{{ secret_name_1 }}"
     - "{{ secret_name_2 }}"
+    - "{{ secret_name_3 }}"
   loop_control:
     loop_var: secret_name
   ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
Add support for rolling updates for docker secrets. This change does roughly what was described in #21.

Adding two additional parameters for the `docker_secret` module:
* `rolling_versions` (default: false): whether to use versioning secrets for rolling updates.
* `versions_to_keep` (default: 5): when using rolling updates, how many of the old versions to keep.

When `rolling_versions` is set to `true` secrets are created with a `_vX` postfix in their names where `X` is replaced with an incremental counter. That counter is also added to the secrets as a label with the name of `ansible_version`. This way when a secret is changed a new version is created with an incremented version number instead of deleting it first then creating again. This aims to solve the problem where the secret is attached to a service, thus deleting it fails.

This is the recommended approach of updating secrets based on the official Docker [documentation](https://docs.docker.com/engine/swarm/secrets/#example-rotate-a-secret).

The change is not breaking, users of this module shouldn't expect any changes.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_secret

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The problem this PR aims to solve is the following:
When a secret is attached to a service docker won't let it get deleted, thus the current version of the module fails execution if one tries to update a secret that is attached to a service already. The [recommendation from docker](https://docs.docker.com/engine/swarm/secrets/#example-rotate-a-secret) for this is to create a new secret with the updated data then update the service definition adding the new secret in place of the old one. Afterwards the old secret can be safely deleted. Having different names for the secrets is a non-issue since one can define the mountpoint for the secret in the container regardless of its name.

If this change gets accepted I'd implement the same functionality for docker_config as well, as the same issue stands there to fix issue #109.

The PR addresses #21, #246

Fixes #21.