### PR TITLE
Support getting container output from local logging driver

### DIFF
--- a/changelogs/fragments/337-container-output-from-local-logging-driver.yml
+++ b/changelogs/fragments/337-container-output-from-local-logging-driver.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "docker_container - support returning Docker container log output when using Docker's ``local`` logging driver, an optimized local logging driver introduced in Docker 18.09 (https://github.com/ansible-collections/community.docker/pull/337)."

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -643,7 +643,7 @@ options:
   output_logs:
     description:
       - If set to true, output of the container command will be printed.
-      - Only effective when I(log_driver) is set to C(json-file) or C(journald).
+      - Only effective when I(log_driver) is set to C(json-file), C(journald), or C(local).
     type: bool
     default: no
   paused:
@@ -3142,7 +3142,7 @@ class ContainerManager(DockerBaseClass):
                     config = self.client.inspect_container(container_id)
                     logging_driver = config['HostConfig']['LogConfig']['Type']
 
-                    if logging_driver in ('json-file', 'journald'):
+                    if logging_driver in ('json-file', 'journald', 'local'):
                         output = self.client.logs(container_id, stdout=True, stderr=True, stream=False, timestamps=False)
                         if self.parameters.output_logs:
                             self._output_logs(msg=output)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `local` [Docker logging driver](https://docs.docker.com/config/containers/logging/local/) is a new-ish, optimized local logging driver that improves upon json-file. Since logs written using `local` can still be accessed through the Docker daemon API, all that is needed here is to add to the supported list.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_container

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
