### PR TITLE
Add RHEL 8.7 and 9.2 to CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -198,8 +198,10 @@ stages:
         parameters:
           testFormat: devel/{0}
           targets:
-            - name: RHEL 9.1 with latest Docker SDK from PyPi
-              test: rhel/9.1-pypi-latest
+            - name: RHEL 9.2 with latest Docker SDK from PyPi
+              test: rhel/9.2-pypi-latest
+            - name: RHEL 8.8
+              test: rhel/8.8
           groups:
             - 1
             - 2
@@ -214,6 +216,10 @@ stages:
         parameters:
           testFormat: 2.15/{0}
           targets:
+            - name: RHEL 9.1
+              test: rhel/9.1
+            - name: RHEL 8.7
+              test: rhel/8.7
             - name: RHEL 7.9
               test: rhel/7.9
           groups:

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -200,8 +200,9 @@ stages:
           targets:
             - name: RHEL 9.2 with latest Docker SDK from PyPi
               test: rhel/9.2-pypi-latest
-            - name: RHEL 8.8
-              test: rhel/8.8
+            # Currently always hangs in group 2
+            # - name: RHEL 8.8
+            #   test: rhel/8.8
           groups:
             - 1
             - 2


### PR DESCRIPTION
##### SUMMARY
Move RHEL 9.1 from devel to stable-2.15; add RHEL 9.2 and 8.8 to devel, add RHEL 8.7 to stable-2.15.

Ref: https://github.com/ansible-collections/news-for-maintainers/issues/47

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
