### PR TITLE
correctly document incompatibility with Python 3.12+

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Please note that this collection does **not** support Windows targets. The conne
 
 Tested with the current ansible-core 2.11, ansible-core 2.12, and ansible-core 2.13 releases, and the current development version of ansible-core. Ansible/ansible-base versions before 2.11.0 are not supported.
 
-Please note that Ansible 2.9 and ansible-base 2.10 are no longer supported. If you need to use them, use community.docker 2.x.y. Also note that this collection does not work with ansible-core 2.11 (this includes ansible-base and Ansible 2.9) on Python 2.12+.
+Please note that Ansible 2.9 and ansible-base 2.10 are no longer supported. If you need to use them, use community.docker 2.x.y. Also note that this collection does not work with ansible-core 2.11 (this includes ansible-base and Ansible 2.9) on Python 3.12+.
 
 ## External requirements
 


### PR DESCRIPTION


##### SUMMARY
there was no, and there will not be, a Python 2.12 ;-)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
README.md

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
