### PR TITLE
docker_container: deprecate `ignore_image` and `purge_networks`

### DIFF
--- a/changelogs/fragments/487-docker_container-deprecate.yml
+++ b/changelogs/fragments/487-docker_container-deprecate.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+  - "docker_container - the ``ignore_image`` option is deprecated and will be removed in community.docker 4.0.0. Use ``image: ignore`` in ``comparisons`` instead (https://github.com/ansible-collections/community.docker/pull/487)."
+  - "docker_container - the ``purge_networks`` option is deprecated and will be removed in community.docker 4.0.0. Use ``networks: strict`` in ``comparisons`` instead, and make sure to provide ``networks``, with value ``[]`` if all networks should be removed (https://github.com/ansible-collections/community.docker/pull/487)."

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -628,10 +628,10 @@ options:
     description:
       - List of networks the container belongs to.
       - For examples of the data structure and usage see EXAMPLES below.
-      - To remove a container from one or more networks, use C(networks: strict) in the I(comparisons) option.
-      - If I(networks_cli_compatible) is set to C(false), this will not remove the default network if I(networks) is specified.
+      - "To remove a container from one or more networks, use C(networks: strict) in the I(comparisons) option."
+      - "If I(networks_cli_compatible) is set to C(false), this will not remove the default network if I(networks) is specified.
         This is different from the behavior of C(docker run ...). You need to explicitly use C(networks: strict) in I(comparisons)
-        to enforce the removal of the default network (and all other networks not explicitly mentioned in I(networks)) in that case.
+        to enforce the removal of the default network (and all other networks not explicitly mentioned in I(networks)) in that case."
     type: list
     elements: dict
     suboptions:
@@ -829,8 +829,8 @@ options:
         state. Use I(restart) to force a matching container to be stopped and restarted.'
       - 'C(stopped) - Asserts that the container is first C(present), and then if the container is running moves it to a stopped
         state.'
-      - To control what will be taken into account when comparing configuration, see the I(comparisons) option. To avoid that the
-        image version will be taken into account, you can also use the C(image: ignore) in the I(comparisons) option.
+      - "To control what will be taken into account when comparing configuration, see the I(comparisons) option. To avoid that the
+        image version will be taken into account, you can also use the C(image: ignore) in the I(comparisons) option."
       - Use the I(recreate) option to always force re-creation of a matching container, even if it is running.
       - If the container should be killed instead of stopped in case it needs to be stopped for recreation, or because I(state) is
         C(stopped), please use the I(force_kill) option. Use I(keep_volumes) to retain anonymous volumes associated with a removed container.

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -396,6 +396,8 @@ options:
         stop this behavior by setting I(ignore_image) to C(true).
       - "B(Warning:) This option is ignored if C(image: ignore) or C(*: ignore) is specified in the
         I(comparisons) option."
+      - "This option is deprecated since community.docker 3.2.0 and will be removed in community.docker 4.0.0.
+        Use C(image: ignore) in I(comparisons) instead of I(ignore_image=true)."
     type: bool
     default: false
   image:
@@ -626,10 +628,10 @@ options:
     description:
       - List of networks the container belongs to.
       - For examples of the data structure and usage see EXAMPLES below.
-      - To remove a container from one or more networks, use the I(purge_networks) option.
+      - To remove a container from one or more networks, use C(networks: strict) in the I(comparisons) option.
       - If I(networks_cli_compatible) is set to C(false), this will not remove the default network if I(networks) is specified.
-        This is different from the behavior of C(docker run ...). You need to explicitly use I(purge_networks) to enforce
-        the removal of the default network (and all other networks not explicitly mentioned in I(networks)) in that case.
+        This is different from the behavior of C(docker run ...). You need to explicitly use C(networks: strict) in I(comparisons)
+        to enforce the removal of the default network (and all other networks not explicitly mentioned in I(networks)) in that case.
     type: list
     elements: dict
     suboptions:
@@ -666,8 +668,8 @@ options:
          via the I(networks) option, the module behaves differently than C(docker run --network):
          C(docker run --network other) will create a container with network C(other) attached,
          but the default network not attached. This module with I(networks: {name: other}) will
-         create a container with both C(default) and C(other) attached. If I(purge_networks) is
-         set to C(true), the C(default) network will be removed afterwards."
+         create a container with both C(default) and C(other) attached. If C(networks: strict)
+         or C(*: strict) is set in I(comparisons), the C(default) network will be removed afterwards."
     type: bool
     default: true
   oom_killer:
@@ -745,16 +747,19 @@ options:
       - ports
   pull:
     description:
-       - If true, always pull the latest version of an image. Otherwise, will only pull an image
-         when missing.
-       - "B(Note:) images are only pulled when specified by name. If the image is specified
-         as a image ID (hash), it cannot be pulled."
+      - If true, always pull the latest version of an image. Otherwise, will only pull an image
+        when missing.
+      - "B(Note:) images are only pulled when specified by name. If the image is specified
+        as a image ID (hash), it cannot be pulled."
     type: bool
     default: false
   purge_networks:
     description:
