### PR TITLE
docs: Fix json path in asserts

### DIFF
--- a/plugins/modules/docker_compose.py
+++ b/plugins/modules/docker_compose.py
@@ -235,8 +235,8 @@ EXAMPLES = '''
 
     - ansible.builtin.assert:
         that:
-          - "not web.flask_web_1.state.running"
-          - "not db.flask_db_1.state.running"
+          - "not output.services.web.flask_web_1.state.running"
+          - "not output.services.db.flask_db_1.state.running"
 
     - name: Restart services
       community.docker.docker_compose:
@@ -250,8 +250,8 @@ EXAMPLES = '''
 
     - ansible.builtin.assert:
         that:
-          - "web.flask_web_1.state.running"
-          - "db.flask_db_1.state.running"
+          - "output.services.web.flask_web_1.state.running"
+          - "output.services.db.flask_db_1.state.running"
 
 - name: Scale the web service to 2
   hosts: localhost
@@ -298,8 +298,8 @@ EXAMPLES = '''
 
     - ansible.builtin.assert:
         that:
-          - "web.flask_web_1.state.running"
-          - "db.flask_db_1.state.running"
+          - "output.services.web.flask_web_1.state.running"
+          - "output.services.db.flask_db_1.state.running"
 
 - name: Run with inline Compose file version 1
   # https://docs.docker.com/compose/compose-file/compose-file-v1/
@@ -331,8 +331,8 @@ EXAMPLES = '''
 
     - ansible.builtin.assert:
         that:
-          - "web.flask_web_1.state.running"
-          - "db.flask_db_1.state.running"
+          - "output.services.web.flask_web_1.state.running"
+          - "output.services.db.flask_db_1.state.running"
 '''
 
 RETURN = '''


### PR DESCRIPTION
##### SUMMARY

The current path to the running state does not include `output.services.` which it should.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

`community.docker.docker_compose`
