### PR TITLE
Allow healthcheck override without test option

### DIFF
--- a/changelogs/fragments/847-docker_container-heackcheck-test_cli_compatible.yml
+++ b/changelogs/fragments/847-docker_container-heackcheck-test_cli_compatible.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - docker_container - adds ``healthcheck.test_cli_compatible`` to allow omit test option on containers without remove existing image test (https://github.com/ansible-collections/community.docker/pull/847).

--- a/plugins/module_utils/module_container/base.py
+++ b/plugins/module_utils/module_container/base.py
@@ -935,6 +935,7 @@ OPTION_HEALTHCHECK = (
     OptionGroup(preprocess=_preprocess_healthcheck)
     .add_option('healthcheck', type='dict', ansible_suboptions=dict(
         test=dict(type='raw'),
+        test_cli_compatible=dict(type='bool', default=False),
         interval=dict(type='str'),
         timeout=dict(type='str'),
         start_period=dict(type='str'),

--- a/plugins/module_utils/module_container/docker_api.py
+++ b/plugins/module_utils/module_container/docker_api.py
@@ -746,7 +746,7 @@ def _preprocess_etc_hosts(module, client, api_version, value):
 def _preprocess_healthcheck(module, client, api_version, value):
     if value is None:
         return value
-    if not value or not value.get('test'):
+    if not value or not (value.get('test') or (value.get('test_cli_compatible') and value.get('test') is None)):
         value = {'test': ['NONE']}
     elif 'test' in value:
         value['test'] = normalize_healthcheck_test(value['test'])

--- a/plugins/module_utils/util.py
+++ b/plugins/module_utils/util.py
@@ -353,7 +353,7 @@ def normalize_healthcheck(healthcheck, normalize_test=False):
     result = dict()
 
     # All supported healthcheck parameters
-    options = ('test', 'interval', 'timeout', 'start_period', 'start_interval', 'retries')
+    options = ('test', 'test_cli_compatible', 'interval', 'timeout', 'start_period', 'start_interval', 'retries')
 
     duration_options = ('interval', 'timeout', 'start_period', 'start_interval')
 
@@ -366,7 +366,7 @@ def normalize_healthcheck(healthcheck, normalize_test=False):
                 continue
             if key in duration_options:
                 value = convert_duration_to_nanosecond(value)
-            if not value:
+            if not value and not (healthcheck['test_cli_compatible'] and key == 'test'):
                 continue
             if key == 'retries':
                 try:
@@ -376,7 +376,7 @@ def normalize_healthcheck(healthcheck, normalize_test=False):
                         'Cannot parse number of retries for healthcheck. '
                         'Expected an integer, got "{0}".'.format(value)
                     )
-            if key == 'test' and normalize_test:
+            if key == 'test' and value and normalize_test:
                 value = normalize_healthcheck_test(value)
             result[key] = value
 

--- a/plugins/module_utils/util.py
+++ b/plugins/module_utils/util.py
@@ -366,7 +366,7 @@ def normalize_healthcheck(healthcheck, normalize_test=False):
                 continue
             if key in duration_options:
                 value = convert_duration_to_nanosecond(value)
-            if not value and not (healthcheck['test_cli_compatible'] and key == 'test'):
+            if not value and not (healthcheck.get('test_cli_compatible') and key == 'test'):
                 continue
             if key == 'retries':
                 try:

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -388,6 +388,7 @@ options:
             This is the classical behavior of the module and currently the default behavior.
         default: false
         type: bool
+        version_added: 3.10.0
       interval:
         description:
           - Time between running the check.

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -379,6 +379,15 @@ options:
           - Command to run to check health.
           - Must be either a string or a list. If it is a list, the first item must be one of V(NONE), V(CMD) or V(CMD-SHELL).
         type: raw
+      test_cli_compatible:
+        description:
+          - If set to V(true), omitting O(healthcheck.test) while providing O(healthcheck) does not disable healthchecks,
+            but simply overwrites the image's values by the ones specified in O(healthcheck). This is
+            the behavior used by the Docker CLI.
+          - If set to V(false), omitting O(healthcheck.test) will disable the container's health check.
+            This is the classical behavior of the module and currently the default behavior.
+        default: false
+        type: bool
       interval:
         description:
           - Time between running the check.


### PR DESCRIPTION
##### SUMMARY

- Use case

Change healthcheck container options while keeping original image test.

ex:

```
healthcheck:
  interval: 1m
  timeout: 10s
  start_period: 30s
  retries: 3      
```

- Actual behavior

```
"Healthcheck" {
  "Test": ["NONE"]
}
```

- New behavior

```
"Healthcheck" {
  "Test": <internal docker image test>,
  "Interval": 60000000000,
  "Timeout": 10000000000,
  "StartPeriod": 30000000000,
  "Retries": 3
}
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_api