### PR TITLE
Integration tests: avoid shadowing loop variables

### DIFF
--- a/tests/integration/targets/docker_compose/tasks/main.yml
+++ b/tests/integration/targets/docker_compose/tasks/main.yml
@@ -20,26 +20,28 @@
 
 # Run the tests
 - block:
-  - include_tasks: run-test.yml
-    with_fileglob:
-    - "tests/*.yml"
+    - include_tasks: run-test.yml
+      with_fileglob:
+        - "tests/*.yml"
+      loop_control:
+        loop_var: test_name
 
   always:
-  - name: "Make sure all containers are removed"
-    docker_container:
-      name: "{{ item }}"
-      state: absent
-      force_kill: true
-    with_items: "{{ cnames }}"
-    diff: false
-  - name: "Make sure all networks are removed"
-    docker_network:
-      name: "{{ item }}"
-      state: absent
-      force: true
-    with_items: "{{ dnetworks }}"
-    when: docker_py_version is version('1.10.0', '>=')
-    diff: false
+    - name: "Make sure all containers are removed"
+      docker_container:
+        name: "{{ item }}"
+        state: absent
+        force_kill: true
+      with_items: "{{ cnames }}"
+      diff: false
+    - name: "Make sure all networks are removed"
+      docker_network:
+        name: "{{ item }}"
+        state: absent
+        force: true
+      with_items: "{{ dnetworks }}"
+      when: docker_py_version is version('1.10.0', '>=')
+      diff: false
 
   when: has_docker_compose and docker_py_version is version('1.8.0', '>=') and docker_api_version is version('1.25', '>=')
 

--- a/tests/integration/targets/docker_compose/tasks/run-test.yml
+++ b/tests/integration/targets/docker_compose/tasks/run-test.yml
@@ -3,5 +3,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: "Loading tasks from {{ item }}"
-  include_tasks: "{{ item }}"
+- name: "Loading tasks from {{ test_name }}"
+  include_tasks: "{{ test_name }}"

--- a/tests/integration/targets/docker_container/tasks/main.yml
+++ b/tests/integration/targets/docker_container/tasks/main.yml
@@ -34,29 +34,31 @@
 
 # Run the tests
 - block:
-  - include_tasks: run-test.yml
-    with_fileglob:
-    - "tests/*.yml"
+    - include_tasks: run-test.yml
+      with_fileglob:
+        - "tests/*.yml"
+      loop_control:
+        loop_var: test_name
 
   always:
-  - name: "Make sure all containers are removed"
-    docker_container:
-      name: "{{ item }}"
-      state: absent
-      force_kill: true
-    with_items: "{{ cnames }}"
-    diff: false
-  - name: "Make sure all images are removed"
-    docker_image_remove:
-      name: "{{ item }}"
-    with_items: "{{ inames }}"
-  - name: "Make sure all networks are removed"
-    docker_network:
-      name: "{{ item }}"
-      state: absent
-      force: true
-    with_items: "{{ dnetworks }}"
-    diff: false
+    - name: "Make sure all containers are removed"
+      docker_container:
+        name: "{{ item }}"
+        state: absent
+        force_kill: true
+      with_items: "{{ cnames }}"
+      diff: false
+    - name: "Make sure all images are removed"
+      docker_image_remove:
+        name: "{{ item }}"
+      with_items: "{{ inames }}"
+    - name: "Make sure all networks are removed"
+      docker_network:
+        name: "{{ item }}"
+        state: absent
+        force: true
+      with_items: "{{ dnetworks }}"
+      diff: false
 
   when: docker_api_version is version('1.25', '>=')
 

--- a/tests/integration/targets/docker_container/tasks/run-test.yml
+++ b/tests/integration/targets/docker_container/tasks/run-test.yml
@@ -3,5 +3,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: "Loading tasks from {{ item }}"
-  include_tasks: "{{ item }}"
+- name: "Loading tasks from {{ test_name }}"
+  include_tasks: "{{ test_name }}"

--- a/tests/integration/targets/docker_container_copy_into/tasks/main.yml
+++ b/tests/integration/targets/docker_container_copy_into/tasks/main.yml
@@ -26,18 +26,20 @@
 
 # Run the tests
 - block:
