### PR TITLE
Fix Python deps setup in callback/inventory tests

### DIFF
--- a/tests/integration/targets/connection_docker_api/setup.yml
+++ b/tests/integration/targets/connection_docker_api/setup.yml
@@ -13,6 +13,6 @@
       import_role:
         name: setup_docker
 
-    - name: Setup docker
+    - name: Setup docker Python deps
       import_role:
         name: setup_docker_python_deps

--- a/tests/integration/targets/inventory_docker_containers/playbooks/docker_setup.yml
+++ b/tests/integration/targets/inventory_docker_containers/playbooks/docker_setup.yml
@@ -13,6 +13,10 @@
       import_role:
         name: setup_docker
 
+    - name: Setup Docker Python deps
+      import_role:
+        name: setup_docker_python_deps
+
     - name: Start containers
       docker_container:
         name: "{{ item.name }}"

--- a/tests/integration/targets/inventory_docker_machine/playbooks/pre-setup.yml
+++ b/tests/integration/targets/inventory_docker_machine/playbooks/pre-setup.yml
@@ -10,6 +10,10 @@
       include_role:
         name: setup_docker
 
+    - name: Setup Docker Python deps
+      import_role:
+        name: setup_docker_python_deps
+
     # There seems to be no better way to install docker-machine. At least I couldn't find any packages for RHEL7/8.
     - name: Download docker-machine binary
       vars:


### PR DESCRIPTION
##### SUMMARY
The Python deps are not set up in case the inventory (and the docker_api connection tests) are run. This causes the test failures in #815, for example.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
connection/inventory plugin tests
