### PR TITLE
Declare stable-1 branch EOL

### DIFF
--- a/changelogs/fragments/eol.yml
+++ b/changelogs/fragments/eol.yml
@@ -1,0 +1,4 @@
+release_summary: Final maintenance release of community.docker major version 1.
+major_changes:
+  - The community.docker 1.x.y release stream is now effectively **End of Life**.
+    No more releases will be made, and regular CI runs will stop.


### PR DESCRIPTION
##### SUMMARY
Since nobody said in #543 that they want to keep this supported, let's declare stable-1 EOL, make a final maintenance release, and shut the branch down (i.e. remove CI).

Closes #543.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelog
