### PR TITLE
docker_swarm: do not pass data_path_addr for older Docker SDK for Python versions

### DIFF
--- a/changelogs/fragments/696-docker_swarm-data_addr_path.yml
+++ b/changelogs/fragments/696-docker_swarm-data_addr_path.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "docker_swarm - make init and join operations work again with Docker SDK for Python before 4.0.0
+     (https://github.com/ansible-collections/community.docker/issues/695, https://github.com/ansible-collections/community.docker/pull/696)."


### PR DESCRIPTION
##### SUMMARY
Fixes #695.

CC @Hursofid

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm
