### PR TITLE
Remove Fedora 36 from CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -160,8 +160,8 @@ stages:
         parameters:
           testFormat: 2.14/linux/{0}
           targets:
-            - name: Fedora 36
-              test: fedora36
+            - name: Alpine 3
+              test: alpine3
           groups:
             - 4
             - 5


### PR DESCRIPTION
##### SUMMARY
Seems like Fedora 36 is failing in CI (https://dev.azure.com/ansible/community.docker/_build/results?buildId=96631&view=results).

Remove it from the CI matrix and replace it with something else.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
