### PR TITLE
Improve/fix API version handling

### DIFF
--- a/changelogs/fragments/389-api-version.yml
+++ b/changelogs/fragments/389-api-version.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Docker SDK for Python based modules and plugins - if the API version is specified as an option, use that one to validate API version requirements of module/plugin options instead of the latest API version supported by the Docker daemon. This also avoids one unnecessary API call per module/plugin (https://github.com/ansible-collections/community.docker/pull/389)."

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -308,7 +308,7 @@ class AnsibleDockerClientBase(Client):
 
         try:
             super(AnsibleDockerClientBase, self).__init__(**self._connect_params)
-            self.docker_api_version_str = self.version()['ApiVersion']
+            self.docker_api_version_str = self.api_version
         except APIError as exc:
             self.fail("Docker API error: %s" % exc)
         except Exception as exc:


### PR DESCRIPTION
##### SUMMARY
Right now we retrieve the API version (the latest one supported by the daemon!) from the Docker daemon after creating the Docker SDK for Python API client. If the `version` module/plugin parameter is used, we should use that version instead, and if it is not used, the Python API client already retrieved that version for us. So let's safe one API call and use the API version supplied by the Python API client.

(The property exists since Docker SDK for Python 1.5.0: https://github.com/docker/docker-py/commit/7a6980d4794f3efaf85ad65458fbfac4c3afdec7 We require version 1.8.0 or newer, so we can depend on it.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Docker SDK for Python based plugins and modules