-  - include_tasks: run-test.yml
-    with_fileglob:
-    - "tests/*.yml"
+    - include_tasks: run-test.yml
+      with_fileglob:
+        - "tests/*.yml"
+      loop_control:
+        loop_var: test_name
 
   always:
-  - name: "Make sure all containers are removed"
-    docker_container:
-      name: "{{ item }}"
-      state: absent
-      force_kill: true
-    with_items: "{{ cnames }}"
-    diff: false
+    - name: "Make sure all containers are removed"
+      docker_container:
+        name: "{{ item }}"
+        state: absent
+        force_kill: true
+      with_items: "{{ cnames }}"
+      diff: false
 
   when: docker_api_version is version('1.25', '>=')
 

--- a/tests/integration/targets/docker_container_copy_into/tasks/run-test.yml
+++ b/tests/integration/targets/docker_container_copy_into/tasks/run-test.yml
@@ -3,5 +3,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: "Loading tasks from {{ item }}"
-  include_tasks: "{{ item }}"
+- name: "Loading tasks from {{ test_name }}"
+  include_tasks: "{{ test_name }}"

--- a/tests/integration/targets/docker_image/tasks/run-test.yml
+++ b/tests/integration/targets/docker_image/tasks/run-test.yml
@@ -3,5 +3,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: "Loading tasks from {{ item }}"
-  include_tasks: "{{ item }}"
+- name: "Loading tasks from {{ test_name }}"
+  include_tasks: "{{ test_name }}"

--- a/tests/integration/targets/docker_image/tasks/test.yml
+++ b/tests/integration/targets/docker_image/tasks/test.yml
@@ -31,22 +31,24 @@
     - StagedDockerfile
 
 - block:
-  - include_tasks: run-test.yml
-    with_fileglob:
-    - "tests/*.yml"
+    - include_tasks: run-test.yml
+      with_fileglob:
+        - "tests/*.yml"
+      loop_control:
+        loop_var: test_name
 
   always:
-  - name: "Make sure all images are removed"
-    docker_image:
-      name: "{{ item }}"
-      state: absent
-    with_items: "{{ inames }}"
-  - name: "Make sure all containers are removed"
-    docker_container:
-      name: "{{ item }}"
-      state: absent
-      force_kill: true
-    with_items: "{{ cnames }}"
+    - name: "Make sure all images are removed"
+      docker_image:
+        name: "{{ item }}"
+        state: absent
+      with_items: "{{ inames }}"
+    - name: "Make sure all containers are removed"
+      docker_container:
+        name: "{{ item }}"
+        state: absent
+        force_kill: true
+      with_items: "{{ cnames }}"
 
   when: docker_api_version is version('1.25', '>=')
 

--- a/tests/integration/targets/docker_image_build/tasks/run-test.yml
+++ b/tests/integration/targets/docker_image_build/tasks/run-test.yml
@@ -3,5 +3,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: "Loading tasks from {{ item }}"
-  include_tasks: "{{ item }}"
+- name: "Loading tasks from {{ test_name }}"
+  include_tasks: "{{ test_name }}"

--- a/tests/integration/targets/docker_image_build/tasks/test.yml
+++ b/tests/integration/targets/docker_image_build/tasks/test.yml
@@ -34,22 +34,24 @@
     msg: "Has buildx plugin: {{ docker_has_buildx }}"
 
 - block:
-  - include_tasks: run-test.yml
-    with_fileglob:
-    - "tests/*.yml"
+    - include_tasks: run-test.yml
+      with_fileglob:
+        - "tests/*.yml"
+      loop_control:
+        loop_var: test_name
 
   always:
-  - name: "Make sure all images are removed"
-    docker_image:
-      name: "{{ item }}"
-      state: absent
-    with_items: "{{ inames }}"
-  - name: "Make sure all containers are removed"
-    docker_container:
-      name: "{{ item }}"
-      state: absent
-      force_kill: true
-    with_items: "{{ cnames }}"
+    - name: "Make sure all images are removed"
+      docker_image:
+        name: "{{ item }}"
+        state: absent
+      with_items: "{{ inames }}"
+    - name: "Make sure all containers are removed"
+      docker_container:
+        name: "{{ item }}"
+        state: absent
+        force_kill: true
+      with_items: "{{ cnames }}"
 
   when: docker_api_version is version('1.25', '>=') and docker_cli_version is version('19.03', '>=') and docker_has_buildx
 

