### PR TITLE
For Python > 2, always use shutil.which instead of custom Windows helper code

### DIFF
--- a/changelogs/fragments/438-docker-py.yml
+++ b/changelogs/fragments/438-docker-py.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "modules and plugins communicating directly with the Docker daemon - simplify use of helper function that was removed in Docker SDK for Python to find executables (https://github.com/ansible-collections/community.docker/pull/438)."

--- a/plugins/module_utils/_api/credentials/utils.py
+++ b/plugins/module_utils/_api/credentials/utils.py
@@ -26,11 +26,14 @@ def find_executable(executable, path=None):
     As distutils.spawn.find_executable, but on Windows, look up
     every extension declared in PATHEXT instead of just `.exe`
     """
+    if not PY2:
+        # shutil.which() already uses PATHEXT on Windows, so on
+        # Python 3 we can simply use shutil.which() in all cases.
+        # (https://github.com/docker/docker-py/commit/42789818bed5d86b487a030e2e60b02bf0cfa284)
+        return which(executable, path=path)
+
     if sys.platform != 'win32':
-        if PY2:
-            return which(executable, path)
-        else:
-            return which(executable, path=path)
+        return which(executable, path)
 
     if path is None:
         path = os.environ['PATH']


### PR DESCRIPTION
##### SUMMARY
This is related to https://github.com/docker/docker-py/commit/42789818bed5d86b487a030e2e60b02bf0cfa284 in the sense that for Python > 2, we also exclusively use shutil.which now, but we do not remove the helper function since we need it for Python 2 on Windows.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/_api/credentials/utils.py
