### PR TITLE
Fix Unix socket path

### DIFF
--- a/changelogs/fragments/host.yml
+++ b/changelogs/fragments/host.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Use ``unix:///var/run/docker.sock`` instead of the legacy ``unix://var/run/docker.sock`` as default for ``docker_host`` (https://github.com/ansible-collections/community.docker/pull/736)."

--- a/plugins/doc_fragments/docker.py
+++ b/plugins/doc_fragments/docker.py
@@ -21,7 +21,7 @@ options:
             - If the value is not specified in the task, the value of environment variable E(DOCKER_HOST) will be used
               instead. If the environment variable is not set, the default value will be used.
         type: str
-        default: unix://var/run/docker.sock
+        default: unix:///var/run/docker.sock
         aliases: [ docker_url ]
     tls_hostname:
         description:
@@ -198,7 +198,7 @@ options:
             - If the value is not specified in the task, the value of environment variable E(DOCKER_HOST) will be used
               instead. If the environment variable is not set, the default value will be used.
         type: str
-        default: unix://var/run/docker.sock
+        default: unix:///var/run/docker.sock
         aliases: [ docker_url ]
     tls_hostname:
         description:

--- a/plugins/inventory/docker_containers.py
+++ b/plugins/inventory/docker_containers.py
@@ -106,7 +106,7 @@ options:
 EXAMPLES = '''
 # Minimal example using local Docker daemon
 plugin: community.docker.docker_containers
-docker_host: unix://var/run/docker.sock
+docker_host: unix:///var/run/docker.sock
 
 # Minimal example using remote Docker daemon
 plugin: community.docker.docker_containers

--- a/plugins/inventory/docker_swarm.py
+++ b/plugins/inventory/docker_swarm.py
@@ -34,7 +34,7 @@ DOCUMENTATION = '''
         docker_host:
             description:
                 - Socket of a Docker swarm manager node (C(tcp), C(unix)).
-                - "Use V(unix://var/run/docker.sock) to connect via local socket."
+                - "Use V(unix:///var/run/docker.sock) to connect via local socket."
             type: str
             required: true
             aliases: [ docker_url ]
@@ -111,7 +111,7 @@ DOCUMENTATION = '''
 EXAMPLES = '''
 # Minimal example using local docker
 plugin: community.docker.docker_swarm
-docker_host: unix://var/run/docker.sock
+docker_host: unix:///var/run/docker.sock
 
 # Minimal example using remote docker
 plugin: community.docker.docker_swarm

--- a/plugins/module_utils/util.py
+++ b/plugins/module_utils/util.py
@@ -14,7 +14,7 @@ from ansible.module_utils.common.collections import is_sequence
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 
 
-DEFAULT_DOCKER_HOST = 'unix://var/run/docker.sock'
+DEFAULT_DOCKER_HOST = 'unix:///var/run/docker.sock'
 DEFAULT_TLS = False
 DEFAULT_TLS_VERIFY = False
 DEFAULT_TLS_HOSTNAME = 'localhost'  # deprecated


### PR DESCRIPTION
##### SUMMARY
`unix://var/run/docker.sock` was classically used in Docker SDK for Python, but is wrong and should be `unix:///var/run/docker.sock`. (The two-slash version doesn't work with the CLI for example.)

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
various
