### PR TITLE
CI: Docker Compose v1 no longer runs on Docker 26, which is now installed on the RHEL VM

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -212,7 +212,7 @@ stages:
             - 3
             - 4
             - 5
-            - 6
+            # - 6  -- Docker 26 no longer works with docker-compose v1
   - stage: Remote_2_16
     displayName: Remote 2.16
     dependsOn: []


### PR DESCRIPTION
##### SUMMARY
Docker 26 removed some deprecated things Docker Compose v1 apparently uses.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
