### PR TITLE
docker_compose_v2: do not consider 'Waiting' events as changes/actions

### DIFF
--- a/changelogs/fragments/804-compose-v2-waiting.yml
+++ b/changelogs/fragments/804-compose-v2-waiting.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "docker_compose_v2 - do not consider a ``Waiting`` event as an action/change (https://github.com/ansible-collections/community.docker/pull/804)."

--- a/plugins/module_utils/compose_v2.py
+++ b/plugins/module_utils/compose_v2.py
@@ -38,7 +38,6 @@ DOCKER_STATUS_DONE = frozenset((
 DOCKER_STATUS_WORKING = frozenset((
     'Creating',
     'Starting',
-    'Waiting',
     'Restarting',
     'Stopping',
     'Killing',
@@ -57,7 +56,10 @@ DOCKER_STATUS_PULL = frozenset((
 DOCKER_STATUS_ERROR = frozenset((
     'Error',
 ))
-DOCKER_STATUS = frozenset(DOCKER_STATUS_DONE | DOCKER_STATUS_WORKING | DOCKER_STATUS_PULL | DOCKER_STATUS_ERROR)
+DOCKER_STATUS_WAITING = frozenset((
+    'Waiting',
+))
+DOCKER_STATUS = frozenset(DOCKER_STATUS_DONE | DOCKER_STATUS_WORKING | DOCKER_STATUS_PULL | DOCKER_STATUS_ERROR | DOCKER_STATUS_WAITING)
 
 DOCKER_PULL_PROGRESS_DONE = frozenset((
     'Already exists',


### PR DESCRIPTION
##### SUMMARY
See #799: `Waiting` means that Compose is waiting for something, like a container to become healthy, and not that something is actually happening. Therefore `Waiting` events should not be returned as actions, or considered when determining `changed`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_compose_v2
