### PR TITLE
Move ansible-core 2.12 to EOL CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -99,17 +99,6 @@ stages:
               test: '2.13/sanity/1'
             - name: Units
               test: '2.13/units/1'
-  - stage: Ansible_2_12
-    displayName: Sanity & Units 2.12
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: '2.12/sanity/1'
-            - name: Units
-              test: '2.12/units/1'
 
 ### Docker
   - stage: Docker_devel
@@ -175,23 +164,6 @@ stages:
               test: opensuse15py2
             - name: Alpine 3
               test: alpine3
-          groups:
-            - 4
-            - 5
-  - stage: Docker_2_12
-    displayName: Docker 2.12
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.12/linux/{0}
-          targets:
-            - name: Fedora 33
-              test: fedora33
-            - name: Fedora 34
-              test: fedora34
-            - name: Ubuntu 18.04
-              test: ubuntu1804
           groups:
             - 4
             - 5
@@ -282,22 +254,6 @@ stages:
             - 3
             - 4
             - 5
-  - stage: Remote_2_12
-    displayName: Remote 2.12
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.12/{0}
-          targets:
-            - name: RHEL 8.4
-              test: rhel/8.4
-          groups:
-            - 1
-            - 2
-            - 3
-            - 4
-            - 5
 
   ## Finally
 
@@ -308,17 +264,14 @@ stages:
       - Ansible_2_15
       - Ansible_2_14
       - Ansible_2_13
-      - Ansible_2_12
       - Remote_devel
       - Remote_2_15
       - Remote_2_14
       - Remote_2_13
-      - Remote_2_12
       - Docker_devel
       - Docker_2_15
       - Docker_2_14
       - Docker_2_13
-      - Docker_2_12
       - Docker_community_devel
     jobs:
       - template: templates/coverage.yml

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Perform sanity testing
         uses: felixfontein/ansible-test-gh-action@main
         with:
-          ansible-core-github-repository-slug: felixfontein/ansible
+          ansible-core-github-repository-slug: ${{ contains(fromJson('["2.10", "2.11"]'), matrix.ansible) && 'felixfontein/ansible' || 'ansible/ansible' }}
           ansible-core-version: stable-${{ matrix.ansible }}
           coverage: ${{ github.event_name == 'schedule' && 'always' || 'never' }}
           pull-request-change-detection: 'true'
@@ -73,7 +73,7 @@ jobs:
           Ansible version ${{ matrix.ansible }}
         uses: felixfontein/ansible-test-gh-action@main
         with:
-          ansible-core-github-repository-slug: felixfontein/ansible
+          ansible-core-github-repository-slug: ${{ contains(fromJson('["2.10", "2.11"]'), matrix.ansible) && 'felixfontein/ansible' || 'ansible/ansible' }}
           ansible-core-version: stable-${{ matrix.ansible }}
           coverage: ${{ github.event_name == 'schedule' && 'always' || 'never' }}
           pull-request-change-detection: 'true'
@@ -134,7 +134,7 @@ jobs:
           under Python ${{ matrix.python }}
         uses: felixfontein/ansible-test-gh-action@main
         with:
-          ansible-core-github-repository-slug: felixfontein/ansible
+          ansible-core-github-repository-slug: ${{ contains(fromJson('["2.10", "2.11"]'), matrix.ansible) && 'felixfontein/ansible' || 'ansible/ansible' }}
           ansible-core-version: stable-${{ matrix.ansible }}
           coverage: ${{ github.event_name == 'schedule' && 'always' || 'never' }}
           docker-image: ${{ matrix.docker }}

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -30,6 +30,7 @@ jobs:
       matrix:
         ansible:
           - '2.11'
+          - '2.12'
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
     # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
     # image for these stable branches. The list of branches where this is necessary will
@@ -66,6 +67,7 @@ jobs:
       matrix:
         ansible:
           - '2.11'
+          - '2.12'
 
     steps:
       - name: >-
@@ -124,6 +126,31 @@ jobs:
             extra-constraints: urllib3 < 2.0.0
           - ansible: '2.11'
             docker: alpine3
+            python: ''
+            target: azp/5/
+          # 2.12
+          - ansible: '2.12'
+            docker: fedora33
+            python: ''
+            target: azp/4/
+          - ansible: '2.12'
+            docker: fedora33
+            python: ''
+            target: azp/5/
+          - ansible: '2.12'
+            docker: fedora34
+            python: ''
+            target: azp/4/
+          - ansible: '2.12'
+            docker: fedora34
+            python: ''
+            target: azp/5/
+          - ansible: '2.12'
+            docker: ubuntu1804
+            python: ''
+            target: azp/4/
+          - ansible: '2.12'
+            docker: ubuntu1804
             python: ''
             target: azp/5/
 


### PR DESCRIPTION
##### SUMMARY
ansible-core 2.12 is EOL since the release of ansible-core 2.15.0.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
