### PR TITLE
Docker SDK for Python 7+: make sure that tls_hostname is not passed, and error out if it was explicitly set

### DIFF
--- a/changelogs/fragments/721-docker-7.yml
+++ b/changelogs/fragments/721-docker-7.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "modules and plugins using the Docker SDK for Python - remove ``tls_hostname`` from the parameters passed to Docker SDK for Python 7.0.0+. Explicitly fail with a nicer error message if it was explicitly set in this case (https://github.com/ansible-collections/community.docker/pull/721)."

--- a/plugins/doc_fragments/docker.py
+++ b/plugins/doc_fragments/docker.py
@@ -29,6 +29,8 @@ options:
             - If the value is not specified in the task, the value of environment variable E(DOCKER_TLS_HOSTNAME) will
               be used instead. If the environment variable is not set, the default value will be used.
             - Note that this option had a default value V(localhost) in older versions. It was removed in community.docker 3.0.0.
+            - B(Note:) this option is no longer supported for Docker SDK for Python 7.0.0+. Specifying it with Docker SDK for
+              Python 7.0.0 or newer will lead to an error.
         type: str
     api_version:
         description:

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -134,6 +134,18 @@ def _get_tls_config(fail_function, **kwargs):
                     ssl_version=ssl_version,
                 )
             )
+    if 'assert_hostname' in kwargs and LooseVersion(docker_version) >= LooseVersion('7.0.0b1'):
+        assert_hostname = kwargs.pop('assert_hostname')
+        if assert_hostname is not None:
+            fail_function(
+                "tls_hostname is not compatible with Docker SDK for Python 7.0.0+. You are using"
+                " Docker SDK for Python {docker_py_version}. The tls_hostname option (value: {tls_hostname})"
+                " has either been set directly or with the environment variable DOCKER_TLS_HOSTNAME."
+                " Make sure it is not set, or switch to an older version of Docker SDK for Python.".format(
+                    docker_py_version=docker_version,
+                    tls_hostname=assert_hostname,
+                )
+            )
     # Filter out all None parameters
     kwargs = dict((k, v) for k, v in kwargs.items() if v is not None)
     try:


### PR DESCRIPTION
##### SUMMARY
It was removed in https://github.com/docker/docker-py/pull/3185 as well, next to `ssl_version`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
common module utils
