### PR TITLE
CI: Replace the container used in the nsenter tests

### DIFF
--- a/tests/integration/targets/connection_nsenter/runme.sh
+++ b/tests/integration/targets/connection_nsenter/runme.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 [[ -n "${DEBUG:-}" || -n "${ANSIBLE_DEBUG:-}" ]] && set -x
 
-readonly IMAGE="quay.io/ansible/python-base:latest"
+readonly IMAGE="quay.io/ansible/ansible-runner:devel"
 readonly PYTHON="$(command -v python3 python | head -n1)"
 
 # Determine collection root

--- a/tests/integration/targets/connection_nsenter/runme.sh
+++ b/tests/integration/targets/connection_nsenter/runme.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 [[ -n "${DEBUG:-}" || -n "${ANSIBLE_DEBUG:-}" ]] && set -x
 
-readonly IMAGE="quay.io/ansible/toolset:latest"
+readonly IMAGE="quay.io/ansible/python-base:latest"
 readonly PYTHON="$(command -v python3 python | head -n1)"
 
 # Determine collection root

--- a/tests/integration/targets/connection_posix/test.sh
+++ b/tests/integration/targets/connection_posix/test.sh
@@ -5,7 +5,9 @@ set -eux
 # Connection tests for POSIX platforms use this script by linking to it from the appropriate 'connection_' target dir.
 # The name of the inventory group to test is extracted from the directory name following the 'connection_' prefix.
 
-group=$(python -c \
+PYTHON="$(command -v python3 python | head -n1)"
+
+group=$(${PYTHON} -c \
     "from os import path; print(path.basename(path.abspath(path.dirname('$0'))).replace('connection_', ''))")
 
 cd ../connection


### PR DESCRIPTION
##### SUMMARY
CI currently fails because the quay.io/ansible/toolset:latest image no longer exists.

Let's try the one from https://github.com/ansible/python-base-image.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
nsenter connection
