### PR TITLE
Deprecate Python 2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,13 @@ Please note that this collection does **not** support Windows targets. The conne
 
 Tested with the current Ansible 2.9, ansible-base 2.10, ansible-core 2.11, ansible-core 2.12 and ansible-core 2.13 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
 
+Please note that support for Ansible 2.9 and ansible-base 2.10 has been deprecated and will be dropped from community.docker 3.0.0 on.
+
 ## External requirements
 
 Most modules and plugins require the [Docker SDK for Python](https://pypi.org/project/docker/). For Python 2.6 support, use [the deprecated docker-py library](https://pypi.org/project/docker-py/) instead.
+
+Please note that Python 2.6 support has been deprecated and will be dropped from community.docker 3.0.0 on.
 
 Both libraries cannot be installed at the same time. If you accidentally did install them simultaneously, you have to uninstall *both* before re-installing one of them.
 

--- a/changelogs/fragments/python-2.6.yml
+++ b/changelogs/fragments/python-2.6.yml
@@ -1,0 +1,4 @@
+deprecated_features:
+  - "Support for Python 2.6 is deprecated and will be removed in the next major release (community.docker 3.0.0).
+     Some modules might still work with Python 2.6, but we will no longer try to ensure compatibility
+     (https://github.com/ansible-collections/community.docker/pull/388)."


### PR DESCRIPTION
##### SUMMARY
I think it's time to drop support for Python 2.6. Right now it is only supported with Docker SDK for Python < 2.0.0, and it will result in a lot of extra work for #364 and #386. If someone really has to use Python 2.6, they can happily continue using an older version of this collection, since the Docker SDK for Python they can use does not get updates anymore anyway.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
collection