--- a/tests/integration/targets/docker_image_load/tasks/run-test.yml
+++ b/tests/integration/targets/docker_image_load/tasks/run-test.yml
@@ -3,5 +3,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: "Loading tasks from {{ item }}"
-  include_tasks: "{{ item }}"
+- name: "Loading tasks from {{ test_name }}"
+  include_tasks: "{{ test_name }}"

--- a/tests/integration/targets/docker_image_load/tasks/test.yml
+++ b/tests/integration/targets/docker_image_load/tasks/test.yml
@@ -15,21 +15,23 @@
     msg: "Using name prefix {{ name_prefix }}"
 
 - block:
-  - include_tasks: run-test.yml
-    with_fileglob:
-    - "tests/*.yml"
+    - include_tasks: run-test.yml
+      with_fileglob:
+        - "tests/*.yml"
+      loop_control:
+        loop_var: test_name
 
   always:
-  - name: "Make sure all images are removed"
-    docker_image_remove:
-      name: "{{ item }}"
-    with_items: "{{ inames }}"
-  - name: "Make sure all containers are removed"
-    docker_container:
-      name: "{{ item }}"
-      state: absent
-      force_kill: true
-    with_items: "{{ cnames }}"
+    - name: "Make sure all images are removed"
+      docker_image_remove:
+        name: "{{ item }}"
+      with_items: "{{ inames }}"
+    - name: "Make sure all containers are removed"
+      docker_container:
+        name: "{{ item }}"
+        state: absent
+        force_kill: true
+      with_items: "{{ cnames }}"
 
   when: docker_api_version is version('1.25', '>=')
 

--- a/tests/integration/targets/docker_image_pull/tasks/run-test.yml
+++ b/tests/integration/targets/docker_image_pull/tasks/run-test.yml
@@ -3,5 +3,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: "Loading tasks from {{ item }}"
-  include_tasks: "{{ item }}"
+- name: "Loading tasks from {{ test_name }}"
+  include_tasks: "{{ test_name }}"

--- a/tests/integration/targets/docker_image_pull/tasks/test.yml
+++ b/tests/integration/targets/docker_image_pull/tasks/test.yml
@@ -15,21 +15,23 @@
     msg: "Using name prefix {{ name_prefix }}"
 
 - block:
-  - include_tasks: run-test.yml
-    with_fileglob:
-    - "tests/*.yml"
+    - include_tasks: run-test.yml
+      with_fileglob:
+        - "tests/*.yml"
+      loop_control:
+        loop_var: test_name
 
   always:
-  - name: "Make sure all images are removed"
-    docker_image_remove:
-      name: "{{ item }}"
-    with_items: "{{ inames }}"
-  - name: "Make sure all containers are removed"
-    docker_container:
-      name: "{{ item }}"
-      state: absent
-      force_kill: true
-    with_items: "{{ cnames }}"
+    - name: "Make sure all images are removed"
+      docker_image_remove:
+        name: "{{ item }}"
+      with_items: "{{ inames }}"
+    - name: "Make sure all containers are removed"
+      docker_container:
+        name: "{{ item }}"
+        state: absent
+        force_kill: true
+      with_items: "{{ cnames }}"
 
   when: docker_api_version is version('1.25', '>=')
 

--- a/tests/integration/targets/docker_image_push/tasks/run-test.yml
+++ b/tests/integration/targets/docker_image_push/tasks/run-test.yml
@@ -3,5 +3,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: "Loading tasks from {{ item }}"
-  include_tasks: "{{ item }}"
+- name: "Loading tasks from {{ test_name }}"
+  include_tasks: "{{ test_name }}"

--- a/tests/integration/targets/docker_image_push/tasks/test.yml
+++ b/tests/integration/targets/docker_image_push/tasks/test.yml
@@ -15,21 +15,23 @@
     msg: "Using name prefix {{ name_prefix }}"
 
 - block:
