### PR TITLE
Rewrite docker_plugin to not use the Docker SDK for Python

### DIFF
--- a/changelogs/fragments/429-docker_plugin.yml
+++ b/changelogs/fragments/429-docker_plugin.yml
@@ -1,0 +1,4 @@
+major_changes:
+  - docker_plugin - no longer uses the Docker SDK for Python. It requires ``requests`` to be installed,
+    and depending on the features used has some more requirements. If the Docker SDK for Python is installed,
+    these requirements are likely met (https://github.com/ansible-collections/community.docker/pull/429).

--- a/tests/integration/targets/docker_plugin/tasks/main.yaml
+++ b/tests/integration/targets/docker_plugin/tasks/main.yaml
@@ -18,7 +18,7 @@
       state: absent
     with_items: "{{ plugin_names }}"
 
-  when: docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.25', '>=')
+  when: docker_api_version is version('1.25', '>=')
 
 - fail: msg="Too old docker / docker-py version to run docker_plugin tests!"
-  when: not(docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)
+  when: not(docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)


### PR DESCRIPTION
##### SUMMARY
Step 1: rewrite to use the low-level client instead of the high-level client. Then it's easier to adjust.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docker_plugin
