### PR TITLE
CI: Add stable-2.17; copy ignore.txt files from 2.17 to 2.18; move stable-2.14 from AZP to GHA

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -66,6 +66,17 @@ stages:
               test: 'devel/sanity/extra'
             - name: Units
               test: 'devel/units/1'
+  - stage: Ansible_2_17
+    displayName: Sanity & Units 2.17
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: Sanity
+              test: '2.17/sanity/1'
+            - name: Units
+              test: '2.17/units/1'
   - stage: Ansible_2_16
     displayName: Sanity & Units 2.16
     dependsOn: []
@@ -115,6 +126,20 @@ stages:
               test: ubuntu2004
             - name: Ubuntu 22.04
               test: ubuntu2204
+            - name: Alpine 3.19
+              test: alpine319
+          groups:
+            - 4
+            - 5
+            - 6
+  - stage: Docker_2_17
+    displayName: Docker 2.17
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.17/linux/{0}
+          targets:
             - name: Alpine 3.19
               test: alpine319
           groups:
@@ -213,6 +238,26 @@ stages:
             - 4
             - 5
             # - 6  -- Docker 26 no longer works with docker-compose v1
+  - stage: Remote_2_17
+    displayName: Remote 2.17
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.17/{0}
+          targets:
+            - name: RHEL 9.3 with latest Docker SDK from PyPi
+              test: rhel/9.3-pypi-latest
+            # Currently always hangs in group 2
+            # - name: RHEL 8.8
+            #   test: rhel/8.8
+          groups:
+            - 1
+            - 2
+            - 3
+            - 4
+            - 5
+            # - 6  -- Docker 26 no longer works with docker-compose v1
   - stage: Remote_2_16
     displayName: Remote 2.16
     dependsOn: []
@@ -272,14 +317,17 @@ stages:
     condition: succeededOrFailed()
     dependsOn:
       - Ansible_devel
+      - Ansible_2_17
       - Ansible_2_16
       - Ansible_2_15
       - Ansible_2_14
       - Remote_devel
+      - Remote_2_17
       - Remote_2_16
       - Remote_2_15
       - Remote_2_14
       - Docker_devel
+      - Docker_2_17
       - Docker_2_16
       - Docker_2_15
       - Docker_2_14

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -99,17 +99,6 @@ stages:
               test: '2.15/sanity/1'
             - name: Units
               test: '2.15/units/1'
-  - stage: Ansible_2_14
-    displayName: Sanity & Units 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: '2.14/sanity/1'
-            - name: Units
-              test: '2.14/units/1'
 
 ### Docker
   - stage: Docker_devel
@@ -178,20 +167,6 @@ stages:
               test: fedora37
             - name: CentOS 7
               test: centos7
-          groups:
-            - 4
-            - 5
-            - 6
-  - stage: Docker_2_14
-    displayName: Docker 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.14/linux/{0}
-          targets:
-            - name: Alpine 3
-              test: alpine3
           groups:
             - 4
             - 5
@@ -294,22 +269,6 @@ stages:
             - 3
             - 4
             - 5
-  - stage: Remote_2_14
-    displayName: Remote 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.14/{0}
-          targets:
-            - name: RHEL 9.0
-              test: rhel/9.0
-          groups:
-            - 1
-            - 2
-            - 3
-            - 4
-            - 5
 
   ## Finally
 
@@ -320,17 +279,14 @@ stages:
       - Ansible_2_17
       - Ansible_2_16
       - Ansible_2_15
-      - Ansible_2_14
       - Remote_devel
       - Remote_2_17
       - Remote_2_16
       - Remote_2_15
-      - Remote_2_14
       - Docker_devel
       - Docker_2_17
       - Docker_2_16
       - Docker_2_15
-      - Docker_2_14
       - Docker_community_devel
     jobs:
       - template: templates/coverage.yml

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -32,6 +32,7 @@ jobs:
           - '2.11'
           - '2.12'
           - '2.13'
+          - '2.14'
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
     # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
     # image for these stable branches. The list of branches where this is necessary will
@@ -72,6 +73,7 @@ jobs:
           - '2.11'
           - '2.12'
           - '2.13'
+          - '2.14'
 
     steps:
       - name: Perform unit testing against Ansible version ${{ matrix.ansible }}
@@ -211,6 +213,19 @@ jobs:
             python: ''
             target: azp/5/
           - ansible: '2.13'
+            docker: alpine3
+            python: ''
+            target: azp/6/
+          # 2.14
+          - ansible: '2.14'
+            docker: alpine3
+            python: ''
+            target: azp/4/
+          - ansible: '2.14'
+            docker: alpine3
+            python: ''
+            target: azp/5/
+          - ansible: '2.14'
             docker: alpine3
             python: ''
             target: azp/6/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Please note that this collection does **not** support Windows targets. The conne
 
 ## Tested with Ansible
 
-Tested with the current ansible-core 2.11, ansible-core 2.12, ansible-core 2.13, ansible-core 2.14, ansible-core 2.15, and ansible-core 2.16 releases, and the current development version of ansible-core. Ansible/ansible-base versions before 2.11.0 are not supported.
+Tested with the current ansible-core 2.11, ansible-core 2.12, ansible-core 2.13, ansible-core 2.14, ansible-core 2.15, ansible-core 2.16, and ansible-core 2.17 releases, and the current development version of ansible-core. Ansible/ansible-base versions before 2.11.0 are not supported.
 
 Please note that Ansible 2.9 and ansible-base 2.10 are no longer supported. If you need to use them, use community.docker 2.x.y. Also note that this collection does not work with ansible-core 2.11 (this includes ansible-base and Ansible 2.9) on Python 3.12+.
 

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,0 +1,4 @@
+plugins/modules/docker_container_copy_into.py validate-modules:undocumented-parameter # _max_file_size_for_diff is used by the action plugin
+plugins/module_utils/_api/api/client.py pylint:use-yield-from  # suggested construct does not work with Python 2
+plugins/module_utils/_api/utils/build.py pylint:use-yield-from  # suggested construct does not work with Python 2
+tests/unit/plugins/module_utils/test_copy.py pylint:use-yield-from  # suggested construct does not work with Python 2

--- a/tests/sanity/ignore-2.18.txt.license
+++ b/tests/sanity/ignore-2.18.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project


### PR DESCRIPTION
##### SUMMARY
Ref: https://forum.ansible.com/t/ansible-core-devel-bumped-to-2-18-0-dev0-stable-2-17-branch-created/4695

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
