### PR TITLE
Clean up vendored Docker SDK for Python TLS handling code

### DIFF
--- a/changelogs/fragments/722-tls.yml
+++ b/changelogs/fragments/722-tls.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "vendored Docker SDK for Python - avoid passing on ``ssl_version`` and ``tls_hostname`` if they were not provided by the user. Remove dead code. (https://github.com/ansible-collections/community.docker/pull/722)."

--- a/plugins/module_utils/_api/tls.py
+++ b/plugins/module_utils/_api/tls.py
@@ -39,8 +39,7 @@ class TLSConfig(object):
     ssl_version = None
 
     def __init__(self, client_cert=None, ca_cert=None, verify=None,
-                 ssl_version=None, assert_hostname=None,
-                 assert_fingerprint=None):
+                 ssl_version=None, assert_hostname=None):
         # Argument compatibility/mapping with
         # https://docs.docker.com/engine/articles/https/
         # This diverges from the Docker CLI in that users can specify 'tls'
@@ -48,7 +47,6 @@ class TLSConfig(object):
         # leaving verify=False
 
         self.assert_hostname = assert_hostname
-        self.assert_fingerprint = assert_fingerprint
 
         # If the user provides an SSL version, we should use their preference
         if ssl_version:
@@ -118,5 +116,4 @@ class TLSConfig(object):
         client.mount('https://', SSLHTTPAdapter(
             ssl_version=self.ssl_version,
             assert_hostname=self.assert_hostname,
-            assert_fingerprint=self.assert_fingerprint,
         ))

--- a/plugins/module_utils/_api/transport/ssladapter.py
+++ b/plugins/module_utils/_api/transport/ssladapter.py
@@ -27,15 +27,11 @@ PoolManager = urllib3.poolmanager.PoolManager
 class SSLHTTPAdapter(BaseHTTPAdapter):
     '''An HTTPS Transport Adapter that uses an arbitrary SSL version.'''
 
-    __attrs__ = HTTPAdapter.__attrs__ + ['assert_fingerprint',
-                                         'assert_hostname',
-                                         'ssl_version']
+    __attrs__ = HTTPAdapter.__attrs__ + ['assert_hostname', 'ssl_version']
 
-    def __init__(self, ssl_version=None, assert_hostname=None,
-                 assert_fingerprint=None, **kwargs):
+    def __init__(self, ssl_version=None, assert_hostname=None, **kwargs):
         self.ssl_version = ssl_version
         self.assert_hostname = assert_hostname
-        self.assert_fingerprint = assert_fingerprint
         super(SSLHTTPAdapter, self).__init__(**kwargs)
 
     def init_poolmanager(self, connections, maxsize, block=False):
@@ -43,9 +39,9 @@ class SSLHTTPAdapter(BaseHTTPAdapter):
             'num_pools': connections,
             'maxsize': maxsize,
             'block': block,
-            'assert_hostname': self.assert_hostname,
-            'assert_fingerprint': self.assert_fingerprint,
         }
+        if self.assert_hostname is not None:
+            kwargs['assert_hostname'] = self.assert_hostname
         if self.ssl_version and self.can_override_ssl_version():
             kwargs['ssl_version'] = self.ssl_version
 
@@ -60,7 +56,7 @@ class SSLHTTPAdapter(BaseHTTPAdapter):
         But we still need to take care of when there is a proxy poolmanager
         """
         conn = super(SSLHTTPAdapter, self).get_connection(*args, **kwargs)
-        if conn.assert_hostname != self.assert_hostname:
+        if self.assert_hostname is not None and conn.assert_hostname != self.assert_hostname:
             conn.assert_hostname = self.assert_hostname
         return conn
 


### PR DESCRIPTION
##### SUMMARY
Make it possible to avoid potential compatibility problems in the future when some attributes are removed. We only set them actively set by the user. This gives users the workaround to simply no longer set values if they cause problems in the future.

##### ISSUE TYPE
- Bugfix Pull Request
- Refactoring Pull Request

##### COMPONENT NAME
vendored Docker SDK for Python
