### PR TITLE
Forgot to switch docs fragment for docker_container: it no longer depends on the Docker SDK for Python

### DIFF
--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -27,8 +27,7 @@ notes:
   - When I(restart) is set to C(true), the module will only restart the container if no config changes are detected.
 
 extends_documentation_fragment:
-  - community.docker.docker
-  - community.docker.docker.docker_py_1_documentation
+  - community.docker.docker.api_documentation
   - community.docker.attributes
   - community.docker.attributes.actiongroup_docker
 


### PR DESCRIPTION
##### SUMMARY
Forgot to switch docs fragment for docker_container: it no longer depends on the Docker SDK for Python.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docker_container
