### PR TITLE
Make sure socket_handler modue utils works when Docker SDK for Python is not installed

### DIFF
--- a/changelogs/fragments/620-bugfixes.yml
+++ b/changelogs/fragments/620-bugfixes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "socket_handler module utils - make sure this fully works when Docker SDK for Python is not available (https://github.com/ansible-collections/community.docker/pull/620)."

--- a/plugins/module_utils/socket_handler.py
+++ b/plugins/module_utils/socket_handler.py
@@ -9,15 +9,11 @@ __metaclass__ = type
 import os
 import os.path
 import socket as pysocket
+import struct
 
 from ansible.module_utils.six import PY2
 
-try:
-    from docker.utils import socket as docker_socket
-    import struct
-except Exception:
-    # missing Docker SDK for Python handled in ansible_collections.community.docker.plugins.module_utils.common
-    pass
+from ansible_collections.community.docker.plugins.module_utils._api.utils import socket as docker_socket
 
 from ansible_collections.community.docker.plugins.module_utils.socket_helper import (
     make_unblocking,


### PR DESCRIPTION
##### SUMMARY
It only needs docker.utils.socket for two constants, which we have in the vendored code as well. So use that instead.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/socket_handler.py
