### PR TITLE
docs(docker_plugin): note that `--grant-all-permissions` is true by default

### DIFF
--- a/plugins/modules/docker_plugin.py
+++ b/plugins/modules/docker_plugin.py
@@ -17,6 +17,7 @@ version_added: 1.3.0
 description:
   - This module allows to install, delete, enable and disable Docker plugins.
   - Performs largely the same function as the C(docker plugin) CLI subcommand.
+notes:
   - The C(--grant-all-permissions) CLI flag is true by default in this module.
 
 extends_documentation_fragment:

--- a/plugins/modules/docker_plugin.py
+++ b/plugins/modules/docker_plugin.py
@@ -17,6 +17,7 @@ version_added: 1.3.0
 description:
   - This module allows to install, delete, enable and disable Docker plugins.
   - Performs largely the same function as the C(docker plugin) CLI subcommand.
+  - The C(--grant-all-permissions) CLI flag is true by default in this module.
 
 extends_documentation_fragment:
   - community.docker.docker.api_documentation


### PR DESCRIPTION
##### SUMMARY

Adds a note to the synopsis of the `docker_plugin` module, describing that the equivalent of the `--grant-all-permissions` CLI flag is true by default.

Maybe fixes issue #145..? I'm not 100% clear on the specific features being requested, but it appears this docs fix is all that remains.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

`docker_plugin`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
