### PR TITLE
Update `docker_stack_info` module documentation to clarify functionality

### DIFF
--- a/plugins/modules/docker_stack_info.py
+++ b/plugins/modules/docker_stack_info.py
@@ -13,20 +13,24 @@ DOCUMENTATION = '''
 ---
 module: docker_stack_info
 author: "Jose Angel Munoz (@imjoseangel)"
-short_description: Return information on a docker stack
+short_description: Return information on all docker stacks
 description:
   - Retrieve information on docker stacks using the C(docker stack) command
     on the target node (see examples).
 extends_documentation_fragment:
   - community.docker.attributes
   - community.docker.attributes.info_module
+seealso:
+  - module: community.docker.docker_stack_task_info
+    description: >- 
+      To retrieve detailed information about the services under a specific 
+      stack use the M(community.docker.docker_stack_task_info) module
 '''
 
 RETURN = '''
 results:
     description: |
-        List of dictionaries containing the list of stacks or tasks associated
-        to a stack name.
+        List of dictionaries containing the list of stacks on the target node
     sample:
         - {"name":"grafana","namespace":"default","orchestrator":"Kubernetes","services":"2"}
     returned: always

--- a/plugins/modules/docker_stack_info.py
+++ b/plugins/modules/docker_stack_info.py
@@ -22,9 +22,9 @@ extends_documentation_fragment:
   - community.docker.attributes.info_module
 seealso:
   - module: community.docker.docker_stack_task_info
-    description: >- 
-      To retrieve detailed information about the services under a specific 
-      stack use the M(community.docker.docker_stack_task_info) module
+    description: >-
+      To retrieve detailed information about the services under a specific
+      stack use the M(community.docker.docker_stack_task_info) module.
 '''
 
 RETURN = '''


### PR DESCRIPTION
##### SUMMARY
* Clarify that this module is used for accessing information on all stacks 
* Add link to docker_stack_task_info module for users looking for detailed info on a single stack

Fixes #690

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
`plugins/modules/docker_stack_info.py`

##### ADDITIONAL INFORMATION