-       - Remove the container from ALL networks not included in I(networks) parameter.
-       - Any default networks such as C(bridge), if not found in I(networks), will be removed as well.
+      - Remove the container from ALL networks not included in I(networks) parameter.
+      - Any default networks such as C(bridge), if not found in I(networks), will be removed as well.
+      - "This option is deprecated since community.docker 3.2.0 and will be removed in community.docker 4.0.0.
+        Use C(networks: strict) in I(comparisons) instead of I(purge_networks=true) and make sure that
+        I(networks) is specified. If you want to remove all networks, specify I(networks: [])."
     type: bool
     default: false
   read_only:
@@ -825,7 +830,7 @@ options:
       - 'C(stopped) - Asserts that the container is first C(present), and then if the container is running moves it to a stopped
         state.'
       - To control what will be taken into account when comparing configuration, see the I(comparisons) option. To avoid that the
-        image version will be taken into account, you can also use the I(ignore_image) option.
+        image version will be taken into account, you can also use the C(image: ignore) in the I(comparisons) option.
       - Use the I(recreate) option to always force re-creation of a matching container, even if it is running.
       - If the container should be killed instead of stopped in case it needs to be stopped for recreation, or because I(state) is
         C(stopped), please use the I(force_kill) option. Use I(keep_volumes) to retain anonymous volumes associated with a removed container.
@@ -1065,12 +1070,14 @@ EXAMPLES = '''
     name: sleepy
     networks:
       - name: TestingNet2
-    purge_networks: true
+    comparisons:
+      networks: strict
 
 - name: Remove container from all networks
   community.docker.docker_container:
     name: sleepy
-    purge_networks: true
+    comparisons:
+      networks: strict
 
 - name: Start a container and use an env file
   community.docker.docker_container:

--- a/tests/integration/targets/docker_container/tasks/tests/network.yml
+++ b/tests/integration/targets/docker_container/tasks/tests/network.yml
@@ -179,7 +179,8 @@
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
-    purge_networks: yes
+    comparisons:
+      networks: strict
     networks:
     - name: bridge
     - name: "{{ nname_1 }}"
@@ -193,7 +194,8 @@
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
-    purge_networks: yes
+    comparisons:
+      networks: strict
     networks:
     - name: "{{ nname_1 }}"
     - name: bridge
@@ -217,7 +219,8 @@
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
-    purge_networks: yes
+    comparisons:
+      networks: strict
     networks:
     - name: bridge
     networks_cli_compatible: no
@@ -230,7 +233,8 @@
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
-    purge_networks: yes
+    comparisons:
+      networks: strict
     networks:
     - name: bridge
     - name: "{{ nname_2 }}"
@@ -350,7 +354,8 @@
     state: started
     networks: []
     networks_cli_compatible: yes
-    purge_networks: yes
+    comparisons:
+      networks: strict
     force_kill: yes
   register: networks_5
 
@@ -387,7 +392,8 @@
     name: "{{ cname }}"
     state: started
     networks_cli_compatible: yes
-    purge_networks: yes
+    comparisons:
+      networks: strict
     force_kill: yes
   register: networks_8
 

--- a/tests/integration/targets/docker_container/tasks/tests/network.yml
+++ b/tests/integration/targets/docker_container/tasks/tests/network.yml
@@ -392,8 +392,11 @@
     name: "{{ cname }}"
     state: started
     networks_cli_compatible: yes
-    comparisons:
-      networks: strict
+    purge_networks: true
+    # To replace `purge_networks=true`, we have to specify `networks: []`:
+    #   comparisons:
+    #     networks: strict
+    #   networks: []
     force_kill: yes
   register: networks_8
 

--- a/tests/integration/targets/docker_container/tasks/tests/options.yml
+++ b/tests/integration/targets/docker_container/tasks/tests/options.yml
@@ -2205,7 +2205,8 @@
 - name: ignore_image
   docker_container:
     image: "{{ docker_test_image_hello_world }}"
-    ignore_image: yes
+    comparisons:
+      image: ignore
     name: "{{ cname }}"
     state: started
   register: ignore_image
@@ -2214,7 +2215,8 @@
 - name: ignore_image (labels and env differ in image, image_comparison=current-image)
   docker_container:
     image: "{{ docker_test_image_registry_nginx }}"
-    ignore_image: yes
+    comparisons:
+      image: ignore
     image_comparison: current-image
     name: "{{ cname }}"
     state: started
@@ -2224,7 +2226,8 @@
 - name: ignore_image (labels and env differ in image, image_comparison=desired-image)
   docker_container:
     image: "{{ docker_test_image_registry_nginx }}"
-    ignore_image: yes
+    comparisons:
+      image: ignore
     image_comparison: desired-image
     name: "{{ cname }}"
     state: started


### PR DESCRIPTION
##### SUMMARY
Deprecate `ignore_image` and `purge_networks` options. Users should use the `comparisons` option instead to fine-tune these aspects of idempotency.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docker_container
