### PR TITLE
Fix non-matching defaults in docs

### DIFF
--- a/plugins/modules/docker_network.py
+++ b/plugins/modules/docker_network.py
@@ -31,6 +31,7 @@ options:
         M(community.docker.docker_container) module to ensure your containers are correctly connected to this network.
     type: list
     elements: str
+    default: []
     aliases:
       - containers
 
@@ -44,6 +45,7 @@ options:
     description:
       - Dictionary of network settings. Consult docker docs for valid options and values.
     type: dict
+    default: {}
 
   force:
     description:
@@ -131,6 +133,7 @@ options:
     description:
       - Dictionary of labels.
     type: dict
+    default: {}
 
   scope:
     description:

--- a/plugins/modules/docker_plugin.py
+++ b/plugins/modules/docker_plugin.py
@@ -48,6 +48,7 @@ options:
     description:
       - Dictionary of plugin settings.
     type: dict
+    default: {}
 
   force_remove:
     description:

--- a/plugins/modules/docker_volume.py
+++ b/plugins/modules/docker_volume.py
@@ -35,6 +35,7 @@ options:
       - "Dictionary of volume settings. Consult docker docs for valid options and values:
         U(https://docs.docker.com/engine/reference/commandline/volume_create/#driver-specific-options)."
     type: dict
+    default: {}
 
   labels:
     description:


### PR DESCRIPTION
##### SUMMARY
Fix various non-matching `default` values exposed by https://github.com/ansible/ansible/pull/79267.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
various