### PR TITLE
[stable-2] docker_swarm: do not pass data_path_addr for older Docker SDK for Python versions

### DIFF
--- a/changelogs/fragments/696-docker_swarm-data_addr_path.yml
+++ b/changelogs/fragments/696-docker_swarm-data_addr_path.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "docker_swarm - make init and join operations work again with Docker SDK for Python before 4.0.0
+     (https://github.com/ansible-collections/community.docker/issues/695, https://github.com/ansible-collections/community.docker/pull/696)."

--- a/plugins/modules/docker_swarm.py
+++ b/plugins/modules/docker_swarm.py
@@ -185,6 +185,7 @@ options:
           like C(eth0).
       - Only used when swarm is initialised or joined. Because of this it is not
         considered for idempotency checking.
+      - Requires API version >= 1.30.
     type: str
     version_added: 2.5.0
 extends_documentation_fragment:
@@ -508,7 +509,6 @@ class SwarmManager(DockerBaseClass):
             init_arguments = {
                 'advertise_addr': self.parameters.advertise_addr,
                 'listen_addr': self.parameters.listen_addr,
-                'data_path_addr': self.parameters.data_path_addr,
                 'force_new_cluster': self.force,
                 'swarm_spec': self.parameters.spec,
             }
@@ -516,6 +516,8 @@ class SwarmManager(DockerBaseClass):
                 init_arguments['default_addr_pool'] = self.parameters.default_addr_pool
             if self.parameters.subnet_size is not None:
                 init_arguments['subnet_size'] = self.parameters.subnet_size
+            if self.parameters.data_path_addr is not None:
+                init_arguments['data_path_addr'] = self.parameters.data_path_addr
             try:
                 self.client.init_swarm(**init_arguments)
             except APIError as exc:
@@ -567,11 +569,16 @@ class SwarmManager(DockerBaseClass):
             self.results['actions'].append("This node is already part of a swarm.")
             return
         if not self.check_mode:
+            join_arguments = {
+                'remote_addrs': self.parameters.remote_addrs,
+                'join_token': self.parameters.join_token,
+                'listen_addr': self.parameters.listen_addr,
+                'advertise_addr': self.parameters.advertise_addr,
+            }
+            if self.parameters.data_path_addr is not None:
+                join_arguments['data_path_addr'] = self.parameters.data_path_addr
             try:
-                self.client.join_swarm(
-                    remote_addrs=self.parameters.remote_addrs, join_token=self.parameters.join_token,
-                    listen_addr=self.parameters.listen_addr, advertise_addr=self.parameters.advertise_addr,
-                    data_path_addr=self.parameters.data_path_addr)
+                self.client.join_swarm(**join_arguments)
             except APIError as exc:
                 self.client.fail("Can not join the Swarm Cluster: %s" % to_native(exc))
         self.results['actions'].append("New node is added to swarm cluster")


### PR DESCRIPTION
##### SUMMARY
Backport of #696 to stable-2.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm
