### PR TITLE
CI: add CentOS Stream 8 with Python 3.6 to matrix

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -111,17 +111,16 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
+            - name: Fedora 36
+              test: fedora36
             - name: openSUSE 15
               test: opensuse15
-            # The following are already tested as VMs with devel:
-            # - name: Fedora 36
-            #   test: fedora36
-            # - name: Ubuntu 20.04
-            #   test: ubuntu2004
-            # - name: Ubuntu 22.04
-            #   test: ubuntu2204
-            # - name: Alpine 3
-            #   test: alpine3
+            - name: Ubuntu 20.04
+              test: ubuntu2004
+            - name: Ubuntu 22.04
+              test: ubuntu2204
+            - name: Alpine 3
+              test: alpine3
           groups:
             - 4
             - 5
@@ -209,14 +208,6 @@ stages:
               test: rhel/7.9
             - name: RHEL 9.0 with latest Docker SDK from PyPi
               test: rhel/9.0-pypi-latest
-            - name: Alpine 3.16
-              test: alpine/3.16
-            - name: Fedora 36
-              test: fedora/36
-            - name: Ubuntu 20.04
-              test: ubuntu/20.04
-            - name: Ubuntu 22.04
-              test: ubuntu/22.04
           groups:
             - 1
             - 2

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -187,6 +187,8 @@ stages:
               test: debian-bullseye/3.9
             - name: ArchLinux
               test: archlinux/3.10
+            - name: CentOS Stream 8 with Python 3.6
+              test: centos-stream8/3.6
             - name: CentOS Stream 8 with Python 3.9
               test: centos-stream8/3.9
           groups:
@@ -206,6 +208,14 @@ stages:
               test: rhel/7.9
             - name: RHEL 9.0 with latest Docker SDK from PyPi
               test: rhel/9.0-pypi-latest
+            - name: Alpine 3.16
+              test: alpine/3.16
+            - name: Fedora 36
+              test: fedora/36
+            - name: Ubuntu 20.04
+              test: ubuntu/20.04
+            - name: Ubuntu 22.04
+              test: ubuntu/22.04
           groups:
             - 1
             - 2

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -111,16 +111,17 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: Fedora 36
-              test: fedora36
             - name: openSUSE 15
               test: opensuse15
-            - name: Ubuntu 20.04
-              test: ubuntu2004
-            - name: Ubuntu 22.04
-              test: ubuntu2204
-            - name: Alpine 3
-              test: alpine3
+            # The following are already tested as VMs with devel:
+            # - name: Fedora 36
+            #   test: fedora36
+            # - name: Ubuntu 20.04
+            #   test: ubuntu2004
+            # - name: Ubuntu 22.04
+            #   test: ubuntu2204
+            # - name: Alpine 3
+            #   test: alpine3
           groups:
             - 4
             - 5


### PR DESCRIPTION
##### SUMMARY
Uses VMs for Alpine 3.16, Fedora 36, Ubuntu 20.04, and Ubuntu 22.04, instead of Docker containers.

This increases the size of the CI matrix since for these platfoms, the test groups 1-3 have not been running before. (These are for Docker Swarm tests which need to reconfigure the Docker daemon, and thus are only run on VMs. Which so far was only RHEL.)

CC @mattclay (as I don't know whether these VMs are supposed to be used by collections as well)

CC @Spredzy @Andersson007 as this extends the CI matrix and RH is paying for that :)

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
