### PR TITLE
docker_image: support labels and shm_size for image build; allow to specify (swap) memory limits in other units than bytes

### DIFF
--- a/changelogs/fragments/727-docker_image-build.yml
+++ b/changelogs/fragments/727-docker_image-build.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "docker_image - allow to specify labels and ``/dev/shm`` size when building images (https://github.com/ansible-collections/community.docker/issues/726, https://github.com/ansible-collections/community.docker/pull/727)."
+  - "docker_image - allow to specify memory size and swap memory size in other units than bytes (https://github.com/ansible-collections/community.docker/pull/727)."

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -156,7 +156,8 @@ options:
     type: float
   cpuset_cpus:
     description:
-      - CPUs in which to allow execution V(1,3) or V(1-3).
+      - CPUs in which to allow execution.
+      - For example V(1,3) or V(1-3).
     type: str
   cpuset_mems:
     description:

--- a/tests/integration/targets/docker_image/tasks/tests/basic.yml
+++ b/tests/integration/targets/docker_image/tasks/tests/basic.yml
@@ -117,7 +117,7 @@
   register: fail_3
   ignore_errors: true
 
-- name: buildargs
+- name: Build image ID (must fail)
   docker_image:
     source: build
     name: "{{ present_1.image.Id }}"

--- a/tests/integration/targets/docker_image/tasks/tests/options.yml
+++ b/tests/integration/targets/docker_image/tasks/tests/options.yml
@@ -76,7 +76,7 @@
     build:
       path: "{{ remote_tmp_dir }}/files"
       container_limits:
-        memory: 4000
+        memory: 4KB
       pull: false
     source: build
   ignore_errors: true
@@ -88,8 +88,8 @@
     build:
       path: "{{ remote_tmp_dir }}/files"
       container_limits:
-        memory: 7000000
-        memswap: 8000000
+        memory: 7MB
+        memswap: 8MB
       pull: false
     source: build
   register: container_limits_2
@@ -444,3 +444,61 @@
 - assert:
     that:
       - path_1 is changed
+
+####################################################################
+## build.shm_size ##################################################
+####################################################################
+
+- name: Build image with custom shm_size
+  docker_image:
+    name: "{{ iname }}"
+    build:
+      path: "{{ remote_tmp_dir }}/files"
+      dockerfile: "MyDockerfile"
+      pull: false
+      shm_size: 128MB
+    source: build
+  register: path_1
+
+- name: cleanup
+  docker_image:
+    name: "{{ iname }}"
+    state: absent
+    force_absent: true
+
+- assert:
+    that:
+      - path_1 is changed
+
+####################################################################
+## build.labels ####################################################
+####################################################################
+
+- name: Build image with labels
+  docker_image:
+    name: "{{ iname }}"
+    build:
+      path: "{{ remote_tmp_dir }}/files"
+      dockerfile: "MyDockerfile"
+      pull: false
+      labels:
+        FOO: BAR
+        this is a label: this is the label's value
+    source: build
+  register: labels_1
+
+- name: cleanup
+  docker_image:
+    name: "{{ iname }}"
+    state: absent
+    force_absent: true
+
+- name: Show image information
+  debug:
+    var: labels_1.image
+
+- assert:
+    that:
+      - labels_1 is changed
+      - labels_1.image.Config.Labels.FOO == 'BAR'
+      - labels_1.image.Config.Labels["this is a label"] == "this is the label's value"


### PR DESCRIPTION
##### SUMMARY
Fixes #726.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docker_image
