### PR TITLE
docker_container: avoid breakage with Python 3.13

### DIFF
--- a/changelogs/fragments/354-remove-dead-code.yml
+++ b/changelogs/fragments/354-remove-dead-code.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "docker_container - remove unused code that will cause problems with Python 3.13 (https://github.com/ansible-collections/community.docker/pull/354)."

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -1188,7 +1188,6 @@ status:
 '''
 
 import os
-import pipes
 import re
 import shlex
 import traceback
@@ -1226,14 +1225,6 @@ try:
 except Exception:
     # missing Docker SDK for Python handled in ansible.module_utils.docker.common
     pass
-
-
-def shell_join(parts):
-    if getattr(shlex, 'quote', None):
-        quote = shlex.quote
-    else:
-        quote = pipes.quote
-    return ' '.join([quote(part) for part in parts])
 
 
 REQUIRES_CONVERSION_TO_BYTES = [


### PR DESCRIPTION
##### SUMMARY
This fixes the currently failing Python 3.11 sanity tests (which were just added to ansible-test in devel branch).

The problem is that `pipes` is removed from Python 3.13's standard library. While looking at that, I noticed that we don't actually use that piece of code, so it can be removed trivially.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container
