### PR TITLE
docker_image: clarify that BuildKit / buildx cannot be used

### DIFF
--- a/plugins/modules/docker_image.py
+++ b/plugins/modules/docker_image.py
@@ -19,6 +19,9 @@ description:
   - Build, load or pull an image, making the image available for creating containers. Also supports tagging
     an image, pushing an image, and archiving an image to a C(.tar) file.
 
+notes:
+  - Building images is done using Docker daemon's API. It is not possible to use BuildKit / buildx this way.
+
 options:
   source:
     description:


### PR DESCRIPTION
##### SUMMARY
See #467 and #364.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docker_image
