### PR TITLE
Remove unused code that relies on functionality deprecated in Python 3.12

### DIFF
--- a/changelogs/fragments/834-datetime-depr.yml
+++ b/changelogs/fragments/834-datetime-depr.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "vendored Docker SDK for Python - remove unused code that relies on functionality deprecated in Python 3.12 (https://github.com/ansible-collections/community.docker/pull/834)."

--- a/plugins/module_utils/_api/api/daemon.py
+++ b/plugins/module_utils/_api/api/daemon.py
@@ -11,12 +11,9 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-from datetime import datetime
 
 from .. import auth
-from ..utils.utils import datetime_to_timestamp, convert_filters
 from ..utils.decorators import minimum_version
-from ..types.daemon import CancellableStream
 
 
 class DaemonApiMixin(object):
@@ -35,65 +32,6 @@ class DaemonApiMixin(object):
         """
         url = self._url('/system/df')
         return self._result(self._get(url), True)
-
-    def events(self, since=None, until=None, filters=None, decode=None):
-        """
-        Get real-time events from the server. Similar to the ``docker events``
-        command.
-
-        Args:
-            since (UTC datetime or int): Get events from this point
-            until (UTC datetime or int): Get events until this point
-            filters (dict): Filter the events by event time, container or image
-            decode (bool): If set to true, stream will be decoded into dicts on
-                the fly. False by default.
-
-        Returns:
-            A :py:class:`docker.types.daemon.CancellableStream` generator
-
-        Raises:
-            :py:class:`docker.errors.APIError`
-                If the server returns an error.
-
-        Example:
-
-            >>> for event in client.events(decode=True)
-            ...   print(event)
-            {u'from': u'image/with:tag',
-             u'id': u'container-id',
-             u'status': u'start',
-             u'time': 1423339459}
-            ...
-
-            or
-
-            >>> events = client.events()
-            >>> for event in events:
-            ...   print(event)
-            >>> # and cancel from another thread
-            >>> events.close()
-        """
-
-        if isinstance(since, datetime):
-            since = datetime_to_timestamp(since)
-
-        if isinstance(until, datetime):
-            until = datetime_to_timestamp(until)
-
-        if filters:
-            filters = convert_filters(filters)
-
-        params = {
-            'since': since,
-            'until': until,
-            'filters': filters
-        }
-        url = self._url('/events')
-
-        response = self._get(url, params=params, stream=True, timeout=None)
-        stream = self._stream_helper(response, decode=decode)
-
-        return CancellableStream(stream, response)
 
     def info(self):
         """

--- a/plugins/module_utils/_api/utils/utils.py
+++ b/plugins/module_utils/_api/utils/utils.py
@@ -17,7 +17,6 @@ import os
 import os.path
 import shlex
 import string
-from datetime import datetime
 from ansible_collections.community.docker.plugins.module_utils.version import StrictVersion
 
 from ansible.module_utils.six import PY2, PY3, binary_type, integer_types, iteritems, string_types, text_type
@@ -419,12 +418,6 @@ def convert_filters(filters):
             for item in v
         ]
     return json.dumps(result)
-
-
-def datetime_to_timestamp(dt):
-    """Convert a UTC datetime to a Unix timestamp"""
-    delta = dt - datetime.utcfromtimestamp(0)
-    return delta.seconds + delta.days * 24 * 3600
 
 
 def parse_bytes(s):

--- a/tests/unit/plugins/module_utils/_api/api/test_client.py
+++ b/tests/unit/plugins/module_utils/_api/api/test_client.py
@@ -35,7 +35,6 @@ if sys.version_info < (2, 7):
 from ansible_collections.community.docker.plugins.module_utils._api import constants, errors
 from ansible_collections.community.docker.plugins.module_utils._api.api.client import APIClient
 from ansible_collections.community.docker.plugins.module_utils._api.constants import DEFAULT_DOCKER_API_VERSION
-from ansible_collections.community.docker.plugins.module_utils._api.utils.utils import convert_filters
 from requests.packages import urllib3
 
 from .. import fake_api
@@ -245,56 +244,6 @@ class DockerApiTest(BaseAPIClientTest):
             'username': 'sakuya',
             'serveraddress': None,
         }
-
-    def test_events(self):
-        self.client.events()
-
-        fake_request.assert_called_with(
-            'GET',
-            url_prefix + 'events',
-            params={'since': None, 'until': None, 'filters': None},
-            stream=True,
-            timeout=None
-        )
-
-    def test_events_with_since_until(self):
-        ts = 1356048000
-        now = datetime.datetime.utcfromtimestamp(ts)
-        since = now - datetime.timedelta(seconds=10)
-        until = now + datetime.timedelta(seconds=10)
-
-        self.client.events(since=since, until=until)
-
-        fake_request.assert_called_with(
-            'GET',
-            url_prefix + 'events',
-            params={
-                'since': ts - 10,
-                'until': ts + 10,
-                'filters': None
-            },
-            stream=True,
-            timeout=None
-        )
-
-    def test_events_with_filters(self):
-        filters = {'event': ['die', 'stop'],
-                   'container': fake_api.FAKE_CONTAINER_ID}
-
-        self.client.events(filters=filters)
-
-        expected_filters = convert_filters(filters)
-        fake_request.assert_called_with(
-            'GET',
-            url_prefix + 'events',
-            params={
-                'since': None,
-                'until': None,
-                'filters': expected_filters
-            },
-            stream=True,
-            timeout=None
-        )
 
     def _socket_path_for_client_session(self, client):
         socket_adapter = client.get_adapter('http+docker://')


### PR DESCRIPTION
##### SUMMARY
`datetime.datetime.utcfromtimestamp()` and `datetime.datetime.utcnow()` have been deprecated.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
vendored Docker SDK for Python
