### PR TITLE
Fix CI

### DIFF
--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -12,6 +12,7 @@ cryptography >= 1.3.0, < 3.4 ; python_version < '3.6' # cryptography 3.4 drops s
 urllib3 < 1.24 ; python_version < '2.7' # urllib3 1.24 and later require python 2.7 or later
 wheel < 0.30.0 ; python_version < '2.7' # wheel 0.30.0 and later require python 2.7 or later
 paramiko < 2.4.0 ; python_version < '2.7' # paramiko 2.4.0 drops support for python 2.6
+paramiko < 3.0.0 ; python_version < '3.7' # paramiko 3.0.0 forces installation of a too new cryptography
 requests < 2.20.0 ; python_version < '2.7' # requests 2.20.0 drops support for python 2.6
 requests < 2.28 ; python_version < '3.7' # requests 2.28.0 drops support for python < 3.7
 virtualenv < 16.0.0 ; python_version < '2.7' # virtualenv 16.0.0 and later require python 2.7 or later


### PR DESCRIPTION
##### SUMMARY
Right now nightly CI fails when trying to install docker_compose, roughtly since paramiko 3.0.0 has been released.
```
Collecting docker-compose<1.25.0 (from -c /tmp/ansible.mufj674p.test/constraints.txt (line 24))
  Downloading https://files.pythonhosted.org/packages/dd/e6/1521d1dfd9c0da1d1863b18e592d91c3df222e55f258b9876fa1e59bc4b5/docker_compose-1.24.1-py2.py3-none-any.whl (134kB)
Requirement already satisfied: docker<5.0.0 in /usr/local/lib/python3.6/site-packages (from -c /tmp/ansible.mufj674p.test/constraints.txt (line 23))
Requirement already satisfied: PyYAML<4.3,>=3.10 in /usr/lib64/python3.6/site-packages (from docker-compose<1.25.0->-c /tmp/ansible.mufj674p.test/constraints.txt (line 24))
Collecting texttable<0.10,>=0.9.0 (from docker-compose<1.25.0->-c /tmp/ansible.mufj674p.test/constraints.txt (line 24))
  Downloading https://files.pythonhosted.org/packages/02/e1/2565e6b842de7945af0555167d33acfc8a615584ef7abd30d1eae00a4d80/texttable-0.9.1.tar.gz
Collecting dockerpty<0.5,>=0.4.1 (from docker-compose<1.25.0->-c /tmp/ansible.mufj674p.test/constraints.txt (line 24))
  Downloading https://files.pythonhosted.org/packages/8d/ee/e9ecce4c32204a6738e0a5d5883d3413794d7498fe8b06f44becc028d3ba/dockerpty-0.4.1.tar.gz
Requirement already satisfied: requests<2.28 in /usr/lib/python3.6/site-packages (from -c /tmp/ansible.mufj674p.test/constraints.txt (line 16))
Requirement already satisfied: websocket-client<1.0.0 in /usr/local/lib/python3.6/site-packages (from -c /tmp/ansible.mufj674p.test/constraints.txt (line 20))
Requirement already satisfied: six<2,>=1.3.0 in /usr/lib/python3.6/site-packages (from docker-compose<1.25.0->-c /tmp/ansible.mufj674p.test/constraints.txt (line 24))
Requirement already satisfied: jsonschema<3,>=2.5.1 in /usr/lib/python3.6/site-packages (from docker-compose<1.25.0->-c /tmp/ansible.mufj674p.test/constraints.txt (line 24))
Collecting cached-property<2,>=1.2.0 (from docker-compose<1.25.0->-c /tmp/ansible.mufj674p.test/constraints.txt (line 24))
  Downloading https://files.pythonhosted.org/packages/48/19/f2090f7dad41e225c7f2326e4cfe6fff49e57dedb5b53636c9551f86b069/cached_property-1.5.2-py2.py3-none-any.whl
Collecting docopt<0.7,>=0.6.1 (from docker-compose<1.25.0->-c /tmp/ansible.mufj674p.test/constraints.txt (line 24))
  Downloading https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz
Collecting paramiko>=2.4.2; extra == "ssh" (from docker<5.0.0->-c /tmp/ansible.mufj674p.test/constraints.txt (line 23))
  Downloading https://files.pythonhosted.org/packages/ae/fe/3ab1540ee3f956fed7c738ac60b17586b3e57629a6b8f8dcbb790fca00c2/paramiko-3.0.0-py3-none-any.whl (210kB)
Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /usr/lib/python3.6/site-packages (from requests<2.28->-c /tmp/ansible.mufj674p.test/constraints.txt (line 16))
Requirement already satisfied: idna<2.8,>=2.5 in /usr/lib/python3.6/site-packages (from requests<2.28->-c /tmp/ansible.mufj674p.test/constraints.txt (line 16))
Requirement already satisfied: urllib3<1.25,>=1.21.1 in /usr/lib/python3.6/site-packages (from requests<2.28->-c /tmp/ansible.mufj674p.test/constraints.txt (line 16))
Collecting pynacl<1.5.0,>=1.4.0 (from -c /tmp/ansible.mufj674p.test/constraints.txt (line 25))
  Downloading https://files.pythonhosted.org/packages/9d/57/2f5e6226a674b2bcb6db531e8b383079b678df5b10cdaa610d6cf20d77ba/PyNaCl-1.4.0-cp35-abi3-manylinux1_x86_64.whl (961kB)
Collecting bcrypt<3.2.0 (from -c /tmp/ansible.mufj674p.test/constraints.txt (line 5))
  Downloading https://files.pythonhosted.org/packages/8b/1d/82826443777dd4a624e38a08957b975e75df859b381ae302cfd7a30783ed/bcrypt-3.1.7-cp34-abi3-manylinux1_x86_64.whl (56kB)
Collecting cryptography>=3.3 (from paramiko>=2.4.2; extra == "ssh"->docker<5.0.0->-c /tmp/ansible.mufj674p.test/constraints.txt (line 23))
  Downloading https://files.pythonhosted.org/packages/12/e3/c46c274cf466b24e5d44df5d5cd31a31ff23e57f074a2bb30931a8c9b01a/cryptography-39.0.0.tar.gz (603kB)
    Complete output from command python setup.py egg_info:
    
            =============================DEBUG ASSISTANCE==========================
            If you are seeing an error here please try the following to
            successfully install cryptography:
    
            Upgrade to the latest pip and try again. This will fix errors for most
            users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
            =============================DEBUG ASSISTANCE==========================
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-v1_z1yjk/cryptography/setup.py", line 18, in <module>
        from setuptools_rust import RustExtension
    ModuleNotFoundError: No module named 'setuptools_rust'
    
    ----------------------------------------

:stderr: WARNING: Running pip install with root privileges is generally not a good idea. Try `__main__.py install --user` instead.
Ignoring certifi: markers 'python_version < "3.5"' don't match your environment
Ignoring coverage: markers 'python_version > "3.7"' don't match your environment
Ignoring cryptography: markers 'python_version < "2.7"' don't match your environment
Ignoring cryptography: markers 'python_version < "3.6"' don't match your environment
Ignoring urllib3: markers 'python_version < "2.7"' don't match your environment
Ignoring wheel: markers 'python_version < "2.7"' don't match your environment
Ignoring paramiko: markers 'python_version < "2.7"' don't match your environment
Ignoring requests: markers 'python_version < "2.7"' don't match your environment
Ignoring virtualenv: markers 'python_version < "2.7"' don't match your environment
Ignoring pyopenssl: markers 'python_version < "2.7"' don't match your environment
Ignoring setuptools: markers 'python_version <= "2.7"' don't match your environment
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-v1_z1yjk/cryptography/
```

Restrict to old enough paramiko on RHEL 8 or other systems using Python 3.6.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
