### PR TITLE
docker-py fix: fix(store): warn on init instead of throw

### DIFF
--- a/changelogs/fragments/581-store-warn-instead-of-error.yml
+++ b/changelogs/fragments/581-store-warn-instead-of-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - modules and plugins communicating directly with the Docker daemon - fail when using a credential helper instead of when initializing it (https://github.com/ansible-collections/community.docker/pull/581).

--- a/plugins/module_utils/_api/api/client.py
+++ b/plugins/module_utils/_api/api/client.py
@@ -98,7 +98,8 @@ class APIClient(
                  timeout=DEFAULT_TIMEOUT_SECONDS, tls=False,
                  user_agent=DEFAULT_USER_AGENT, num_pools=None,
                  credstore_env=None, use_ssh_client=False,
-                 max_pool_size=DEFAULT_MAX_POOL_SIZE):
+                 max_pool_size=DEFAULT_MAX_POOL_SIZE,
+                 warn=None):
         super(APIClient, self).__init__()
 
         fail_on_missing_imports()
@@ -108,6 +109,7 @@ class APIClient(
                 'If using TLS, the base_url argument must be provided.'
             )
 
+        self._warn = warn
         self.base_url = base_url
         self.timeout = timeout
         self.headers['User-Agent'] = user_agent
@@ -123,7 +125,7 @@ class APIClient(
         self._proxy_configs = ProxyConfig.from_dict(proxies)
 
         self._auth_configs = auth.load_config(
-            config_dict=self._general_configs, credstore_env=credstore_env,
+            config_dict=self._general_configs, credstore_env=credstore_env, warn=self._warn,
         )
         self.credstore_env = credstore_env
 
@@ -500,7 +502,7 @@ class APIClient(
             None
         """
         self._auth_configs = auth.load_config(
-            dockercfg_path, credstore_env=self.credstore_env
+            dockercfg_path, credstore_env=self.credstore_env, warn=self._warn,
         )
 
     def _set_auth_headers(self, headers):
@@ -511,7 +513,7 @@ class APIClient(
         if not self._auth_configs or self._auth_configs.is_empty:
             log.debug("No auth config in memory - loading from filesystem")
             self._auth_configs = auth.load_config(
-                credstore_env=self.credstore_env
+                credstore_env=self.credstore_env, warn=self._warn,
             )
 
         # Send the full auth configuration (if any exists), since the build

--- a/plugins/module_utils/_api/api/daemon.py
+++ b/plugins/module_utils/_api/api/daemon.py
@@ -140,11 +140,11 @@ class DaemonApiMixin(object):
         # if so load that config.
         if dockercfg_path and os.path.exists(dockercfg_path):
             self._auth_configs = auth.load_config(
-                dockercfg_path, credstore_env=self.credstore_env
+                dockercfg_path, credstore_env=self.credstore_env, warn=self._warn,
             )
         elif not self._auth_configs or self._auth_configs.is_empty:
             self._auth_configs = auth.load_config(
-                credstore_env=self.credstore_env
+                credstore_env=self.credstore_env, warn=self._warn,
             )
 
         authcfg = self._auth_configs.resolve_authconfig(registry)

--- a/plugins/module_utils/_api/credentials/store.py
+++ b/plugins/module_utils/_api/credentials/store.py
@@ -23,7 +23,7 @@ from .utils import find_executable
 
 
 class Store(object):
-    def __init__(self, program, environment=None):
+    def __init__(self, program, environment=None, warn=None):
         """ Create a store object that acts as an interface to
             perform the basic operations for storing, retrieving
             and erasing credentials using `program`.
@@ -32,11 +32,11 @@ class Store(object):
         self.exe = find_executable(self.program)
         self.environment = environment
         if self.exe is None:
-            raise errors.InitializationError(
-                '{0} not installed or not available in PATH'.format(
-                    self.program
-                )
-            )
+            msg = '{0} not installed or not available in PATH'.format(self.program)
+            if warn is not None:
+                warn(msg)
+            else:
+                raise errors.InitializationError(msg)
 
     def get(self, server):
         """ Retrieve credentials for `server`. If no credentials are found,
@@ -84,6 +84,10 @@ class Store(object):
         return json.loads(data.decode('utf-8'))
 
     def _execute(self, subcmd, data_input):
+        if self.exe is None:
+            raise errors.StoreError(
+                '{0} not installed or not available in PATH'.format(self.program)
+            )
         output = None
         env = create_environment_dict(self.environment)
         try:

--- a/plugins/module_utils/common_api.py
+++ b/plugins/module_utils/common_api.py
@@ -115,7 +115,7 @@ class AnsibleDockerClientBase(Client):
         self._connect_params = get_connect_params(self.auth_params, fail_function=self.fail)
 
         try:
-            super(AnsibleDockerClientBase, self).__init__(**self._connect_params, warn=self.warn)
+            super(AnsibleDockerClientBase, self).__init__(warn=self.warn, **self._connect_params)
             self.docker_api_version_str = self.api_version
         except MissingRequirementException as exc:
             self.fail(missing_required_lib(exc.requirement), exception=exc.import_exception)

--- a/plugins/modules/docker_image.py
+++ b/plugins/modules/docker_image.py
@@ -664,7 +664,7 @@ class ImageManager(DockerBaseClass):
                         push_repository, push_tag = parse_repository_tag(push_repository)
                     push_registry, dummy = resolve_repository_name(push_repository)
                     headers = {}
-                    header = get_config_header(self.client, push_registry)
+                    header = get_config_header(self.client, push_registry, warn=self.client.module.warn)
                     if header:
                         headers['X-Registry-Auth'] = header
                     response = self.client._post_json(

--- a/plugins/modules/docker_login.py
+++ b/plugins/modules/docker_login.py
@@ -276,11 +276,11 @@ class LoginManager(DockerBaseClass):
     def _login(self, reauth):
         if self.config_path and os.path.exists(self.config_path):
             self.client._auth_configs = auth.load_config(
-                self.config_path, credstore_env=self.client.credstore_env
+                self.config_path, credstore_env=self.client.credstore_env, warn=self.client.module.warn,
             )
         elif not self.client._auth_configs or self.client._auth_configs.is_empty:
             self.client._auth_configs = auth.load_config(
-                credstore_env=self.client.credstore_env
+                credstore_env=self.client.credstore_env, warn=self.client.module.warn,
             )
 
         authcfg = self.client._auth_configs.resolve_authconfig(self.registry_url)
@@ -392,15 +392,15 @@ class LoginManager(DockerBaseClass):
 
         credstore_env = self.client.credstore_env
 
-        config = auth.load_config(config_path=dockercfg_path)
+        config = auth.load_config(config_path=dockercfg_path, warn=self.client.module.warn)
 
-        store_name = auth.get_credential_store(config, registry)
+        store_name = auth.get_credential_store(config, registry, warn=self.client.module.warn)
 
         # Make sure that there is a credential helper before trying to instantiate a
         # Store object.
         if store_name:
             self.log("Found credential store %s" % store_name)
-            return Store(store_name, environment=credstore_env)
+            return Store(store_name, environment=credstore_env, warn=self.client.module.warn)
 
         return DockerFileStore(dockercfg_path)
 

--- a/plugins/modules/docker_plugin.py
+++ b/plugins/modules/docker_plugin.py
@@ -237,7 +237,7 @@ class DockerPluginManager(object):
                     # Get privileges
                     headers = {}
                     registry, repo_name = auth.resolve_repository_name(self.parameters.plugin_name)
-                    header = auth.get_config_header(self.client, registry)
+                    header = auth.get_config_header(self.client, registry, warn=self.client.module.warn)
                     if header:
                         headers['X-Registry-Auth'] = header
                     privileges = self.client.get_json('/plugins/privileges', params={'remote': self.parameters.plugin_name}, headers=headers)

--- a/plugins/plugin_utils/common_api.py
+++ b/plugins/plugin_utils/common_api.py
@@ -30,6 +30,9 @@ class AnsibleDockerClient(AnsibleDockerClientBase):
             msg += '\nContext:\n' + '\n'.join('  {0} = {1!r}'.format(k, v) for (k, v) in kwargs.items())
         raise AnsibleConnectionFailure(msg)
 
+    def warn(self, msg):
+        self.display.warning(msg)
+
     def deprecate(self, msg, version=None, date=None, collection_name=None):
         self.display.deprecated(msg, version=version, date=date, collection_name=collection_name)
 


### PR DESCRIPTION
##### SUMMARY
Cherry-picked https://github.com/docker/docker-py/pull/3080. 

Using the proper ansible-core mechanisms for warnings instead of `import warnings` resulted in a lot of extra code.

Ref: #435

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vendored Docker SDK for Python
