### PR TITLE
Forgot to update copied version of deprecation notice

### DIFF
--- a/plugins/doc_fragments/docker.py
+++ b/plugins/doc_fragments/docker.py
@@ -201,9 +201,7 @@ options:
             - When verifying the authenticity of the Docker Host server, provide the expected name of the server.
             - If the value is not specified in the task, the value of environment variable C(DOCKER_TLS_HOSTNAME) will
               be used instead. If the environment variable is not set, the default value will be used.
-            - The current default value is C(localhost). This default is deprecated and will change in community.docker
-              2.0.0 to be a value computed from I(docker_host). Explicitly specify C(localhost) to make sure this value
-              will still be used, and to disable the deprecation message which will be shown otherwise.
+            - Note that this option had a default value C(localhost) in older versions. It was removed in community.docker 3.0.0.
         type: str
     api_version:
         description:


### PR DESCRIPTION
##### SUMMARY
I copied this over from the original docs fragment before updating the deprecation in `main`, and failed to update it correctly when rebasing the Docker API PR...

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
API docs fragment
