### PR TITLE
Connection plugins: implement connection reset

### DIFF
--- a/changelogs/fragments/312-docker-connection-reset.yml
+++ b/changelogs/fragments/312-docker-connection-reset.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- "docker connection plugin - implement connection reset by clearing internal container user cache (https://github.com/ansible-collections/community.docker/pull/312)."
+- "docker_api connection plugin - implement connection reset by clearing internal container user/group ID cache (https://github.com/ansible-collections/community.docker/pull/312)."

--- a/plugins/connection/docker.py
+++ b/plugins/connection/docker.py
@@ -431,3 +431,7 @@ class Connection(ConnectionBase):
         """ Terminate the connection. Nothing to do for Docker"""
         super(Connection, self).close()
         self._connected = False
+
+    def reset(self):
+        # Clear container user cache
+        self._container_user_cache = {}

--- a/plugins/connection/docker_api.py
+++ b/plugins/connection/docker_api.py
@@ -352,3 +352,6 @@ class Connection(ConnectionBase):
         """ Terminate the connection. Nothing to do for Docker"""
         super(Connection, self).close()
         self._connected = False
+
+    def reset(self):
+        self.ids.clear()


### PR DESCRIPTION
##### SUMMARY
The default behavior for connection plugins which do not implement `reset()` is `display.warning("Reset is not implemented for this connection")`. A proper reset isn't really needed, so instead let's do something that makes sense.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docker and docker_api connection plugins
