### PR TITLE
Add docker_container_exec note on env variables; remove superfluous notes

### DIFF
--- a/plugins/modules/docker_container_exec.py
+++ b/plugins/modules/docker_container_exec.py
@@ -96,6 +96,8 @@ options:
 notes:
   - Does B(not work with TCP TLS sockets) when using O(stdin). This is caused by the inability to send C(close_notify) without closing the connection
     with Python's C(SSLSocket)s. See U(https://github.com/ansible-collections/community.docker/issues/605) for more information.
+  - If you need to evaluate environment variables of the container in O(command) or O(argv), you need to pass the command through a shell,
+    like O(command=/bin/sh -c "echo $ENV_VARIABLE").
 author:
   - "Felix Fontein (@felixfontein)"
 

--- a/plugins/modules/docker_container_exec.py
+++ b/plugins/modules/docker_container_exec.py
@@ -94,7 +94,6 @@ options:
     version_added: 2.1.0
 
 notes:
-  - Does not support C(check_mode).
   - Does B(not work with TCP TLS sockets) when using O(stdin). This is caused by the inability to send C(close_notify) without closing the connection
     with Python's C(SSLSocket)s. See U(https://github.com/ansible-collections/community.docker/issues/605) for more information.
 author:

--- a/plugins/modules/docker_image_load.py
+++ b/plugins/modules/docker_image_load.py
@@ -39,9 +39,6 @@ options:
     type: path
     required: true
 
-notes:
-  - Does not support C(check_mode).
-
 requirements:
   - "Docker API >= 1.25"
 


### PR DESCRIPTION
##### SUMMARY
- Add a note to docker_container_exec how to make sure that env variables are evaluated.
- Remove a "check mode not supported" note from docker_container_exec and docker_image_load since that information is already conveyed by the module's attributes.

Fixes #805.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docker_container_exec
docker_image_load
