### PR TITLE
Make unit tests work with Python 3.12

### DIFF
--- a/tests/unit/plugins/connection/test_docker.py
+++ b/tests/unit/plugins/connection/test_docker.py
@@ -13,6 +13,7 @@ from ansible_collections.community.docker.tests.unit.compat import unittest
 from ansible.errors import AnsibleError
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader
+from ansible.module_utils.six import PY2
 
 
 class TestDockerConnectionClass(unittest.TestCase):
@@ -36,7 +37,8 @@ class TestDockerConnectionClass(unittest.TestCase):
     def test_docker_connection_module_too_old(self, mock_new_docker_verison, mock_old_docker_version):
         self.dc._version = None
         self.dc.remote_user = 'foo'
-        self.assertRaisesRegexp(AnsibleError, '^docker connection type requires docker 1.3 or higher$', self.dc._get_actual_user)
+        (self.assertRaisesRegexp if PY2 else self.assertRaisesRegex)(
+            AnsibleError, '^docker connection type requires docker 1.3 or higher$', self.dc._get_actual_user)
 
     @mock.patch('ansible_collections.community.docker.plugins.connection.docker.Connection._old_docker_version',
                 return_value=('false', 'garbage', '', 1))
@@ -54,4 +56,5 @@ class TestDockerConnectionClass(unittest.TestCase):
     def test_docker_connection_module_wrong_cmd(self, mock_new_docker_version, mock_old_docker_version):
         self.dc._version = None
         self.dc.remote_user = 'foo'
-        self.assertRaisesRegexp(AnsibleError, '^Docker version check (.*?) failed: ', self.dc._get_actual_user)
+        (self.assertRaisesRegexp if PY2 else self.assertRaisesRegex)(
+            AnsibleError, '^Docker version check (.*?) failed: ', self.dc._get_actual_user)

--- a/tests/unit/plugins/module_utils/_api/transport/test_ssladapter.py
+++ b/tests/unit/plugins/module_utils/_api/transport/test_ssladapter.py
@@ -20,14 +20,18 @@ if sys.version_info < (2, 7):
 
 from ansible_collections.community.docker.plugins.module_utils._api.transport import ssladapter
 
+HAS_MATCH_HOSTNAME = True
 try:
     from backports.ssl_match_hostname import (
         match_hostname, CertificateError
     )
 except ImportError:
-    from ssl import (
-        match_hostname, CertificateError
-    )
+    try:
+        from ssl import (
+            match_hostname, CertificateError
+        )
+    except ImportError:
+        HAS_MATCH_HOSTNAME = False
 
 try:
     from ssl import OP_NO_SSLv3, OP_NO_SSLv2, OP_NO_TLSv1
@@ -47,6 +51,7 @@ class SSLAdapterTest(unittest.TestCase):
         assert not ssl_context.options & OP_NO_TLSv1
 
 
+@pytest.mark.skipif(not HAS_MATCH_HOSTNAME, reason='match_hostname is not available')
 class MatchHostnameTest(unittest.TestCase):
     cert = {
         'issuer': (


### PR DESCRIPTION
##### SUMMARY
Right now they fail for two reasons:
1. `ssl` removed `match_hostname` - this is only really needed for Python 2.x in production, and then in the unit tests (for whatever reason).
2. The alias `assertRaisesRegexp` of `assertRaisesRegex` in `unittest` has been removed (https://docs.python.org/2/library/unittest.html#unittest.TestCase.assertRaisesRegex). Unfortunately for Python 2.x you still need the old name.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
unit tests
