### PR TITLE
Deprecate API version 1.20

### DIFF
--- a/changelogs/fragments/396-deprecate-docker-api-1.20.yml
+++ b/changelogs/fragments/396-deprecate-docker-api-1.20.yml
@@ -1,0 +1,6 @@
+deprecated_features:
+  - "Support for Docker API version 1.20 has been deprecated and will be removed in community.docker 3.0.0.
+     Support for it was dropped from Docker SDK for Python already in 2018 for version 3.0.0. This affects
+     the modules ``docker_container``, ``docker_container_exec``, ``docker_container_info``, ``docker_compose``,
+     ``docker_login``, ``docker_image``, and ``docker_image_info``, whose minimally supported API version
+     is 1.20 (https://github.com/ansible-collections/community.docker/pull/396)."


### PR DESCRIPTION
##### SUMMARY
Right now some modules still support API version 1.20. Docker SDK for Python dropped support for this in version 3.0.0 (it still supports API version 1.21 in the latest release), see https://github.com/docker/docker-py/commit/df8422d0791d7d03cd3e1efe37a9c72f242f1f78. Supporting it in the rewrite (#364) would be quite an extra burden for something that likely nobody is still using. If someone is really still using it, they have to stick to an old version of Docker SDK for Python, and community.docker 2.x.y.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
various modules
