### PR TITLE
CI: ansible-core devel drops support for Python 2.7 and 3.6

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -109,12 +109,8 @@ stages:
         parameters:
           testFormat: devel/linux/{0}
           targets:
-            - name: CentOS 7
-              test: centos7
-            #- name: Fedora 38
-            #  test: fedora38
-            - name: openSUSE 15
-              test: opensuse15
+            - name: Fedora 38
+              test: fedora38
             - name: Ubuntu 20.04
               test: ubuntu2004
             - name: Ubuntu 22.04
@@ -132,8 +128,10 @@ stages:
         parameters:
           testFormat: 2.16/linux/{0}
           targets:
-            - name: Fedora 38
-              test: fedora38
+            - name: CentOS 7
+              test: centos7
+            - name: openSUSE 15
+              test: opensuse15
           groups:
             - 4
             - 5
@@ -181,10 +179,6 @@ stages:
               test: debian-bookworm/3.11
             - name: ArchLinux
               test: archlinux/3.11
-            - name: CentOS Stream 8 with Python 3.6
-              test: centos-stream8/3.6
-            - name: CentOS Stream 8 with Python 3.9
-              test: centos-stream8/3.9
           groups:
             - 4
             - 5

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -155,7 +155,7 @@ jobs:
             docker: ubuntu1804
             python: ''
             target: azp/5/
-          # 2.12
+          # 2.13
           - ansible: '2.13'
             docker: fedora35
             python: ''

--- a/tests/integration/targets/setup_docker_compose/vars/Alpine.yml
+++ b/tests/integration/targets/setup_docker_compose/vars/Alpine.yml
@@ -1,0 +1,10 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+docker_compose_packages:
+  - docker-compose
+  - py3-yaml
+docker_compose_pip_packages:
+  - docker-compose

--- a/tests/integration/targets/setup_docker_compose/vars/Alpine.yml
+++ b/tests/integration/targets/setup_docker_compose/vars/Alpine.yml
@@ -5,6 +5,7 @@
 
 docker_compose_packages:
   - docker-compose
-  - py3-yaml
 docker_compose_pip_packages:
   - docker-compose
+  # Force PyYAML to 5.3.1
+  - PyYAML==5.3.1


### PR DESCRIPTION
##### SUMMARY
Ref: https://github.com/ansible-collections/news-for-maintainers/issues/60

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