-  - include_tasks: run-test.yml
-    with_fileglob:
-    - "tests/*.yml"
+    - include_tasks: run-test.yml
+      with_fileglob:
+        - "tests/*.yml"
+      loop_control:
+        loop_var: test_name
 
   always:
-  - name: "Make sure all images are removed"
-    docker_image_remove:
-      name: "{{ item }}"
-    with_items: "{{ inames }}"
-  - name: "Make sure all containers are removed"
-    docker_container:
-      name: "{{ item }}"
-      state: absent
-      force_kill: true
-    with_items: "{{ cnames }}"
+    - name: "Make sure all images are removed"
+      docker_image_remove:
+        name: "{{ item }}"
+      with_items: "{{ inames }}"
+    - name: "Make sure all containers are removed"
+      docker_container:
+        name: "{{ item }}"
+        state: absent
+        force_kill: true
+      with_items: "{{ cnames }}"
 
   when: docker_api_version is version('1.25', '>=')
 

--- a/tests/integration/targets/docker_login/tasks/run-test.yml
+++ b/tests/integration/targets/docker_login/tasks/run-test.yml
@@ -3,5 +3,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: "Loading tasks from {{ item }}"
-  include_tasks: "{{ item }}"
+- name: "Loading tasks from {{ test_name }}"
+  include_tasks: "{{ test_name }}"

--- a/tests/integration/targets/docker_login/tasks/test.yml
+++ b/tests/integration/targets/docker_login/tasks/test.yml
@@ -4,9 +4,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - block:
-  - include_tasks: run-test.yml
-    with_fileglob:
-    - "tests/*.yml"
+    - include_tasks: run-test.yml
+      with_fileglob:
+        - "tests/*.yml"
+      loop_control:
+        loop_var: test_name
   when: docker_api_version is version('1.25', '>=')
 
 - fail: msg="Too old docker / docker-py version to run docker_image tests!"

--- a/tests/integration/targets/docker_network/tasks/main.yml
+++ b/tests/integration/targets/docker_network/tasks/main.yml
@@ -28,23 +28,25 @@
     msg: "Using name prefix {{ name_prefix }}"
 
 - block:
-  - include_tasks: run-test.yml
-    with_fileglob:
-    - "tests/*.yml"
+    - include_tasks: run-test.yml
+      with_fileglob:
+        - "tests/*.yml"
+      loop_control:
+        loop_var: test_name
 
   always:
-  - name: "Make sure all containers are removed"
-    docker_container:
-      name: "{{ item }}"
-      state: absent
-      force_kill: true
-    loop: "{{ cnames }}"
-  - name: "Make sure all networks are removed"
-    docker_network:
-      name: "{{ item }}"
-      state: absent
-      force: true
-    loop: "{{ dnetworks }}"
+    - name: "Make sure all containers are removed"
+      docker_container:
+        name: "{{ item }}"
+        state: absent
+        force_kill: true
+      loop: "{{ cnames }}"
+    - name: "Make sure all networks are removed"
+      docker_network:
+        name: "{{ item }}"
+        state: absent
+        force: true
+      loop: "{{ dnetworks }}"
 
   when: docker_api_version is version('1.25', '>=')  # FIXME: find out API version!
 

--- a/tests/integration/targets/docker_network/tasks/run-test.yml
+++ b/tests/integration/targets/docker_network/tasks/run-test.yml
@@ -3,5 +3,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: "Loading tasks from {{ item }}"
-  include_tasks: "{{ item }}"
+- name: "Loading tasks from {{ test_name }}"
+  include_tasks: "{{ test_name }}"

--- a/tests/integration/targets/docker_plugin/tasks/main.yml
+++ b/tests/integration/targets/docker_plugin/tasks/main.yml
@@ -17,16 +17,18 @@
   register: dev_fuse_stat
 
 - block:
-  - include_tasks: run-test.yml
-    with_fileglob:
-    - "tests/*.yml"
+    - include_tasks: run-test.yml
+      with_fileglob:
+        - "tests/*.yml"
+      loop_control:
+        loop_var: test_name
 
   always:
-  - name: "Make sure plugin is removed"
-    docker_plugin:
-      plugin_name: "{{ item }}"
-      state: absent
-    with_items: "{{ plugin_names }}"
+    - name: "Make sure plugin is removed"
+      docker_plugin:
+        plugin_name: "{{ item }}"
+        state: absent
+      with_items: "{{ plugin_names }}"
 
   when: docker_api_version is version('1.25', '>=') and dev_fuse_stat.stat.exists
 

