### PR TITLE
Documentation: changed cmd return value to command

### DIFF
--- a/plugins/modules/docker_compose.py
+++ b/plugins/modules/docker_compose.py
@@ -339,7 +339,7 @@ services:
           returned: success
           type: complex
           contains:
-              cmd:
+              command:
                   description: One or more commands to be executed in the container.
                   returned: success
                   type: list


### PR DESCRIPTION
##### SUMMARY
Seems like there is a slight issue. The cmd param doesn't exist, but command works well, also all examples use command param.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
https://docs.ansible.com/ansible/latest/collections/community/docker/docker_compose_module.html#return-services/container_name/cmd

##### ADDITIONAL INFORMATION
If you try to specify cmd you will get the following error:
```
{"changed": false, "msg": "Configuration error - The Compose file '/tmp/ansible6ogp6awz/docker-compose.yml' is invalid because:\nUnsupported config option for services.envoy: 'cmd'"}
```
