### PR TITLE
certifi dropped Python 2 support

### DIFF
--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -1,4 +1,5 @@
 bcrypt < 3.2.0 ; python_version <= '3.6'
+certifi < 2022.5.18 ; python_version < '3.5' # certifi 2022.5.18 requires Python 3.5 or later
 cffi >= 1.14.2, != 1.14.3 # Yanked version which older versions of pip will still install
 coverage >= 4.2, < 5.0.0, != 4.3.2 ; python_version <= '3.7' # features in 4.2+ required, avoid known bug in 4.3.2 on python 2.6, coverage 5.0+ incompatible
 coverage >= 4.5.4, < 5.0.0 ; python_version > '3.7' # coverage had a bug in < 4.5.4 that would cause unit tests to hang in Python 3.8, coverage 5.0+ incompatible


### PR DESCRIPTION
##### SUMMARY
Should fix Ubuntu 16.04 errors in CI.

(Ubuntu 16.04's pip does not check Python version constraints, so it doesn't notice that certifi 2022.5.18 doesn't work with Python 2.7 and installs it anyway...)

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
