### PR TITLE
CI: Move Alpine 3.18 docker to stable-2.16, add Alpine 3.19 docker

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -115,8 +115,8 @@ stages:
               test: ubuntu2004
             - name: Ubuntu 22.04
               test: ubuntu2204
-            - name: Alpine 3
-              test: alpine3
+            - name: Alpine 3.19
+              test: alpine319
           groups:
             - 4
             - 5
@@ -135,6 +135,8 @@ stages:
               test: centos7
             - name: openSUSE 15
               test: opensuse15
+            - name: Alpine 3
+              test: alpine3
           groups:
             - 4
             - 5


### PR DESCRIPTION
##### SUMMARY
Ref: https://forum.ansible.com/t/ansible-test-added-alpine-3-19-and-deprecated-3-18/4508

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
