### PR TITLE
docker_container: add networks[].mac_address option

### DIFF
--- a/changelogs/fragments/763-docker_container-mac_address.yml
+++ b/changelogs/fragments/763-docker_container-mac_address.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - "docker_container - add ``networks[].mac_address`` option for Docker API 1.44+.
+     Note that Docker API 1.44 no longer uses the global ``mac_address`` option, this new option is the only way to set the MAC address for a container
+     (https://github.com/ansible-collections/community.docker/pull/763)."

--- a/plugins/module_utils/module_container/base.py
+++ b/plugins/module_utils/module_container/base.py
@@ -177,6 +177,7 @@ class OptionGroup(object):
 class Engine(object):
     min_api_version = None  # string or None
     min_api_version_obj = None  # LooseVersion object or None
+    extra_option_minimal_versions = None  # dict[str, dict[str, Any]] or None
 
     @abc.abstractmethod
     def get_value(self, module, container, api_version, options, image, host_info):
@@ -509,6 +510,8 @@ def _preprocess_networks(module, values):
                         parsed_link = (link, link)
                     parsed_links.append(tuple(parsed_link))
                 network['links'] = parsed_links
+            if network['mac_address']:
+                network['mac_address'] = network['mac_address'].replace('-', ':')
 
     return values
 
@@ -945,7 +948,7 @@ OPTION_HOSTNAME = (
 )
 
 OPTION_IMAGE = (
-    OptionGroup(preprocess=_preprocess_networks)
+    OptionGroup()
     .add_option('image', type='str')
 )
 
@@ -1019,6 +1022,7 @@ OPTION_NETWORK = (
         ipv6_address=dict(type='str'),
         aliases=dict(type='list', elements='str'),
         links=dict(type='list', elements='str'),
+        mac_address=dict(type='str'),
     ))
 )
 

--- a/plugins/module_utils/module_container/module.py
+++ b/plugins/module_utils/module_container/module.py
@@ -614,6 +614,8 @@ class ContainerManager(DockerBaseClass):
                         expected_links.append("%s:%s" % (link, alias))
                     if not compare_generic(expected_links, network_info.get('Links'), 'allow_more_present', 'set'):
                         diff = True
+                if network.get('mac_address') and network['mac_address'] != network_info.get('MacAddress'):
+                    diff = True
                 if diff:
                     different = True
                     differences.append(dict(
@@ -623,7 +625,8 @@ class ContainerManager(DockerBaseClass):
                             ipv4_address=network_info_ipam.get('IPv4Address'),
                             ipv6_address=network_info_ipam.get('IPv6Address'),
                             aliases=network_info.get('Aliases'),
-                            links=network_info.get('Links')
+                            links=network_info.get('Links'),
+                            mac_address=network_info.get('MacAddress'),
                         )
                     ))
         return different, differences

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -525,6 +525,7 @@ options:
     description:
       - Container MAC address (for example, V(92:d0:c6:0a:29:33)).
       - Note that the global container-wide MAC address is deprecated and no longer used since Docker API version 1.44.
+      - Use O(networks[].mac_address) instead.
     type: str
   memory:
     description:
@@ -690,6 +691,12 @@ options:
             can be used in the network to reach this container.
         type: list
         elements: str
+      mac_address:
+        description:
+          - Endpoint MAC address (for example, V(92:d0:c6:0a:29:33)).
+          - This is only available for Docker API version 1.44 and later.
+        type: str
+        version_added: 3.6.0
   networks_cli_compatible:
     description:
       - "If O(networks_cli_compatible=true) (default), this module will behave as


### PR DESCRIPTION
##### SUMMARY
This is the only way with API version 1.44+ to set the container's MAC address.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docker_container
