### PR TITLE
docker_swarm: adds data_path_addr option for swarm init and swarm join

### DIFF
--- a/changelogs/fragments/344-adds-data-path-addr.yml
+++ b/changelogs/fragments/344-adds-data-path-addr.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - docker_swarm - adds data_path_addr parameter during swarm initialization or when joining (https://github.com/ansible-collections/community.docker/issues/339).
+  - docker_swarm - adds ``data_path_addr`` parameter during swarm initialization or when joining (https://github.com/ansible-collections/community.docker/issues/339).

--- a/changelogs/fragments/344-adds-data-path-addr.yml
+++ b/changelogs/fragments/344-adds-data-path-addr.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - docker_swarm - adds data_path_addr parameter during swarm initialization or when joining (https://github.com/ansible-collections/community.docker/issues/339).

--- a/plugins/modules/docker_swarm.py
+++ b/plugins/modules/docker_swarm.py
@@ -661,7 +661,7 @@ def main():
         ),
         default_addr_pool=dict(docker_py_version='4.0.0', docker_api_version='1.39'),
         subnet_size=dict(docker_py_version='4.0.0', docker_api_version='1.39'),
-        data_path_addr=dict(docker_py_version='4.0.0', docker_api_version='1.31'),
+        data_path_addr=dict(docker_py_version='4.0.0', docker_api_version='1.30'),
     )
 
     client = AnsibleDockerSwarmClient(

--- a/plugins/modules/docker_swarm.py
+++ b/plugins/modules/docker_swarm.py
@@ -180,7 +180,7 @@ options:
       - Address or interface to use for data path traffic.
       - This can either be an address in the form C(192.168.1.1), or an interface,
           like C(eth0).
-      - Only used when swarm is initialised or joined. Because of this it's not
+      - Only used when swarm is initialised or joined. Because of this it is not
         considered for idempotency checking.
     type: str
     version_added: 2.5.0

--- a/plugins/modules/docker_swarm.py
+++ b/plugins/modules/docker_swarm.py
@@ -183,6 +183,7 @@ options:
       - Only used when swarm is initialised or joined. Because of this it's not
         considered for idempotency checking.
     type: str
+    version_added: 2.5.0
 extends_documentation_fragment:
 - community.docker.docker
 - community.docker.docker.docker_py_1_documentation


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allows usage of data_path_addr parameter while initializing or joining a swarm. See also #339.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Execute docker init
  community.docker.docker_swarm:
    state: present
    advertise_addr: ens11
    listen_addr: ens11
    data_path_addr: ens10
```
