### PR TITLE
docker_network: Add support for --config-from and --config-only

### DIFF
--- a/changelogs/fragments/843-docker_network-config-from-config-only.yml
+++ b/changelogs/fragments/843-docker_network-config-from-config-only.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - docker_network - adds ``config_only`` and ``config_from`` to support creating and using config only networks (https://github.com/ansible-collections/community.docker/issues/395).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Added support to docker_network.py for `--config-only` and `--config-from`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #395 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_network

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
