### PR TITLE
docker_swarm: add data_path_port option for swarm init

### DIFF
--- a/changelogs/fragments/466-add-data-path-port.yml
+++ b/changelogs/fragments/466-add-data-path-port.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - docker_swarm - allows usage of the `data_path_port` parameter when initializing or joining a swarm (https://github.com/ansible-collections/community.docker/issues/296).

--- a/changelogs/fragments/466-add-data-path-port.yml
+++ b/changelogs/fragments/466-add-data-path-port.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - docker_swarm - allows usage of the ``data_path_port`` parameter when initializing or joining a swarm (https://github.com//issues/296).
+  - docker_swarm - allows usage of the ``data_path_port`` parameter when initializing a swarm (https://github.com/ansible-collections/community.docker/issues/296).

--- a/changelogs/fragments/466-add-data-path-port.yml
+++ b/changelogs/fragments/466-add-data-path-port.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - docker_swarm - allows usage of the `data_path_port` parameter when initializing or joining a swarm (https://github.com/ansible-collections/community.docker/issues/296).
+  - docker_swarm - allows usage of the ``data_path_port`` parameter when initializing or joining a swarm (https://github.com//issues/296).

--- a/plugins/modules/docker_swarm.py
+++ b/plugins/modules/docker_swarm.py
@@ -522,7 +522,6 @@ class SwarmManager(DockerBaseClass):
                 'advertise_addr': self.parameters.advertise_addr,
                 'listen_addr': self.parameters.listen_addr,
                 'data_path_addr': self.parameters.data_path_addr,
-                'data_path_port': self.parameters.data_path_port,
                 'force_new_cluster': self.force,
                 'swarm_spec': self.parameters.spec,
             }

--- a/plugins/modules/docker_swarm.py
+++ b/plugins/modules/docker_swarm.py
@@ -189,7 +189,7 @@ options:
     description:
       - Port to use for data path traffic.
       - This needs to be a port number like C(9789).
-      - Only used when swarm is initialised or joined. Because of this it is not
+      - Only used when swarm is initialised. Because of this it is not
         considered for idempotency checking.
     type: int
     version_added: 3.1.0
@@ -530,6 +530,8 @@ class SwarmManager(DockerBaseClass):
                 init_arguments['default_addr_pool'] = self.parameters.default_addr_pool
             if self.parameters.subnet_size is not None:
                 init_arguments['subnet_size'] = self.parameters.subnet_size
+            if self.parameters.data_path_port is not None:
+                init_arguments['data_path_port'] = self.parameters.data_path_port
             try:
                 self.client.init_swarm(**init_arguments)
             except APIError as exc:
@@ -585,8 +587,7 @@ class SwarmManager(DockerBaseClass):
                 self.client.join_swarm(
                     remote_addrs=self.parameters.remote_addrs, join_token=self.parameters.join_token,
                     listen_addr=self.parameters.listen_addr, advertise_addr=self.parameters.advertise_addr,
-                    data_path_addr=self.parameters.data_path_addr,
-                    data_path_port=self.parameters.data_path_port)
+                    data_path_addr=self.parameters.data_path_addr)
             except APIError as exc:
                 self.client.fail("Can not join the Swarm Cluster: %s" % to_native(exc))
         self.results['actions'].append("New node is added to swarm cluster")

--- a/plugins/modules/docker_swarm.py
+++ b/plugins/modules/docker_swarm.py
@@ -192,6 +192,7 @@ options:
       - Only used when swarm is initialised or joined. Because of this it is not
         considered for idempotency checking.
     type: int
+    version_added: 3.1.0
 extends_documentation_fragment:
 - community.docker.docker
 - community.docker.docker.docker_py_1_documentation


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allows usage of the `data_path_port` parameter when initializing a swarm.  Fixes #296.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
- name: Init a new swarm with different data-path-port parameter
  docker_swarm:
    state: present
    data_path_port: 4790
```
