### PR TITLE
docker_container: mac_address no longer works with Docker API v1.44+

### DIFF
--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -524,6 +524,7 @@ options:
   mac_address:
     description:
       - Container MAC address (for example, V(92:d0:c6:0a:29:33)).
+      - Note that the global container-wide MAC address is deprecated and no longer used since Docker API version 1.44.
     type: str
   memory:
     description:

--- a/tests/integration/targets/docker_container/tasks/tests/options.yml
+++ b/tests/integration/targets/docker_container/tasks/tests/options.yml
@@ -3010,46 +3010,48 @@ avoid such warnings, please quote the value.' in (log_options_2.warnings | defau
 ## mac_address #####################################################
 ####################################################################
 
-- name: mac_address
-  docker_container:
-    image: "{{ docker_test_image_alpine }}"
-    command: '/bin/sh -c "sleep 10m"'
-    name: "{{ cname }}"
-    mac_address: 92:d0:c6:0a:29:33
-    state: started
-  register: mac_address_1
+- when: docker_api_version is version('1.44', '<')
+  block:
+    - name: mac_address
+      docker_container:
+        image: "{{ docker_test_image_alpine }}"
+        command: '/bin/sh -c "sleep 10m"'
+        name: "{{ cname }}"
+        mac_address: 92:d0:c6:0a:29:33
+        state: started
+      register: mac_address_1
 
-- name: mac_address (idempotency)
-  docker_container:
-    image: "{{ docker_test_image_alpine }}"
-    command: '/bin/sh -c "sleep 10m"'
-    name: "{{ cname }}"
-    mac_address: 92:d0:c6:0a:29:33
-    state: started
-  register: mac_address_2
+    - name: mac_address (idempotency)
+      docker_container:
+        image: "{{ docker_test_image_alpine }}"
+        command: '/bin/sh -c "sleep 10m"'
+        name: "{{ cname }}"
+        mac_address: 92:d0:c6:0a:29:33
+        state: started
+      register: mac_address_2
 
-- name: mac_address (change)
-  docker_container:
-    image: "{{ docker_test_image_alpine }}"
-    command: '/bin/sh -c "sleep 10m"'
-    name: "{{ cname }}"
-    mac_address: 92:d0:c6:0a:29:44
-    state: started
-    force_kill: true
-  register: mac_address_3
+    - name: mac_address (change)
+      docker_container:
+        image: "{{ docker_test_image_alpine }}"
+        command: '/bin/sh -c "sleep 10m"'
+        name: "{{ cname }}"
+        mac_address: 92:d0:c6:0a:29:44
+        state: started
+        force_kill: true
+      register: mac_address_3
 
-- name: cleanup
-  docker_container:
-    name: "{{ cname }}"
-    state: absent
-    force_kill: true
-  diff: false
+    - name: cleanup
+      docker_container:
+        name: "{{ cname }}"
+        state: absent
+        force_kill: true
+      diff: false
 
-- assert:
-    that:
-    - mac_address_1 is changed
-    - mac_address_2 is not changed
-    - mac_address_3 is changed
+    - assert:
+        that:
+        - mac_address_1 is changed
+        - mac_address_2 is not changed
+        - mac_address_3 is changed
 
 ####################################################################
 ## memory ##########################################################


### PR DESCRIPTION
##### SUMMARY
Update documentation, and fix tests.

Subset of #763.

##### ISSUE TYPE
- Docs Pull Request
- Test Pull Request

##### COMPONENT NAME
docker_container
