### PR TITLE
Fix tests on Ubuntu 22.04

### DIFF
--- a/tests/integration/targets/setup_docker/tasks/Debian.yml
+++ b/tests/integration/targets/setup_docker/tasks/Debian.yml
@@ -14,7 +14,9 @@
   shell: curl -fsSL https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg >key && apt-key add key
 
 - name: Add Docker repo
-  shell: add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+  apt_repository:
+    repo: deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable
+    state: present
 
 - block:
   - name: Prevent service restart

--- a/tests/integration/targets/setup_docker/vars/Ubuntu-22.yml
+++ b/tests/integration/targets/setup_docker/vars/Ubuntu-22.yml
@@ -1,0 +1,4 @@
+---
+docker_prereq_packages:
+  - ca-certificates
+  - curl


### PR DESCRIPTION
##### SUMMARY
They are currently failing:
```
00:44 fatal: [testhost]: FAILED! => {"cache_update_time": 1657184539, "cache_updated": false, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"       install 'apt-transport-https=2.4.5' 'software-properties-common=0.99.22.2'' failed: E: Unable to correct problems, you have held broken packages.\n", "rc": 100, "stderr": "E: Unable to correct problems, you have held broken packages.\n", "stderr_lines": ["E: Unable to correct problems, you have held broken packages."], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nSome packages could not be installed. This may mean that you have\nrequested an impossible situation or if you are using the unstable\ndistribution that some required packages have not yet been created\nor been moved out of Incoming.\nThe following information may help to resolve the situation:\n\nThe following packages have unmet dependencies:\n software-properties-common : Depends: packagekit but it is not installable\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "Some packages could not be installed. This may mean that you have", "requested an impossible situation or if you are using the unstable", "distribution that some required packages have not yet been created", "or been moved out of Incoming.", "The following information may help to resolve the situation:", "", "The following packages have unmet dependencies:", " software-properties-common : Depends: packagekit but it is not installable"]}
```

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