--- a/tests/integration/targets/docker_plugin/tasks/run-test.yml
+++ b/tests/integration/targets/docker_plugin/tasks/run-test.yml
@@ -3,5 +3,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: "Loading tasks from {{ item }}"
-  include_tasks: "{{ item }}"
+- name: "Loading tasks from {{ test_name }}"
+  include_tasks: "{{ test_name }}"

--- a/tests/integration/targets/docker_swarm/tasks/main.yml
+++ b/tests/integration/targets/docker_swarm/tasks/main.yml
@@ -14,9 +14,11 @@
     - docker_api_version is version('1.25', '>=')
 
   block:
-    - include_tasks: "{{ item }}"
+    - include_tasks: run-test.yml
       with_fileglob:
-        - 'tests/*.yml'
+        - "tests/*.yml"
+      loop_control:
+        loop_var: test_name
 
   always:
     - import_tasks: cleanup.yml

--- a/tests/integration/targets/docker_swarm/tasks/run-test.yml
+++ b/tests/integration/targets/docker_swarm/tasks/run-test.yml
@@ -2,3 +2,6 @@
 # Copyright (c) Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: "Loading tasks from {{ test_name }}"
+  include_tasks: "{{ test_name }}"

--- a/tests/integration/targets/docker_swarm_service/tasks/main.yml
+++ b/tests/integration/targets/docker_swarm_service/tasks/main.yml
@@ -24,14 +24,16 @@
 
 # Run the tests
 - block:
-  - name: Create a Swarm cluster
-    docker_swarm:
-      state: present
-      advertise_addr: "{{ansible_default_ipv4.address | default('127.0.0.1')}}"
+    - name: Create a Swarm cluster
+      docker_swarm:
+        state: present
+        advertise_addr: "{{ansible_default_ipv4.address | default('127.0.0.1')}}"
 
-  - include_tasks: run-test.yml
-    with_fileglob:
-      - "tests/*.yml"
+    - include_tasks: run-test.yml
+      with_fileglob:
+        - "tests/*.yml"
+      loop_control:
+        loop_var: test_name
 
   always:
     - name: Make sure all services are removed

--- a/tests/integration/targets/docker_swarm_service/tasks/run-test.yml
+++ b/tests/integration/targets/docker_swarm_service/tasks/run-test.yml
@@ -3,5 +3,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: "Loading tasks from {{ item }}"
-  include_tasks: "{{ item }}"
+- name: "Loading tasks from {{ test_name }}"
+  include_tasks: "{{ test_name }}"

--- a/tests/integration/targets/docker_volume/tasks/main.yml
+++ b/tests/integration/targets/docker_volume/tasks/main.yml
@@ -17,16 +17,18 @@
     msg: "Using name prefix {{ name_prefix }}"
 
 - block:
-  - include_tasks: run-test.yml
-    with_fileglob:
-    - "tests/*.yml"
+    - include_tasks: run-test.yml
+      with_fileglob:
+        - "tests/*.yml"
+      loop_control:
+        loop_var: test_name
 
   always:
-  - name: "Make sure all volumes are removed"
-    docker_volume:
-      name: "{{ item }}"
-      state: absent
-    with_items: "{{ vnames }}"
+    - name: "Make sure all volumes are removed"
+      docker_volume:
+        name: "{{ item }}"
+        state: absent
+      with_items: "{{ vnames }}"
 
   when: docker_api_version is version('1.25', '>=')
 

--- a/tests/integration/targets/docker_volume/tasks/run-test.yml
+++ b/tests/integration/targets/docker_volume/tasks/run-test.yml
@@ -3,5 +3,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: "Loading tasks from {{ item }}"
-  include_tasks: "{{ item }}"
+- name: "Loading tasks from {{ test_name }}"
+  include_tasks: "{{ test_name }}"


### PR DESCRIPTION
##### SUMMARY
When multiple tests are run, use loop variable `test_name` for the test name instead of the default `item`. Otherwise the tests themselves cannot use `item` without warnings.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
integration tests
