### PR TITLE
[stable-2] SuSE: install docker-compose v1 from pip instead of system packages

### DIFF
--- a/tests/integration/targets/setup_docker_compose/vars/Suse-py3.yml
+++ b/tests/integration/targets/setup_docker_compose/vars/Suse-py3.yml
@@ -1,2 +1,2 @@
 ---
-docker_compose_pip_packages: []
+docker_compose_packages: []


### PR DESCRIPTION
##### SUMMARY
Backport of #650 to stable-2.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
docker_compose integration tests
