### PR TITLE
Fix example of docker-compose module

### DIFF
--- a/plugins/modules/docker_compose.py
+++ b/plugins/modules/docker_compose.py
@@ -236,7 +236,7 @@ EXAMPLES = '''
       ansible.builtin.debug:
         var: output
 
-    - name: Verify that web and db services are running
+    - name: Verify that web and db services are not running
       ansible.builtin.assert:
         that:
           - "not output.services.web.flask_web_1.state.running"


### PR DESCRIPTION
##### SUMMARY
Fix example of docker-compose module.

The name of the task was _"Verify that web and db services are running"_ while the task itself checked the opposite.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docker-compose
