### PR TITLE
Docker SDK for Python 7+: make sure that ssl_version is not passed, and error out if it was explicitly set

### DIFF
--- a/changelogs/fragments/715-docker-7.yml
+++ b/changelogs/fragments/715-docker-7.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "modules and plugins using the Docker SDK for Python - remove ``ssl_version`` from the parameters passed to Docker SDK for Python 7.0.0+. Explicitly fail with a nicer error message if it was explicitly set in this case (https://github.com/ansible-collections/community.docker/pull/715)."

--- a/plugins/doc_fragments/docker.py
+++ b/plugins/doc_fragments/docker.py
@@ -72,6 +72,8 @@ options:
             - Provide a valid SSL version number. Default value determined by L(SSL Python module, https://docs.python.org/3/library/ssl.html).
             - If the value is not specified in the task, the value of environment variable E(DOCKER_SSL_VERSION) will be
               used instead.
+            - B(Note:) this option is no longer supported for Docker SDK for Python 7.0.0+. Specifying it with Docker SDK for
+              Python 7.0.0 or newer will lead to an error.
         type: str
     tls:
         description:

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -122,6 +122,18 @@ if not HAS_DOCKER_PY:
 
 
 def _get_tls_config(fail_function, **kwargs):
+    if 'ssl_version' in kwargs and LooseVersion(docker_version) >= LooseVersion('7.0.0b1'):
+        ssl_version = kwargs.pop('ssl_version')
+        if ssl_version is not None:
+            fail_function(
+                "ssl_version is not compatible with Docker SDK for Python 7.0.0+. You are using"
+                " Docker SDK for Python {docker_py_version}. The ssl_version option (value: {ssl_version})"
+                " has either been set directly or with the environment variable DOCKER_SSL_VERSION."
+                " Make sure it is not set, or switch to an older version of Docker SDK for Python.".format(
+                    docker_py_version=docker_version,
+                    ssl_version=ssl_version,
+                )
+            )
     try:
         tls_config = TLSConfig(**kwargs)
         return tls_config

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -135,7 +135,7 @@ def _get_tls_config(fail_function, **kwargs):
                 )
             )
     # Filter out all None parameters
-    kwargs = {k: v for k, v in kwargs.items() if v is not None}
+    kwargs = dict((k, v) for k, v in kwargs.items() if v is not None)
     try:
         tls_config = TLSConfig(**kwargs)
         return tls_config

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -134,6 +134,8 @@ def _get_tls_config(fail_function, **kwargs):
                     ssl_version=ssl_version,
                 )
             )
+    # Filter out all None parameters
+    kwargs = {k: v for k, v in kwargs.items() if v is not None}
     try:
         tls_config = TLSConfig(**kwargs)
         return tls_config


### PR DESCRIPTION
##### SUMMARY
Also updates the documentation to warn against its usage.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
common module utils
