### PR TITLE
CI: Remove 'warn:' that's removed in ansible-core 2.14

### DIFF
--- a/tests/integration/targets/docker_swarm/tasks/cleanup.yml
+++ b/tests/integration/targets/docker_swarm/tasks/cleanup.yml
@@ -14,8 +14,6 @@
 
     - name: CLEANUP | Clear out /var/lib/docker
       shell: rm -rf  /var/lib/docker/*
-      args:
-        warn: no
 
     - name: CLEANUP | Start docker daemon
       service:

--- a/tests/integration/targets/setup_docker/tasks/Fedora.yml
+++ b/tests/integration/targets/setup_docker/tasks/Fedora.yml
@@ -15,8 +15,6 @@
 
 - name: Update cache
   command: dnf makecache
-  args:
-    warn: no
 
 - name: Install docker
   dnf:

--- a/tests/integration/targets/setup_docker/tasks/RedHat-7.yml
+++ b/tests/integration/targets/setup_docker/tasks/RedHat-7.yml
@@ -15,8 +15,6 @@
 - name: Enable extras repository for RHEL on AWS
   # RHEL 7.6 uses REGION-rhel-server-extras and RHEL 7.7+ use rhel-7-server-rhui-extras-rpms
   command: yum-config-manager --enable REGION-rhel-server-extras rhel-7-server-rhui-extras-rpms
-  args:
-    warn: no
 
 # Docker broke their .repo file, so we set it up ourselves
 - name: Set-up repository
@@ -29,8 +27,6 @@
 
 - name: Update cache
   command: yum -y makecache fast
-  args:
-    warn: no
 
 - name: Install docker
   yum:


### PR DESCRIPTION
##### SUMMARY
See https://github.com/ansible/ansible/pull/77411.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
