### PR TITLE
CI: remove no longer needed ignore

### DIFF
--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,2 +1,1 @@
-.azure-pipelines/scripts/publish-codecov.py replace-urlopen
 plugins/modules/docker_container_copy_into.py validate-modules:undocumented-parameter # _max_file_size_for_diff is used by the action plugin


### PR DESCRIPTION
##### SUMMARY
Nightly CI fails because ansible-core devel's ansible-test no longer requires a `replace-urlopen` ignore for `.azure-pipelines/scripts/publish-codecov.py`.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
sanity test ignores
