### PR TITLE
Support --template-driver for docker_config (#332)

### DIFF
--- a/changelogs/fragments/345-docker_config-template-driver.yml
+++ b/changelogs/fragments/345-docker_config-template-driver.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - docker_config - add support for ``template_driver`` with one option ``golang`` (https://github.com/ansible-collections/community.docker/issues/332, https://github.com/ansible-collections/community.docker/pull/345).

--- a/plugins/modules/docker_config.py
+++ b/plugins/modules/docker_config.py
@@ -81,7 +81,7 @@ options:
       - present
   template_driver:
     description:
-      - TODO
+      - Set to C(golang) to use a Golang template file in I(data).
     type: str
     choices:
       - golang

--- a/plugins/modules/docker_config.py
+++ b/plugins/modules/docker_config.py
@@ -331,6 +331,7 @@ class ConfigManager(DockerBaseClass):
             self.results['config_id'] = config['ID']
             self.results['config_name'] = config['Spec']['Name']
             data_changed = False
+            template_driver_changed = False
             attrs = config.get('Spec', {})
             if attrs.get('Labels', {}).get('ansible_key'):
                 if attrs['Labels']['ansible_key'] != self.data_key:
@@ -338,7 +339,8 @@ class ConfigManager(DockerBaseClass):
             else:
                 if not self.force:
                     self.client.module.warn("'ansible_key' label not found. Config will not be changed unless the force parameter is set to 'yes'")
-            template_driver_changed = attrs['Labels']['template_driver'] != self.template_driver
+            if attrs['Labels']['template_driver'] != self.template_driver:
+                template_driver_changed = True
             labels_changed = not compare_generic(self.labels, attrs.get('Labels'), 'allow_more_present', 'dict')
             if self.rolling_versions:
                 self.version = self.get_version(config)

--- a/plugins/modules/docker_config.py
+++ b/plugins/modules/docker_config.py
@@ -304,7 +304,9 @@ class ConfigManager(DockerBaseClass):
                 # only use templating argument when self.template_driver is defined
                 kwargs = {}
                 if self.template_driver:
-                    kwargs['templating'] = { 'name': 'golang' }
+                    kwargs['templating'] = {
+                        'name': self.template_driver
+                    }
                 config_id = self.client.create_config(self.name, self.data, labels=labels, **kwargs)
                 self.configs += self.client.configs(filters={'id': config_id})
         except APIError as exc:
@@ -372,7 +374,7 @@ def main():
         force=dict(type='bool', default=False),
         rolling_versions=dict(type='bool', default=False),
         versions_to_keep=dict(type='int', default=5),
-        template_driver=dict(type='str', choices=['golang', 'golang_again']),
+        template_driver=dict(type='str', choices=['golang']),
     )
 
     required_if = [

--- a/plugins/modules/docker_config.py
+++ b/plugins/modules/docker_config.py
@@ -295,13 +295,14 @@ class ConfigManager(DockerBaseClass):
         config_id = None
         # We can't see the data after creation, so adding a label we can use for idempotency check
         labels = {
-            'ansible_key': self.data_key,
-            'templating': self.templating,
+            'ansible_key': self.data_key
         }
         if self.rolling_versions:
             self.version += 1
             labels['ansible_version'] = str(self.version)
             self.name = '{name}_v{version}'.format(name=self.name, version=self.version)
+        if self.templating:
+            labels['template_driver'] = self.templating['name']
         if self.labels:
             labels.update(self.labels)
 

--- a/plugins/modules/docker_config.py
+++ b/plugins/modules/docker_config.py
@@ -295,7 +295,8 @@ class ConfigManager(DockerBaseClass):
         config_id = None
         # We can't see the data after creation, so adding a label we can use for idempotency check
         labels = {
-            'ansible_key': self.data_key
+            'ansible_key': self.data_key,
+            'templating': self.templating,
         }
         if self.rolling_versions:
             self.version += 1
@@ -309,7 +310,7 @@ class ConfigManager(DockerBaseClass):
                 # only use templating argument when self.templating is defined
                 kwargs = {}
                 if self.templating:
-                    kwargs['templating'] = self.templating
+                    kwargs['templating'] = { 'name': 'golang' }
                 config_id = self.client.create_config(self.name, self.data, labels=labels, **kwargs)
                 self.configs += self.client.configs(filters={'id': config_id})
         except APIError as exc:
@@ -376,7 +377,7 @@ def main():
         force=dict(type='bool', default=False),
         rolling_versions=dict(type='bool', default=False),
         versions_to_keep=dict(type='int', default=5),
-        template_driver=dict(type='str', choices=['golang']),
+        template_driver=dict(type='str', choices=['golang', 'golang_again']),
     )
 
     required_if = [

--- a/plugins/modules/docker_config.py
+++ b/plugins/modules/docker_config.py
@@ -98,6 +98,7 @@ requirements:
 author:
   - Chris Houseknecht (@chouseknecht)
   - John Hu (@ushuz)
+  - Sasha Jenner (@sashajenner)
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY
Adding `template_driver` option with one option 'golang'. Creates a dictionary `templating` or `None` as required by `create_config` (https://docker-py.readthedocs.io/en/stable/api.html#docker.api.config.ConfigApiMixin.create_config). This is to be used in conjunction with a template file specified in `data`.

Fixes  #332.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Support --template-driver for docker_config