### PR TITLE
Remove docker-compose from python dependencies

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: community
 name: docker
-version: 2.6.0
+version: 3.0.0-alpha.0
 readme: README.md
 authors:
   - Ansible Docker Working Group

--- a/meta/ee-requirements.txt
+++ b/meta/ee-requirements.txt
@@ -1,2 +1,3 @@
 docker
-docker-compose
+# do not add docker-compose python package as a depedency as the module
+# is unmaintained and it is now a go project and called by docker directly.


### PR DESCRIPTION
##### SUMMARY

As this module is unmaintained and is creating conflicts with other packages, we need to remove it in order to still be able to use the rest of the collection. In a follow-up we should migrate our docker_compose module to use docker compose cli, so it would work with v2 of it.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION

This issue with community.docker is blocking integration of newer ansible-lint into creator-ee, and devtools team will remove community.docker and molecule-docker plugin from this container until that is addressed.

References:

* https://github.com/ansible/creator-ee/pull/65
* https://github.com/ansible-collections/community.docker/pull/360
