### PR TITLE
fix(community.docker.docker_volume): labels can be none

### DIFF
--- a/changelogs/fragments/702-docker-volume-label-none.yaml
+++ b/changelogs/fragments/702-docker-volume-label-none.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - docker_volume - fix crash caused by accessing an empty dictionary. The ``has_different_config()`` was raising an ``AttributeError`` because the self.existing_volume["Labels"] dictionary was None.
+  - docker_volume - fix crash caused by accessing an empty dictionary. The ``has_different_config()`` was raising an ``AttributeError`` because the ``self.existing_volume["Labels"]`` dictionary was ``None`` (https://github.com/ansible-collections/community.docker/pull/702).

--- a/changelogs/fragments/702-docker-volume-label-none.yaml
+++ b/changelogs/fragments/702-docker-volume-label-none.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - docker_volume - fix crash caused by accessing an empty dictionary. The ``has_different_config()`` was raising an ``AttributeError`` because the self.existing_volume["Labels"] dictionary was None.

--- a/plugins/modules/docker_volume.py
+++ b/plugins/modules/docker_volume.py
@@ -214,7 +214,7 @@ class DockerVolumeManager(object):
                                         parameter=value,
                                         active=self.existing_volume['Options'].get(key))
         if self.parameters.labels:
-            existing_labels = self.existing_volume.get('Labels', {})
+            existing_labels = self.existing_volume.get('Labels', {}) or {}
             for label in self.parameters.labels:
                 if existing_labels.get(label) != self.parameters.labels.get(label):
                     differences.add('labels.%s' % label,

--- a/plugins/modules/docker_volume.py
+++ b/plugins/modules/docker_volume.py
@@ -214,7 +214,7 @@ class DockerVolumeManager(object):
                                         parameter=value,
                                         active=self.existing_volume['Options'].get(key))
         if self.parameters.labels:
-            existing_labels = self.existing_volume.get('Labels', {}) or {}
+            existing_labels = self.existing_volume.get('Labels') or {}
             for label in self.parameters.labels:
                 if existing_labels.get(label) != self.parameters.labels.get(label):
                     differences.add('labels.%s' % label,


### PR DESCRIPTION
Catch case where volume labels can be _None_ (it`s the default when creating a volume).



##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

> community.docker.docker_volume

##### ADDITIONAL INFORMATION

```bash
(ansi-debug-py3.11) ~/test # docker volume create foo
foo
(ansi-debug-py3.11) ~/test # docker volume inspect foo
[
    {
        "CreatedAt": "2023-11-12T08:06:39Z",
        "Driver": "local",
        "Labels": null,
        "Mountpoint": "/var/lib/docker/volumes/foo/_data",
        "Name": "foo",
        "Options": null,
        "Scope": "local"
    }
]
(ansi-debug-py3.11) ~/test # ansible localhost -mcommunity.docker.docker_volume  -a'{"volume_name":"foo","recreate":"options-changed","state":"present","label
s":{"merry":"christmas"}}'
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'NoneType' object has no
 attribute 'get'
localhost | FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1699776709.2802129-75992-15114258512832
6/AnsiballZ_docker_volume.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1699776709.2802129-
75992-151142585128326/AnsiballZ_docker_volume.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAM
S)\n  File \"/root/.ansible/tmp/ansible-tmp-1699776709.2802129-75992-151142585128326/AnsiballZ_docker_volume.py\", line 47, in invoke_mod
ule\n    runpy.run_module(mod_name='ansible_collections.community.docker.plugins.modules.docker_volume', init_globals=dict(_module_fqn='a
nsible_collections.community.docker.plugins.modules.docker_volume', _modlib_path=modlib_path),\n  File \"<frozen runpy>\", line 226, in r
un_module\n  File \"<frozen runpy>\", line 98, in _run_module_code\n  File \"<frozen runpy>\", line 88, in _run_code\n  File \"/tmp/ansib
le_community.docker.docker_volume_payload_bppcq2tj/ansible_community.docker.docker_volume_payload.zip/ansible_collections/community/docke
r/plugins/modules/docker_volume.py\", line 348, in <module>\n  File \"/tmp/ansible_community.docker.docker_volume_payload_bppcq2tj/ansibl
e_community.docker.docker_volume_payload.zip/ansible_collections/community/docker/plugins/modules/docker_volume.py\", line 331, in main\n
  File \"/tmp/ansible_community.docker.docker_volume_payload_bppcq2tj/ansible_community.docker.docker_volume_payload.zip/ansible_collecti
ons/community/docker/plugins/modules/docker_volume.py\", line 168, in __init__\n  File \"/tmp/ansible_community.docker.docker_volume_payl
oad_bppcq2tj/ansible_community.docker.docker_volume_payload.zip/ansible_collections/community/docker/plugins/modules/docker_volume.py\", 
line 281, in present\n  File \"/tmp/ansible_community.docker.docker_volume_payload_bppcq2tj/ansible_community.docker.docker_volume_payloa
d.zip/ansible_collections/community/docker/plugins/modules/docker_volume.py\", line 232, in has_different_config\nAttributeError: 'NoneTy
pe' object has no attribute 'get'\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
```