### PR TITLE
Deprecate docker-compose EE dependency

### DIFF
--- a/changelogs/fragments/373-deprecate-docker-compose-dependency.yml
+++ b/changelogs/fragments/373-deprecate-docker-compose-dependency.yml
@@ -1,0 +1,5 @@
+deprecated_features:
+  - "The dependency on docker-compose for Execution Environments is deprecated and will be removed in community.docker 3.0.0.
+     The `Python docker-compose library <https://pypi.org/project/docker-compose/>`__ is unmaintained and can cause dependency
+     issues. You can manually still install it in an Execution Environment when needed
+     (https://github.com/ansible-collections/community.docker/pull/373)."


### PR DESCRIPTION
##### SUMMARY
We only just added it, but it already caused problems (see for example https://github.com/ansible/creator-ee/pull/68).

Maybe we need to do something similar for Docker SDK for Python as well, but first we need to figure out how to continue with #364.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
EE
