### PR TITLE
CI: Move Fedora 35 from devel to stable-2.13 CI runs

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -113,8 +113,6 @@ stages:
               test: centos7
             - name: Fedora 36
               test: fedora36
-            - name: Fedora 35
-              test: fedora35
             - name: openSUSE 15
               test: opensuse15
             - name: Ubuntu 20.04
@@ -136,6 +134,8 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
+            - name: Fedora 35
+              test: fedora35
             - name: openSUSE 15 py2
               test: opensuse15py2
             - name: Alpine 3


### PR DESCRIPTION
##### SUMMARY
See https://github.com/ansible-collections/news-for-maintainers/issues/21.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
