### PR TITLE
CI: Make tests work with Docker API version 1.42

### DIFF
--- a/tests/integration/targets/docker_container/tasks/tests/options.yml
+++ b/tests/integration/targets/docker_container/tasks/tests/options.yml
@@ -2743,6 +2743,8 @@
   when:
     - kernel_memory_1 is not failed or 'kernel memory accounting disabled in this runc build' not in kernel_memory_1.msg
     - "'Docker warning: Specifying a kernel memory limit is deprecated and will be removed in a future release.' not in (kernel_memory_1.warnings | default([]))"
+    # API version 1.42 seems to remove the kernel memory option completely
+    - "'KernelMemory' in kernel_memory_1.container.HostConfig or docker_api_version is version('1.42', '<')"
 
 ####################################################################
 ## kill_signal #####################################################

--- a/tests/integration/targets/docker_prune/tasks/main.yml
+++ b/tests/integration/targets/docker_prune/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - block:
   # Create objects to be pruned
-  - name: Create container
+  - name: Create container with anonymous volume
     docker_container:
       name: "{{ cname }}"
       image: "{{ docker_test_image_hello_world }}"
@@ -24,6 +24,16 @@
       volumes:
         # Should create an anonymous volume
         - /data
+    register: container_av
+  - name: Delete container
+    docker_container:
+      name: "{{ cname }}"
+      state: absent
+  - name: Re-create container (without volume)
+    docker_container:
+      name: "{{ cname }}"
+      image: "{{ docker_test_image_hello_world }}"
+      state: present
     register: container
   - name: Create network
     docker_network:
@@ -53,6 +63,7 @@
     assert:
       that:
       # containers
+      - container_av.container.Id not in result.containers
       - container.container.Id in result.containers
       - "'containers_space_reclaimed' in result"
       # images
@@ -60,7 +71,7 @@
       # networks
       - network.network.Name in result.networks
       # volumes
-      - container.container.Mounts[0].Name in result.volumes
+      - container_av.container.Mounts[0].Name in result.volumes
       - "'volumes_space_reclaimed' in result"
       # builder_cache
       - "'builder_cache_space_reclaimed' in result"

--- a/tests/integration/targets/docker_prune/tasks/main.yml
+++ b/tests/integration/targets/docker_prune/tasks/main.yml
@@ -16,16 +16,22 @@
 
 - block:
   # Create objects to be pruned
-  - docker_container:
+  - name: Create container
+    docker_container:
       name: "{{ cname }}"
       image: "{{ docker_test_image_hello_world }}"
       state: present
+      volumes:
+        # Should create an anonymous volume
+        - /data
     register: container
-  - docker_network:
+  - name: Create network
+    docker_network:
       name: "{{ nname }}"
       state: present
     register: network
-  - docker_volume:
+  - name: Create named volume
+    docker_volume:
       name: "{{ vname }}"
       state: present
     register: volume
@@ -40,8 +46,11 @@
     register: result
 
   # Analyze result
-  - debug: var=result
-  - assert:
+  - name: Show results
+    debug:
+      var: result
+  - name: General checks
+    assert:
       that:
       # containers
       - container.container.Id in result.containers
@@ -51,19 +60,55 @@
       # networks
       - network.network.Name in result.networks
       # volumes
-      - volume.volume.Name in result.volumes
+      - container.container.Mounts[0].Name in result.volumes
       - "'volumes_space_reclaimed' in result"
       # builder_cache
       - "'builder_cache_space_reclaimed' in result"
+  - name: API-version specific volumes check (API version before 1.42)
+    assert:
+      that:
+      # For API version 1.41 and before, pruning always considers all volumes
+      - volume.volume.Name in result.volumes
+    when: docker_api_version is version('1.42', '<')
+  - name: API-version specific volumes check (API version 1.42+)
+    assert:
+      that:
+      # For API version 1.41 and before, pruning considers only anonymous volumes,
+      # so our named container is not removed
+      - volume.volume.Name not in result.volumes
+    when: docker_api_version is version('1.42', '>=')
 
   # Test with filters
-  - docker_prune:
+  - name: Prune with filters
+    docker_prune:
       images: yes
       images_filters:
         dangling: true
     register: result
 
-  - debug: var=result
+  - name: Show results
+    debug:
+      var: result
+
+  - name: Prune volumes with all filter (API version 1.42+)
+    when: docker_api_version is version('1.42', '>=')
+    block:
+    - name: Prune with filters
+      docker_prune:
+        volumes: yes
+        volumes_filters:
+          all: true
+      register: result
+
+    - name: Show results
+      debug:
+        var: result
+
+    - name: Check results
+      assert:
+        that:
+          - volume.volume.Name in result.volumes
+          - "'volumes_space_reclaimed' in result"
 
   when: docker_api_version is version('1.25', '>=')
 

--- a/tests/integration/targets/docker_prune/tasks/main.yml
+++ b/tests/integration/targets/docker_prune/tasks/main.yml
@@ -16,20 +16,7 @@
 
 - block:
   # Create objects to be pruned
-  - name: Create container with anonymous volume
-    docker_container:
-      name: "{{ cname }}"
-      image: "{{ docker_test_image_hello_world }}"
-      state: present
-      volumes:
-        # Should create an anonymous volume
-        - /data
-    register: container_av
-  - name: Delete container
-    docker_container:
-      name: "{{ cname }}"
-      state: absent
-  - name: Re-create container (without volume)
+  - name: Create container (without volume)
     docker_container:
       name: "{{ cname }}"
       image: "{{ docker_test_image_hello_world }}"
@@ -45,6 +32,12 @@
       name: "{{ vname }}"
       state: present
     register: volume
+  - name: Create anonymous volume
+    command: docker volume create
+    register: volume_anon
+
+  - name: List volumes
+    command: docker volume list
 
   # Prune objects
   - docker_prune:
@@ -63,7 +56,6 @@
     assert:
       that:
       # containers
-      - container_av.container.Id not in result.containers
       - container.container.Id in result.containers
       - "'containers_space_reclaimed' in result"
       # images
@@ -71,7 +63,7 @@
       # networks
       - network.network.Name in result.networks
       # volumes
-      - container_av.container.Mounts[0].Name in result.volumes
+      - volume_anon.stdout in result.volumes
       - "'volumes_space_reclaimed' in result"
       # builder_cache
       - "'builder_cache_space_reclaimed' in result"

--- a/tests/integration/targets/docker_stack_info/tasks/test_stack_info.yml
+++ b/tests/integration/targets/docker_stack_info/tasks/test_stack_info.yml
@@ -69,7 +69,6 @@
       that:
         - 'output.results | type_debug == "list"'
         - 'output.results[0].Name == "test_stack"'
-        - 'output.results[0].Orchestrator == "Swarm"'
         - 'output.results[0].Services == "1"'
 
   always:


### PR DESCRIPTION
##### SUMMARY
Docker API version 1.42 introduces some breaking changes ([changelog](https://docs.docker.com/engine/release-notes/23.0/)):
 - pruning volumes no longer removes named unused volumes by default (needs explicit `all: true` filter)
 - kernel memory option for containers was completely removed
 - the orchestrator information was removed from docker stack info output

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
various
