### PR TITLE
docker_image: fix archive idempotency

### DIFF
--- a/changelogs/fragments/765-docker_image-archive.yml
+++ b/changelogs/fragments/765-docker_image-archive.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "docker_image - fix archiving idempotency with Docker API 1.44 or later (https://github.com/ansible-collections/community.docker/pull/765)."

--- a/plugins/module_utils/image_archive.py
+++ b/plugins/module_utils/image_archive.py
@@ -126,6 +126,12 @@ def archived_image_manifest(archive_path):
                         exc
                     )
 
+                for prefix in (
+                    'blobs/sha256/',  # Moby 25.0.0, Docker API 1.44
+                ):
+                    if image_id.startswith(prefix):
+                        image_id = image_id[len(prefix):]
+
                 try:
                     repo_tags = m0['RepoTags']
                 except KeyError as exc:


### PR DESCRIPTION
##### SUMMARY
Docker API 1.44 broke the way the image ID needs to be extracted.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_image
