### PR TITLE
docker_compose v1 tests: force PyYAML==5.3.1 on Arch Linux

### DIFF
--- a/tests/integration/targets/setup_docker_compose/vars/Archlinux.yml
+++ b/tests/integration/targets/setup_docker_compose/vars/Archlinux.yml
@@ -1,0 +1,9 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+docker_compose_pip_packages:
+  - docker-compose
+  # Force PyYAML to 5.3.1
+  - PyYAML==5.3.1


### PR DESCRIPTION
##### SUMMARY
Nightly CI fails due to a newer CPython version. Since docker-compose v1 is no longer updated, we have to either skip tests completely or pin to PyYAML 5.3.1.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
docker_compose tests
