### PR TITLE
docker_compose_v2: allow to specify pull policy; parse pull events; improve error handling; always return stderr

### DIFF
--- a/plugins/modules/docker_compose_v2.py
+++ b/plugins/modules/docker_compose_v2.py
@@ -375,16 +375,17 @@ actions:
       description:
         - The status change that happened.
       type: str
-      sample: Created
+      sample: Creating
       choices:
-        - Started
-        - Exited
-        - Restarted
-        - Created
-        - Stopped
-        - Killed
-        - Removed
-        - Recreated
+        - Starting
+        - Exiting
+        - Restarting
+        - Creating
+        - Stopping
+        - Killing
+        - Removing
+        - Recreating
+        - Pulling
 '''
 
 import os

--- a/tests/integration/targets/docker_compose_v2/tasks/tests/pull.yml
+++ b/tests/integration/targets/docker_compose_v2/tasks/tests/pull.yml
@@ -1,0 +1,90 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- vars:
+    pname: "{{ name_prefix }}-pull"
+    cname: "{{ name_prefix }}-cont"
+    non_existing_image: does-not-exist:latest
+    project_src: "{{ remote_tmp_dir }}/{{ pname }}"
+    test_service_non_existing: |
+      version: '3'
+      services:
+        {{ cname }}:
+          image: {{ non_existing_image }}
+    test_service_hello_world: |
+      version: '3'
+      services:
+        {{ cname }}:
+          image: {{ docker_test_image_hello_world }}
+
+  block:
+    - name: Registering container name
+      set_fact:
+        cnames: "{{ cnames + [pname ~ '-' ~ cname ~ '-1'] }}"
+        dnetworks: "{{ dnetworks + [pname ~ '_default'] }}"
+
+    - name: Create project directory
+      file:
+        path: '{{ project_src }}'
+        state: directory
+
+    - name: Make sure images are not around
+      docker_image_remove:
+        name: '{{ item }}'
+      loop:
+        - '{{ non_existing_image }}'
+        - '{{ docker_test_image_hello_world }}'
+
+####################################################################
+## Missing image ###################################################
+####################################################################
+
+    - name: Template project file with non-existing image
+      copy:
+        dest: '{{ project_src }}/docker-compose.yml'
+        content: '{{ test_service_non_existing }}'
+
+    - name: Present with pull=never (check)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+        pull: never
+      check_mode: true
+      register: present_1_check
+      ignore_errors: true
+
+    - name: Present with pull=never
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+        pull: never
+      register: present_1
+      ignore_errors: true
+
+    - name: Present without explicit pull (check)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+      check_mode: true
+      register: present_2_check
+      ignore_errors: true
+
+    - name: Present without explicit pull
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+      register: present_2
+      ignore_errors: true
+
+    - assert:
+        that:
+          - present_1_check is failed or present_1_check is changed
+          - present_1_check is changed or present_1_check.msg.startswith('General error:')
+          - present_1 is failed
+          - present_1.msg.startswith('General error:')
+          - present_2_check is failed
+          - present_2_check.msg.startswith('Error when processing ' ~ cname ~ ':')
+          - present_2 is failed
+          - present_2.msg.startswith('Error when processing ' ~ cname ~ ':')

--- a/tests/integration/targets/docker_compose_v2/tasks/tests/pull.yml
+++ b/tests/integration/targets/docker_compose_v2/tasks/tests/pull.yml
@@ -13,11 +13,13 @@
       services:
         {{ cname }}:
           image: {{ non_existing_image }}
-    test_service_hello_world: |
+    test_service_alpine: |
       version: '3'
       services:
         {{ cname }}:
-          image: {{ docker_test_image_hello_world }}
+          image: {{ docker_test_image_alpine }}
+          command: /bin/sh -c 'sleep 10m'
+          stop_grace_period: 1s
 
   block:
     - name: Registering container name
@@ -35,7 +37,7 @@
         name: '{{ item }}'
       loop:
         - '{{ non_existing_image }}'
-        - '{{ docker_test_image_hello_world }}'
+        - '{{ docker_test_image_alpine }}'
 
 ####################################################################
 ## Missing image ###################################################
@@ -88,3 +90,122 @@
           - present_2_check.msg.startswith('Error when processing ' ~ cname ~ ':')
           - present_2 is failed
           - present_2.msg.startswith('Error when processing ' ~ cname ~ ':')
+
+####################################################################
+## Regular image ###################################################
+####################################################################
+
+    - name: Template project file with Alpine image
+      copy:
+        dest: '{{ project_src }}/docker-compose.yml'
+        content: '{{ test_service_alpine }}'
+
+    - name: Present with pull=missing (check)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+        pull: missing
+      check_mode: true
+      register: present_1_check
+
+    - name: Present with pull=missing
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+        pull: missing
+      register: present_1
+
+    - name: Present with pull=missing (idempotent, check)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+        pull: missing
+      check_mode: true
+      register: present_2_check
+
+    - name: Present with pull=missing (idempotent)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+        pull: missing
+      register: present_2
+
+    - name: Present with pull=always (check)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+        pull: always
+      check_mode: true
+      register: present_3_check
+
+    - name: Present with pull=always
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+        pull: always
+      register: present_3
+
+    - name: Stopping service
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: absent
+
+    - name: Present with pull=never (check)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+        pull: missing
+      check_mode: true
+      register: present_4_check
+
+    - name: Present with pull=never
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+        pull: missing
+      register: present_4
+
+    - name: Present with pull=never (idempotent, check)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+        pull: missing
+      check_mode: true
+      register: present_5_check
+
+    - name: Present with pull=never (idempotent)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+        pull: missing
+      register: present_5
+
+    - name: Cleanup
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: absent
+
+    - assert:
+        that:
+          - present_1_check is changed
+          - present_1_check.actions | selectattr('status', 'eq', 'Pulling') | first
+          - present_1_check.actions | selectattr('status', 'eq', 'Creating') | first
+          - present_1 is changed
+          - present_1.actions | selectattr('status', 'eq', 'Pulling') | first
+          - present_1.actions | selectattr('status', 'eq', 'Creating') | first
+          - present_2_check is not changed
+          - present_2 is not changed
+          - present_3_check is changed
+          - present_3_check.actions | selectattr('status', 'eq', 'Pulling') | first
+          - present_3_check.actions | selectattr('status', 'eq', 'Creating') | length == 0
+          - present_3_check.actions | selectattr('status', 'eq', 'Recreating') | length == 0
+          - present_3 is changed
+          - present_3.actions | selectattr('status', 'eq', 'Pulling') | first
+          - present_3.actions | selectattr('status', 'eq', 'Creating') | length == 0
+          - present_3.actions | selectattr('status', 'eq', 'Recreating') | length == 0
+          - present_4_check is changed
+          - present_4_check.actions | selectattr('status', 'eq', 'Pulling') | length == 0
+          - present_4 is changed
+          - present_4.actions | selectattr('status', 'eq', 'Pulling') | length == 0
+          - present_5_check is not changed
+          - present_5 is not changed

--- a/tests/integration/targets/docker_compose_v2/tasks/tests/start-stop.yml
+++ b/tests/integration/targets/docker_compose_v2/tasks/tests/start-stop.yml
@@ -3,18 +3,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: Set up project and container names
-  set_fact:
-    pname: "{{ name_prefix }}"
-    cname: "{{ name_prefix ~ '-hi' }}"
-
-- name: Registering container name
-  set_fact:
-    cnames: "{{ cnames + [pname ~ '-' ~ cname ~ '-1'] }}"
-    dnetworks: "{{ dnetworks + [pname ~ '_default'] }}"
-
-- name: Define services
-  set_fact:
+- vars:
+    pname: "{{ name_prefix }}-start-stop"
+    cname: "{{ name_prefix }}-container"
     project_src: "{{ remote_tmp_dir }}/{{ pname }}"
     test_service: |
       version: '3'
@@ -31,235 +22,241 @@
           command: '/bin/sh -c "sleep 15m"'
           stop_grace_period: 1s
 
-- name: Create project directory
-  file:
-    path: '{{ project_src }}'
-    state: directory
+  block:
+    - name: Registering container name
+      set_fact:
+        cnames: "{{ cnames + [pname ~ '-' ~ cname ~ '-1'] }}"
+        dnetworks: "{{ dnetworks + [pname ~ '_default'] }}"
+
+    - name: Create project directory
+      file:
+        path: '{{ project_src }}'
+        state: directory
 
 ####################################################################
 ## Present #########################################################
 ####################################################################
 
-- name: Template default project file
-  copy:
-    dest: '{{ project_src }}/docker-compose.yml'
-    content: '{{ test_service }}'
+    - name: Template default project file
+      copy:
+        dest: '{{ project_src }}/docker-compose.yml'
+        content: '{{ test_service }}'
 
-- name: Present (check)
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: present
-  check_mode: true
-  register: present_1_check
+    - name: Present (check)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+      check_mode: true
+      register: present_1_check
 
-- name: Present
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: present
-  register: present_1
+    - name: Present
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+      register: present_1
 
-- name: Present (idempotent check)
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: present
-  check_mode: true
-  register: present_2_check
+    - name: Present (idempotent check)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+      check_mode: true
+      register: present_2_check
 
-- name: Present (idempotent)
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: present
-  register: present_2
+    - name: Present (idempotent)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+      register: present_2
 
-- name: Template modified project file
-  copy:
-    dest: '{{ project_src }}/docker-compose.yml'
-    content: '{{ test_service_mod }}'
+    - name: Template modified project file
+      copy:
+        dest: '{{ project_src }}/docker-compose.yml'
+        content: '{{ test_service_mod }}'
 
-- name: Present (changed check)
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: present
-  check_mode: true
-  register: present_3_check
+    - name: Present (changed check)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+      check_mode: true
+      register: present_3_check
 
-- name: Present (changed)
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: present
-  register: present_3
+    - name: Present (changed)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+      register: present_3
 
-- assert:
-    that:
-      - present_1_check is changed
-      - present_1 is changed
-      - present_1.containers | length == 1
-      - present_1.containers[0].Name == pname ~ '-' ~ cname ~ '-1'
-      - present_1.containers[0].Image == docker_test_image_alpine
-      - present_1.images | length == 1
-      - present_1.images[0].ContainerName == pname ~ '-' ~ cname ~ '-1'
-      - present_1.images[0].Repository == (docker_test_image_alpine | split(':') | first)
-      - present_1.images[0].Tag == (docker_test_image_alpine | split(':') | last)
-      - present_2_check is not changed
-      - present_2 is not changed
-      - present_3_check is changed
-      - present_3 is changed
+    - assert:
+        that:
+          - present_1_check is changed
+          - present_1 is changed
+          - present_1.containers | length == 1
+          - present_1.containers[0].Name == pname ~ '-' ~ cname ~ '-1'
+          - present_1.containers[0].Image == docker_test_image_alpine
+          - present_1.images | length == 1
+          - present_1.images[0].ContainerName == pname ~ '-' ~ cname ~ '-1'
+          - present_1.images[0].Repository == (docker_test_image_alpine | split(':') | first)
+          - present_1.images[0].Tag == (docker_test_image_alpine | split(':') | last)
+          - present_2_check is not changed
+          - present_2 is not changed
+          - present_3_check is changed
+          - present_3 is changed
 
 ####################################################################
 ## Absent ##########################################################
 ####################################################################
 
-- name: Absent (check)
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: absent
-  check_mode: true
-  register: absent_1_check
+    - name: Absent (check)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: absent
+      check_mode: true
+      register: absent_1_check
 
-- name: Absent
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: absent
-  register: absent_1
+    - name: Absent
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: absent
+      register: absent_1
 
-- name: Absent (idempotent check)
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: absent
-  check_mode: true
-  register: absent_2_check
+    - name: Absent (idempotent check)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: absent
+      check_mode: true
+      register: absent_2_check
 
-- name: Absent (idempotent)
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: absent
-  register: absent_2
+    - name: Absent (idempotent)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: absent
+      register: absent_2
 
-- assert:
-    that:
-      - absent_1_check is changed
-      - absent_1 is changed
-      - absent_2_check is not changed
-      - absent_2 is not changed
+    - assert:
+        that:
+          - absent_1_check is changed
+          - absent_1 is changed
+          - absent_2_check is not changed
+          - absent_2 is not changed
 
 ####################################################################
 ## Stopping and starting ###########################################
 ####################################################################
 
-- name: Template default project file
-  copy:
-    dest: '{{ project_src }}/docker-compose.yml'
-    content: '{{ test_service }}'
+    - name: Template default project file
+      copy:
+        dest: '{{ project_src }}/docker-compose.yml'
+        content: '{{ test_service }}'
 
-- name: Present stopped (check)
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: stopped
-  check_mode: true
-  register: present_1_check
+    - name: Present stopped (check)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: stopped
+      check_mode: true
+      register: present_1_check
 
-- name: Present stopped
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: stopped
-  register: present_1
+    - name: Present stopped
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: stopped
+      register: present_1
 
-- name: Present stopped (idempotent check)
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: stopped
-  check_mode: true
-  register: present_2_check
+    - name: Present stopped (idempotent check)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: stopped
+      check_mode: true
+      register: present_2_check
 
-- name: Present stopped (idempotent)
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: stopped
-  register: present_2
+    - name: Present stopped (idempotent)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: stopped
+      register: present_2
 
-- name: Started (check)
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: present
-  check_mode: true
-  register: present_3_check
+    - name: Started (check)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+      check_mode: true
+      register: present_3_check
 
-- name: Started
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: present
-  register: present_3
+    - name: Started
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+      register: present_3
 
-- name: Started (idempotent check)
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: present
-  check_mode: true
-  register: present_4_check
+    - name: Started (idempotent check)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+      check_mode: true
+      register: present_4_check
 
-- name: Started (idempotent)
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: present
-  register: present_4
+    - name: Started (idempotent)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+      register: present_4
 
-- name: Restarted (check)
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: restarted
-  check_mode: true
-  register: present_5_check
+    - name: Restarted (check)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: restarted
+      check_mode: true
+      register: present_5_check
 
-- name: Restarted
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: restarted
-  register: present_5
+    - name: Restarted
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: restarted
+      register: present_5
 
-- name: Stopped (check)
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: stopped
-  check_mode: true
-  register: present_6_check
+    - name: Stopped (check)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: stopped
+      check_mode: true
+      register: present_6_check
 
-- name: Stopped
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: stopped
-  register: present_6
+    - name: Stopped
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: stopped
+      register: present_6
 
-- name: Restarted (check)
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: restarted
-  check_mode: true
-  register: present_7_check
+    - name: Restarted (check)
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: restarted
+      check_mode: true
+      register: present_7_check
 
-- name: Restarted
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: restarted
-  register: present_7
+    - name: Restarted
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: restarted
+      register: present_7
 
-- name: Cleanup
-  docker_compose_v2:
-    project_src: '{{ project_src }}'
-    state: absent
+    - name: Cleanup
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: absent
 
-- assert:
-    that:
-      - present_1_check is changed
-      - present_1 is changed
-      - present_2_check is not changed
-      - present_2 is not changed
-      - present_3_check is changed
-      - present_3 is changed
-      - present_4_check is not changed
-      - present_4 is not changed
-      - present_5_check is changed
-      - present_5 is changed
-      - present_6_check is changed
-      - present_6 is changed
-      - present_7_check is changed
-      - present_7 is changed
+    - assert:
+        that:
+          - present_1_check is changed
+          - present_1 is changed
+          - present_2_check is not changed
+          - present_2 is not changed
+          - present_3_check is changed
+          - present_3 is changed
+          - present_4_check is not changed
+          - present_4 is not changed
+          - present_5_check is changed
+          - present_5 is changed
+          - present_6_check is changed
+          - present_6 is changed
+          - present_7_check is changed
+          - present_7 is changed


### PR DESCRIPTION
##### SUMMARY
- Allow to specify pull policy (`docker compose up --pull`).
- Parse pull events (right now they result in warnings).
- Improve error handling.
- Always return `stderr` (and return `stdout` in case it's not empty) - this makes debugging misbehavior easier since you know what `docker compose` actually said.
- Fix documentation on action status values.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
docker_compose_v2
