### PR TITLE
[stable-2] Docker SDK for Python 7+: make sure that tls_hostname is not passed, and error out if it was explicitly set

### DIFF
--- a/changelogs/fragments/721-docker-7.yml
+++ b/changelogs/fragments/721-docker-7.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "modules and plugins using the Docker SDK for Python - remove ``tls_hostname`` from the parameters passed to Docker SDK for Python 7.0.0+. Explicitly fail with a nicer error message if it was explicitly set in this case (https://github.com/ansible-collections/community.docker/pull/721)."

--- a/plugins/doc_fragments/docker.py
+++ b/plugins/doc_fragments/docker.py
@@ -31,7 +31,7 @@ options:
               2.0.0 to be a value computed from I(docker_host). Explicitly specify C(localhost) to make sure this value
               will still be used, and to disable the deprecation message which will be shown otherwise.
             - B(Note:) this option is no longer supported for Docker SDK for Python 7.0.0+. Specifying it with Docker SDK for
-              Python 7.0.0 or newer will lead to an error.
+              Python 7.0.0 or newer will lead to an error. The value C(localhost) will explicitly be ignored.
         type: str
     api_version:
         description:

--- a/plugins/doc_fragments/docker.py
+++ b/plugins/doc_fragments/docker.py
@@ -30,6 +30,8 @@ options:
             - The current default value is C(localhost). This default is deprecated and will change in community.docker
               2.0.0 to be a value computed from I(docker_host). Explicitly specify C(localhost) to make sure this value
               will still be used, and to disable the deprecation message which will be shown otherwise.
+            - B(Note:) this option is no longer supported for Docker SDK for Python 7.0.0+. Specifying it with Docker SDK for
+              Python 7.0.0 or newer will lead to an error.
         type: str
     api_version:
         description:

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -133,6 +133,18 @@ def _get_tls_config(fail_function, **kwargs):
                     ssl_version=ssl_version,
                 )
             )
+    if 'assert_hostname' in kwargs and LooseVersion(docker_version) >= LooseVersion('7.0.0b1'):
+        assert_hostname = kwargs.pop('assert_hostname')
+        if assert_hostname is not None:
+            fail_function(
+                "tls_hostname is not compatible with Docker SDK for Python 7.0.0+. You are using"
+                " Docker SDK for Python {docker_py_version}. The tls_hostname option (value: {tls_hostname})"
+                " has either been set directly or with the environment variable DOCKER_TLS_HOSTNAME."
+                " Make sure it is not set, or switch to an older version of Docker SDK for Python.".format(
+                    docker_py_version=docker_version,
+                    tls_hostname=assert_hostname,
+                )
+            )
     # Filter out all None parameters
     kwargs = dict((k, v) for k, v in kwargs.items() if v is not None)
     try:

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -135,7 +135,7 @@ def _get_tls_config(fail_function, **kwargs):
             )
     if 'assert_hostname' in kwargs and LooseVersion(docker_version) >= LooseVersion('7.0.0b1'):
         assert_hostname = kwargs.pop('assert_hostname')
-        if assert_hostname is not None:
+        if assert_hostname is not None and assert_hostname != 'localhost':
             fail_function(
                 "tls_hostname is not compatible with Docker SDK for Python 7.0.0+. You are using"
                 " Docker SDK for Python {docker_py_version}. The tls_hostname option (value: {tls_hostname})"


### PR DESCRIPTION
##### SUMMARY
Manual backport of #722 to stable-2.

I added a commit which does not fail if the value happens to be `localhost`. This is necessary since in community.docker 2.x.y `tls_hostname` has `localhost` as the (deprecated) default.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
common module utils
