### PR TITLE
Add support for rotating docker configs

### DIFF
--- a/changelogs/fragments/272-rolling-configs.yml
+++ b/changelogs/fragments/272-rolling-configs.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - docker_config - add support for rolling update, set ``rolling_versions`` to ``true`` to enable (https://github.com/ansible-collections/community.docker/pull/295, https://github.com/ansible-collections/community.docker/issues/109).

--- a/tests/integration/targets/docker_config/tasks/test_docker_config.yml
+++ b/tests/integration/targets/docker_config/tasks/test_docker_config.yml
@@ -150,6 +150,82 @@
       that:
         - not output.changed
 
+# Rolling update
+
+  - name: Create rolling config
+    docker_config:
+      name: rolling_password
+      data: opensesame!
+      rolling_versions: true
+      state: present
+    register: original_output
+
+  - name: Create variable config_id
+    set_fact:
+      config_id: "{{ original_output.config_id }}"
+
+  - name: Inspect config
+    command: "docker config inspect {{ config_id }}"
+    register: inspect
+    ignore_errors: yes
+
+  - debug: var=inspect
+
+  - name: assert config creation succeeded
+    assert:
+      that:
+         - "'rolling_password' in inspect.stdout"
+         - "'ansible_key' in inspect.stdout"
+         - "'ansible_version' in inspect.stdout"
+         - original_output.config_name == 'rolling_password_v1'
+    when: inspect is not failed
+  - assert:
+      that:
+         - "'is too new. Maximum supported API version is' in inspect.stderr"
+    when: inspect is failed
+
+  - name: Create config again
+    docker_config:
+      name: rolling_password
+      data: newpassword!
+      rolling_versions: true
+      state: present
+    register: new_output
+
+  - name: assert that new version is created
+    assert:
+      that:
+         - new_output.changed
+         - new_output.config_id != original_output.config_id
+         - new_output.config_name != original_output.config_name
+         - new_output.config_name == 'rolling_password_v2'
+
+  - name: Remove rolling configs
+    docker_config:
+      name: rolling_password
+      rolling_versions: true
+      state: absent
+
+  - name: Check that config is removed
+    command: "docker config inspect {{ original_output.config_id }}"
+    register: output
+    ignore_errors: yes
+
+  - name: assert config was removed
+    assert:
+      that:
+        - output.failed
+
+  - name: Check that config is removed
+    command: "docker config inspect {{ new_output.config_id }}"
+    register: output
+    ignore_errors: yes
+
+  - name: assert config was removed
+    assert:
+      that:
+        - output.failed
+
   always:
   - name: Remove a Swarm cluster
     docker_swarm:

--- a/tests/integration/targets/docker_swarm_service/tasks/tests/configs.yml
+++ b/tests/integration/targets/docker_swarm_service/tasks/tests/configs.yml
@@ -5,6 +5,7 @@
     service_name: "{{ name_prefix ~ '-configs' }}"
     config_name_1: "{{ name_prefix ~ '-configs-1' }}"
     config_name_2: "{{ name_prefix ~ '-configs-2' }}"
+    config_name_3: "{{ name_prefix ~ '-configs-3' }}"
 
 - name: Registering container name
   set_fact:
@@ -22,6 +23,14 @@
     data: "test"
     state: present
   register: "config_result_2"
+  when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
+
+- docker_config:
+    name: "{{ config_name_3 }}"
+    data: "config3"
+    state: present
+    rolling_versions: true
+  register: "config_result_3"
   when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
 
 ####################################################################
@@ -131,6 +140,40 @@
   register: configs_8
   ignore_errors: yes
 
+- name: rolling configs
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: "{{ docker_test_image_alpine }}"
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs:
+      - config_name: "{{ config_name_3 }}_v1"
+        filename: "/run/configs/{{ config_name_3 }}.txt"
+  register: configs_9
+  ignore_errors: yes
+
+- name: update rolling config
+  docker_config:
+    name: "{{ config_name_3 }}"
+    data: "newconfig3"
+    state: "present"
+    rolling_versions: true
+  register: configs_10
+  when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
+  ignore_errors: yes
+
+- name: rolling configs service update
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: "{{ docker_test_image_alpine }}"
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs:
+      - config_name: "{{ config_name_3 }}_v2"
+        filename: "/run/configs/{{ config_name_3 }}.txt"
+  register: configs_11
+  ignore_errors: yes
+
 - name: cleanup
   docker_swarm_service:
     name: "{{ service_name }}"
@@ -147,6 +190,9 @@
     - configs_6 is not changed
     - configs_7 is changed
     - configs_8 is not changed
+    - configs_9 is changed
+    - configs_10 is not failed
+    - configs_11 is changed
   when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
 
 - assert:
@@ -407,6 +453,7 @@
   loop:
     - "{{ config_name_1 }}"
     - "{{ config_name_2 }}"
+    - "{{ config_name_3 }}"
   loop_control:
     loop_var: config_name
   ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
Add support for rolling updates for docker configs. Based on the same functionality for secrets in #293.

Adding two additional parameters for the `docker_config` module:
* `rolling_versions` (default: false): whether to use versioning configs for rolling updates.
* `versions_to_keep` (default: 5): when using rolling updates, how many of the old versions to keep.

When `rolling_versions` is set to `true` configs are created with a `_vX` postfix in their names where `X` is replaced with an incremental counter. That counter is also added to the configs as a label with the name of `ansible_version`. This way when a config is changed a new version is created with an incremented version number instead of deleting it first then creating again. This aims to solve the problem where the config is attached to a service, thus deleting it fails.

This is the recommended approach of updating configs based on the official Docker [documentation](https://docs.docker.com/engine/swarm/configs/#example-rotate-a-config).

The change is not breaking, users of this module shouldn't expect any changes.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The problem this PR aims to solve is the following:
When a config is attached to a service docker won't let it get deleted, thus the current version of the module fails execution if one tries to update a config that is attached to a service already. The [recommendation from docker](https://docs.docker.com/engine/swarm/configs/#example-rotate-a-config) for this is to create a new config with the updated data then update the service definition adding the new config in place of the old one. Afterwards the old config can be safely deleted. Having different names for the config is a non-issue since one can define the mountpoint for the config in the container regardless of its name.

The PR addresses #109 