### PR TITLE
CI: Add rhel/9.3 for devel, remove rhel/9.2

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -192,8 +192,8 @@ stages:
         parameters:
           testFormat: devel/{0}
           targets:
-            - name: RHEL 9.2 with latest Docker SDK from PyPi
-              test: rhel/9.2-pypi-latest
+            - name: RHEL 9.3 with latest Docker SDK from PyPi
+              test: rhel/9.3-pypi-latest
             # Currently always hangs in group 2
             # - name: RHEL 8.8
             #   test: rhel/8.8


### PR DESCRIPTION
##### SUMMARY
Ref: https://forum.ansible.com/t/ansible-test-added-rhel-9-3-and-deprecated-rhel-9-2/2336
Ref: https://github.com/ansible-collections/news-for-maintainers/issues/62

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
