### PR TITLE
CI: devel supports Fedora 39, and no longer Fedora 38

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -109,8 +109,8 @@ stages:
         parameters:
           testFormat: devel/linux/{0}
           targets:
-            - name: Fedora 38
-              test: fedora38
+            - name: Fedora 39
+              test: fedora39
             - name: Ubuntu 20.04
               test: ubuntu2004
             - name: Ubuntu 22.04
@@ -128,6 +128,8 @@ stages:
         parameters:
           testFormat: 2.16/linux/{0}
           targets:
+            - name: Fedora 38
+              test: fedora38
             - name: CentOS 7
               test: centos7
             - name: openSUSE 15


### PR DESCRIPTION
##### SUMMARY
Ref: https://github.com/ansible-collections/news-for-maintainers/issues/63

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
