### PR TITLE
docker_swarm: document docker_node module for manager removal

### DIFF
--- a/plugins/modules/docker_swarm.py
+++ b/plugins/modules/docker_swarm.py
@@ -80,7 +80,8 @@ options:
       - Set to C(join), to join an existing cluster.
       - Set to C(absent), to leave an existing cluster.
       - Set to C(remove), to remove an absent node from the cluster.
-        Note that removing requires Docker SDK for Python >= 2.4.0. Managers need to be demoted with the module M(community.docker.docker_node) before removal.
+      - M(community.docker.docker_node) can be used to demote a manager before removal.
+      Note that removing requires Docker SDK for Python >= 2.4.0.
     type: str
     default: present
     choices:

--- a/plugins/modules/docker_swarm.py
+++ b/plugins/modules/docker_swarm.py
@@ -80,8 +80,8 @@ options:
       - Set to C(join), to join an existing cluster.
       - Set to C(absent), to leave an existing cluster.
       - Set to C(remove), to remove an absent node from the cluster.
+        Note that removing requires Docker SDK for Python >= 2.4.0.
       - M(community.docker.docker_node) can be used to demote a manager before removal.
-      Note that removing requires Docker SDK for Python >= 2.4.0.
     type: str
     default: present
     choices:

--- a/plugins/modules/docker_swarm.py
+++ b/plugins/modules/docker_swarm.py
@@ -80,7 +80,7 @@ options:
       - Set to C(join), to join an existing cluster.
       - Set to C(absent), to leave an existing cluster.
       - Set to C(remove), to remove an absent node from the cluster.
-        Note that removing requires Docker SDK for Python >= 2.4.0.
+        Note that removing requires Docker SDK for Python >= 2.4.0. Managers need to be demoted with the module M(community.docker.docker_node) before removal.
     type: str
     default: present
     choices:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #601.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Simple PR to add 1 bullet point that notes that the module `docker_node` can be used
to demote a manager before a swarm manager node removal.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
