### PR TITLE
CI: ansible-core 2.11 is EOL; move CI runs to GHA

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -99,17 +99,6 @@ stages:
               test: '2.12/sanity/1'
             - name: Units
               test: '2.12/units/1'
-  - stage: Ansible_2_11
-    displayName: Sanity & Units 2.11
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: '2.11/sanity/1'
-            - name: Units
-              test: '2.11/units/1'
 
 ### Docker
   - stage: Docker_devel
@@ -181,21 +170,6 @@ stages:
               test: fedora34
             - name: Ubuntu 18.04
               test: ubuntu1804
-          groups:
-            - 4
-            - 5
-  - stage: Docker_2_11
-    displayName: Docker 2.11
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.11/linux/{0}
-          targets:
-            - name: Fedora 32
-              test: fedora32
-            - name: Alpine 3
-              test: alpine3
           groups:
             - 4
             - 5
@@ -285,22 +259,6 @@ stages:
             - 3
             - 4
             - 5
-  - stage: Remote_2_11
-    displayName: Remote 2.11
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: RHEL {0}
-          testFormat: 2.11/rhel/{0}
-          targets:
-            - test: '8.3'
-          groups:
-            - 1
-            - 2
-            - 3
-            - 4
-            - 5
 
   ## Finally
 
@@ -311,17 +269,14 @@ stages:
       - Ansible_2_14
       - Ansible_2_13
       - Ansible_2_12
-      - Ansible_2_11
       - Remote_devel
       - Remote_2_14
       - Remote_2_13
       - Remote_2_12
-      - Remote_2_11
       - Docker_devel
       - Docker_2_14
       - Docker_2_13
       - Docker_2_12
-      - Docker_2_11
       - Docker_community_devel
     jobs:
       - template: templates/coverage.yml

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -1,0 +1,116 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# For the comprehensive list of the inputs supported by the ansible-community/ansible-test-gh-action GitHub Action, see
+# https://github.com/marketplace/actions/ansible-test
+
+name: EOL CI
+on:
+  # Run EOL CI against all pushes (direct commits, also merged PRs), Pull Requests
+  push:
+    branches:
+      - main
+      - stable-*
+  pull_request:
+  # Run EOL CI once per day (at 09:00 UTC)
+  schedule:
+    - cron: '0 9 * * *'
+
+jobs:
+  sanity:
+    name: EOL Sanity (Ⓐ${{ matrix.ansible }})
+    strategy:
+      matrix:
+        ansible:
+          - '2.11'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Perform sanity testing
+        uses: felixfontein/ansible-test-gh-action@integration-error-behavior
+        with:
+          ansible-core-version: stable-${{ matrix.ansible }}
+          coverage: ${{ github.event_name == 'schedule' && 'always' || 'never' }}
+          pull-request-change-detection: 'true'
+          testing-type: sanity
+
+  units:
+    runs-on: ubuntu-latest
+    name: EOL Units (Ⓐ${{ matrix.ansible }})
+    strategy:
+      # As soon as the first unit test fails, cancel the others to free up the CI queue
+      fail-fast: true
+      matrix:
+        ansible:
+          - '2.11'
+
+    steps:
+      - name: >-
+          Perform unit testing against
+          Ansible version ${{ matrix.ansible }}
+        uses: felixfontein/ansible-test-gh-action@integration-error-behavior
+        with:
+          ansible-core-version: stable-${{ matrix.ansible }}
+          coverage: ${{ github.event_name == 'schedule' && 'always' || 'never' }}
+          pull-request-change-detection: 'true'
+          testing-type: units
+
+  integration:
+    runs-on: ubuntu-latest
+    name: EOL I (Ⓐ${{ matrix.ansible }}+${{ matrix.docker }}+py${{ matrix.python }}:${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        ansible:
+          - ''
+        docker:
+          - ''
+        python:
+          - ''
+        target:
+          - ''
+        exclude:
+          - ansible: ''
+        include:
+          # 2.11
+          - ansible: '2.11'
+            docker: fedora32
+            python: ''
+            target: azp/4/
+          - ansible: '2.11'
+            docker: fedora32
+            python: ''
+            target: azp/5/
+          - ansible: '2.11'
+            docker: alpine3
+            python: ''
+            target: azp/4/
+          - ansible: '2.11'
+            docker: alpine3
+            python: ''
+            target: azp/5/
+
+    steps:
+      - name: >-
+          Perform integration testing against
+          Ansible version ${{ matrix.ansible }}
+          under Python ${{ matrix.python }}
+        uses: felixfontein/ansible-test-gh-action@integration-error-behavior
+        with:
+          ansible-core-version: stable-${{ matrix.ansible }}
+          coverage: ${{ github.event_name == 'schedule' && 'always' || 'never' }}
+          docker-image: ${{ matrix.docker }}
+          integration-continue-on-error: 'false'
+          pre-test-cmd: >-
+            mkdir -p ../../ansible
+            ;
+            git clone --depth=1 --single-branch https://github.com/ansible-collections/ansible.posix.git ../../ansible/posix
+            ;
+            git clone --depth=1 --single-branch https://github.com/ansible-collections/community.crypto.git ../../community/crypto
+            ;
+            git clone --depth=1 --single-branch https://github.com/ansible-collections/community.general.git ../../community/general
+          pull-request-change-detection: 'true'
+          target: ${{ matrix.target }}
+          target-python-version: ${{ matrix.python }}
+          testing-type: integration


### PR DESCRIPTION
##### SUMMARY
See https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#ansible-core-changelogs

Analogue to https://github.com/ansible-collections/community.crypto/pull/534. Uses my fork of https://github.com/ansible-community/ansible-test-gh-action to be able to use https://github.com/ansible-community/ansible-test-gh-action/pull/49, https://github.com/ansible-community/ansible-test-gh-action/pull/50, and https://github.com/ansible-community/ansible-test-gh-action/pull/51.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
