### PR TITLE
Compose v2: don't emit waiting events for healthy containers

### DIFF
--- a/plugins/module_utils/compose_v2.py
+++ b/plugins/module_utils/compose_v2.py
@@ -303,6 +303,8 @@ def parse_events(stderr, dry_run=False, warn_function=None):
                 warn_missing_dry_run_prefix = True
         event = _extract_event(line)
         if event is not None:
+            if event.status == "Healthy":
+                events = [e for e in events if not (e.resource_id == event.resource_id and e.status == "Waiting")]
             events.append(event)
             if event.status in DOCKER_STATUS_ERROR:
                 error_event = event


### PR DESCRIPTION
The output of the compose command that is used for parsing events can contain multiple events for containers with health checks.  With one event status Waiting then a following event with the status Healthy. This causes the module to erroneously report changes.

This change ensures only the last event for each container is reported.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

`docker compose --ansi never --progress plain --project-directory <dir> --detach --no-color --quiet-pull --` will emit multiple events for containers with health checks. For example:

```
# docker compose --ansi never --progress plain --project-directory /srv/netbox-docker up --detach --no-color --quiet-pull --
 Container netbox-docker-redis-cache-1  Running
 Container netbox-docker-postgres-1  Running
 Container netbox-docker-redis-1  Running
 Container netbox-docker-netbox-1  Running
 Container netbox-docker-netbox-housekeeping-1  Running
 Container netbox-docker-netbox-worker-1  Running
 Container netbox-docker-netbox-1  Waiting
 Container netbox-docker-netbox-1  Waiting
 Container netbox-docker-netbox-1  Healthy
 Container netbox-docker-netbox-1  Healthy
```

This causes the module to report changes because it reports 2 containers with the Waiting status. The last four events are all for the same container, and only the last status should be reported.

To fix this, when a "Healthy" event is processed, any "Waiting" events for that same container are removed from the events list.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.docker.docker_compose_v2

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Use ansible to manage a compose definition with health checks.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
