### PR TITLE
Add docstring to ImageManager.__init__ and fix docstring for ImageManager.archive_image

### DIFF
--- a/plugins/modules/docker_image.py
+++ b/plugins/modules/docker_image.py
@@ -373,6 +373,14 @@ from ansible_collections.community.docker.plugins.module_utils._api.utils.utils 
 class ImageManager(DockerBaseClass):
 
     def __init__(self, client, results):
+        '''
+        Configure a docker_image task.
+
+        :param client: Ansible Docker Client wrapper over Docker client
+        :type client: AnsibleDockerClient
+        :param results: This task adds its output values to this dictionary
+        :type results: dict
+        '''
 
         super(ImageManager, self).__init__()
 
@@ -531,8 +539,10 @@ class ImageManager(DockerBaseClass):
         '''
         Archive an image to a .tar file. Called when archive_path is passed.
 
-        :param name - name of the image. Type: str
-        :return None
+        :param name: Name/repository of the image
+        :type name: str
+        :param tag: Optional image tag; assumed to be "latest" if None
+        :type tag: str | None
         '''
 
         if not tag:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Change originally in #500 but pulled this out as a standalone change because that build is failing and to see if this build would fail also.

This change can stand alone without #500.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`docker_image`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

No changes to module behavior or output.