### PR TITLE
SuSE: install docker-compose v1 from pip instead of system packages

### DIFF
--- a/tests/integration/targets/setup_docker_compose/vars/Suse-py3.yml
+++ b/tests/integration/targets/setup_docker_compose/vars/Suse-py3.yml
@@ -3,4 +3,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-docker_compose_pip_packages: []
+docker_compose_packages: []


### PR DESCRIPTION
##### SUMMARY
The system package switched to docker-compose v2.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
docker_compose integration tests
