### PR TITLE
Make reuse conformant

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -25,10 +25,6 @@ jobs:
         run: |
           pip install reuse
 
-      - name: Remove changelog fragments for REUSE compliance check
-        run: |
-          rm -fv changelogs/fragments/*.yml
-
       - name: Check REUSE compliance
         run: |
           reuse lint

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,0 +1,34 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Verify REUSE
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # Run CI once per day (at 04:30 UTC)
+  schedule:
+    - cron: '30 4 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          pip install reuse
+
+      - name: Remove changelog fragments for REUSE compliance check
+        run: |
+          rm -fv changelogs/fragments/*.yml
+
+      - name: Check REUSE compliance
+        run: |
+          reuse lint

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,5 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+
+Files: changelogs/fragments/*
+Copyright: Ansible Project
+License: GPL-3.0-or-later

--- a/CHANGELOG.rst.license
+++ b/CHANGELOG.rst.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ See [LICENSES/GPL-3.0-or-later.txt](https://github.com/ansible-collections/commu
 
 Parts of the collection are licensed under the [Apache 2.0 license](https://github.com/ansible-collections/community.docker/blob/main/LICENSES/Apache-2.0.txt). This mostly applies to files vendored from the [Docker SDK for Python](https://github.com/docker/docker-py/).
 
-All files except changelog fragments (that will not be part of a release) have a machine readable `SDPX-License-Identifier:` comment denoting its respective license(s), or an equivalent entry in an accompanying ``.license`` file. This conforms to the `REUSE specification <https://reuse.software/spec/>`_.
+All files have a machine readable `SDPX-License-Identifier:` comment denoting its respective license(s) or an equivalent entry in an accompanying `.license` file. Only changelog fragments (which will not be part of a release) are covered by a blanket statement in `.reuse/dep5`. This conforms to the [REUSE specification](https://reuse.software/spec/).

--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ See [LICENSES/GPL-3.0-or-later.txt](https://github.com/ansible-collections/commu
 
 Parts of the collection are licensed under the [Apache 2.0 license](https://github.com/ansible-collections/community.docker/blob/main/LICENSES/Apache-2.0.txt). This mostly applies to files vendored from the [Docker SDK for Python](https://github.com/docker/docker-py/).
 
-Most files in the collection that are not automatically generated have a machine readable `SDPX-License-Identifier:` comment denoting its respective license(s).
+All files except changelog fragments (that will not be part of a release) have a machine readable `SDPX-License-Identifier:` comment denoting its respective license(s), or an equivalent entry in an accompanying ``.license`` file. This conforms to the `REUSE specification <https://reuse.software/spec/>`_.

--- a/changelogs/changelog.yaml.license
+++ b/changelogs/changelog.yaml.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/changelogs/fragments/licenses.yml
+++ b/changelogs/fragments/licenses.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "The collection repository conforms to the `REUSE specification <https://reuse.software/spec/>`__ except for the changelog fragments (https://github.com/ansible-collections/community.docker/pull/462)."

--- a/tests/sanity/extra/extra-docs.json.license
+++ b/tests/sanity/extra/extra-docs.json.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/sanity/extra/licenses.json.license
+++ b/tests/sanity/extra/licenses.json.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/sanity/extra/licenses.py
+++ b/tests/sanity/extra/licenses.py
@@ -21,29 +21,35 @@ def find_licenses(filename, relax=False):
     spdx_license_identifiers = []
     other_license_identifiers = []
     has_copyright = False
-    with open(filename, 'r', encoding='utf-8') as f:
-        for line in f:
-            line = line.rstrip()
-            if 'Copyright ' in line:
-                has_copyright = True
-            if 'Copyright: ' in line:
-                print('%s: found copyright line with "Copyright:". Please remove the colon.' % (filename, ))
-            idx = line.find('SPDX-License-Identifier: ')
-            if idx >= 0:
-                spdx_license_identifiers.append(line[idx + len('SPDX-License-Identifier: '):])
-            if 'GNU General Public License' in line:
-                if 'v3.0+' in line:
-                    other_license_identifiers.append('GPL-3.0-or-later')
-                if 'version 3 or later' in line:
-                    other_license_identifiers.append('GPL-3.0-or-later')
-            if 'Simplified BSD License' in line:
-                other_license_identifiers.append('BSD-2-Clause')
-            if 'Apache License 2.0' in line:
-                other_license_identifiers.append('Apache-2.0')
-            if 'PSF License' in line or 'Python-2.0' in line:
-                other_license_identifiers.append('PSF-2.0')
-            if 'MIT License' in line:
-                other_license_identifiers.append('MIT')
+    try:
+        with open(filename, 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.rstrip()
+                if 'Copyright ' in line:
+                    has_copyright = True
+                if 'Copyright: ' in line:
+                    print('%s: found copyright line with "Copyright:". Please remove the colon.' % (filename, ))
+                if 'SPDX-FileCopyrightText: ' in line:
+                    has_copyright = True
+                idx = line.find('SPDX-License-Identifier: ')
+                if idx >= 0:
+                    lic_id = line[idx + len('SPDX-License-Identifier: '):]
+                    spdx_license_identifiers.extend(lic_id.split(' OR '))
+                if 'GNU General Public License' in line:
+                    if 'v3.0+' in line:
+                        other_license_identifiers.append('GPL-3.0-or-later')
+                    if 'version 3 or later' in line:
+                        other_license_identifiers.append('GPL-3.0-or-later')
+                if 'Simplified BSD License' in line:
+                    other_license_identifiers.append('BSD-2-Clause')
+                if 'Apache License 2.0' in line:
+                    other_license_identifiers.append('Apache-2.0')
+                if 'PSF License' in line or 'Python-2.0' in line:
+                    other_license_identifiers.append('PSF-2.0')
+                if 'MIT License' in line:
+                    other_license_identifiers.append('MIT')
+    except Exception as exc:
+        print('%s: error while processing file: %s' % (filename, exc))
     if len(set(spdx_license_identifiers)) < len(spdx_license_identifiers):
         print('%s: found identical SPDX-License-Identifier values' % (filename, ))
     if other_license_identifiers and set(other_license_identifiers) != set(spdx_license_identifiers):
@@ -61,24 +67,13 @@ def main():
     # The following paths are allowed to have no license identifier
     no_comments_allowed = [
         'changelogs/fragments/*.yml',
-        'tests/sanity/extra/*.json',
-        'tests/sanity/ignore-2.*.txt',
-        'LICENSES/*.txt',
-        'COPYING',
-    ]
-
-    # Files of this name are allowed to be empty
-    empty_allowed = [
-        '.keep',
-        '__init__.py',
     ]
 
     # These files are completely ignored
     ignore_paths = [
-        'CHANGELOG.rst',
-        'changelogs/changelog.yaml',
-        'tests/sanity/extra/licenses.py',  # The strings in find_licenses() confuse this code :-)
         '.ansible-test-timeout.json',
+        'LICENSES/*.txt',
+        'COPYING',
     ]
 
     no_comments_allowed = [fn for pattern in no_comments_allowed for fn in glob.glob(pattern)]
@@ -91,9 +86,10 @@ def main():
             path = path[2:]
         if path in ignore_paths or path.startswith('tests/output/'):
             continue
-        if os.path.basename(path) in empty_allowed:
-            if os.stat(path).st_size == 0:
-                continue
+        if os.stat(path).st_size == 0:
+            continue
+        if not path.endswith('.license') and os.path.exists(path + '.license'):
+            path = path + '.license'
         valid_licenses_for_path = valid_licenses
         if path.startswith('plugins/') and not path.startswith(('plugins/modules/', 'plugins/module_utils/')):
             valid_licenses_for_path = [license for license in valid_licenses if license == 'GPL-3.0-or-later']

--- a/tests/sanity/extra/licenses.py
+++ b/tests/sanity/extra/licenses.py
@@ -72,6 +72,7 @@ def main():
     # These files are completely ignored
     ignore_paths = [
         '.ansible-test-timeout.json',
+        '.reuse/dep5',
         'LICENSES/*.txt',
         'COPYING',
     ]

--- a/tests/sanity/extra/licenses.py.license
+++ b/tests/sanity/extra/licenses.py.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: 2022, Felix Fontein <felix@fontein.de>

--- a/tests/sanity/extra/no-unwanted-files.json.license
+++ b/tests/sanity/extra/no-unwanted-files.json.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/sanity/ignore-2.10.txt.license
+++ b/tests/sanity/ignore-2.10.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/sanity/ignore-2.11.txt.license
+++ b/tests/sanity/ignore-2.11.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/sanity/ignore-2.12.txt.license
+++ b/tests/sanity/ignore-2.12.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/sanity/ignore-2.13.txt.license
+++ b/tests/sanity/ignore-2.13.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/sanity/ignore-2.14.txt.license
+++ b/tests/sanity/ignore-2.14.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/sanity/ignore-2.9.txt.license
+++ b/tests/sanity/ignore-2.9.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project


### PR DESCRIPTION
##### SUMMARY
Everything except changelog/fragments/ is now reuse conformant (https://reuse.software/spec/).

CC @gotmax23

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
licensing
