### PR TITLE
docker_image_build: allow to specify multiple platforms, allow to specify secrets and outputs

### DIFF
--- a/changelogs/fragments/852-docker_image_build.yml
+++ b/changelogs/fragments/852-docker_image_build.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "docker_image_build - allow ``platform`` to be a list of platforms instead of only a single platform for multi-platform builds (https://github.com/ansible-collections/community.docker/pull/852)."

--- a/changelogs/fragments/852-docker_image_build.yml
+++ b/changelogs/fragments/852-docker_image_build.yml
@@ -1,2 +1,3 @@
 minor_changes:
   - "docker_image_build - allow ``platform`` to be a list of platforms instead of only a single platform for multi-platform builds (https://github.com/ansible-collections/community.docker/pull/852)."
+  - "docker_image_build - add ``secrets`` option to allow passing secrets to the build (https://github.com/ansible-collections/community.docker/pull/852)."

--- a/changelogs/fragments/852-docker_image_build.yml
+++ b/changelogs/fragments/852-docker_image_build.yml
@@ -1,3 +1,4 @@
 minor_changes:
   - "docker_image_build - allow ``platform`` to be a list of platforms instead of only a single platform for multi-platform builds (https://github.com/ansible-collections/community.docker/pull/852)."
   - "docker_image_build - add ``secrets`` option to allow passing secrets to the build (https://github.com/ansible-collections/community.docker/pull/852)."
+  - "docker_image_build - add ``outputs`` option to allow configuring outputs for the build (https://github.com/ansible-collections/community.docker/pull/852)."

--- a/plugins/modules/docker_image_build.py
+++ b/plugins/modules/docker_image_build.py
@@ -18,6 +18,9 @@ version_added: 3.6.0
 
 description:
   - This module allows you to build Docker images using Docker's buildx plugin (BuildKit).
+  - Note that the module is B(not idempotent) in the sense of classical Ansible modules.
+    The only idempotence check is whether the built image already exists. This check can
+    be disabled with the O(rebuild) option.
 
 extends_documentation_fragment:
   - community.docker.docker.cli_documentation

--- a/plugins/modules/docker_image_build.py
+++ b/plugins/modules/docker_image_build.py
@@ -92,8 +92,10 @@ options:
     type: str
   platform:
     description:
-      - Platform in the format C(os[/arch[/variant]]).
-    type: str
+      - Platforms in the format C(os[/arch[/variant]]).
+      - Since community.docker 3.10.0 this can be a list of platforms, instead of just a single platform.
+    type: list
+    elements: str
   shm_size:
     description:
       - "Size of C(/dev/shm) in format C(<number>[<unit>]). Number is positive integer.
@@ -131,6 +133,15 @@ EXAMPLES = '''
     name: localhost/python/3.12:latest
     path: /home/user/images/python
     dockerfile: Dockerfile-3.12
+
+- name: Build multi-platform image
+  community.docker.docker_image_build:
+    name: multi-platform-image
+    tag: "1.5.2"
+    path: /home/user/images/multi-platform
+    platform:
+      - linux/amd64
+      - linux/arm64/v8
 '''
 
 RETURN = '''
@@ -251,7 +262,8 @@ class ImageBuilder(DockerBaseClass):
         if self.target:
             args.extend(['--target', self.target])
         if self.platform:
-            args.extend(['--platform', self.platform])
+            for platform in self.platform:
+                args.extend(['--platform', platform])
         if self.shm_size:
             args.extend(['--shm-size', str(self.shm_size)])
         if self.labels:
@@ -297,7 +309,7 @@ def main():
         etc_hosts=dict(type='dict'),
         args=dict(type='dict'),
         target=dict(type='str'),
-        platform=dict(type='str'),
+        platform=dict(type='list', elements='str'),
         shm_size=dict(type='str'),
         labels=dict(type='dict'),
         rebuild=dict(type='str', choices=['never', 'always'], default='never'),

--- a/tests/integration/targets/docker_image_build/tasks/test.yml
+++ b/tests/integration/targets/docker_image_build/tasks/test.yml
@@ -35,6 +35,17 @@
     msg: "Has buildx plugin: {{ docker_has_buildx }}"
 
 - block:
+    - name: Determine plugin versions
+      command: docker info -f '{{ "{{" }}json .ClientInfo.Plugins{{ "}}" }}'
+      register: plugin_versions
+
+    - name: Determine buildx plugin version
+      set_fact:
+        buildx_version: >-
+          {{
+            (plugin_versions.stdout | from_json | selectattr('Name', 'eq', 'buildx') | map(attribute='Version') | first).lstrip('v')
+          }}
+
     - include_tasks: run-test.yml
       with_fileglob:
         - "tests/*.yml"

--- a/tests/integration/targets/docker_image_build/tasks/test.yml
+++ b/tests/integration/targets/docker_image_build/tasks/test.yml
@@ -28,6 +28,7 @@
     - Dockerfile
     - EtcHostsDockerfile
     - MyDockerfile
+    - SecretsDockerfile
     - StagedDockerfile
 
 - debug:

--- a/tests/integration/targets/docker_image_build/tasks/tests/options.yml
+++ b/tests/integration/targets/docker_image_build/tasks/tests/options.yml
@@ -211,31 +211,33 @@
   set_fact:
     docker_image_build_secret_value: this is my secret {{ '%0x' % ((2**32) | random) }}
 
-- name: Build image with secrets
-  docker_image_build:
-    name: "{{ iname }}"
-    path: "{{ remote_tmp_dir }}/files"
-    dockerfile: "SecretsDockerfile"
-    pull: false
-    secrets:
-      - id: my-awesome-secret
-        type: value
-        value: '{{ docker_image_build_secret_value }}'
-    nocache: true  # using a cache can result in the output step being CACHED
-  register: secrets_1
+- when: buildx_version is version('0.6.0', '>=')
+  block:
+    - name: Build image with secrets via environment variables
+      docker_image_build:
+        name: "{{ iname }}"
+        path: "{{ remote_tmp_dir }}/files"
+        dockerfile: "SecretsDockerfile"
+        pull: false
+        secrets:
+          - id: my-awesome-secret
+            type: value
+            value: '{{ docker_image_build_secret_value }}'
+        nocache: true  # using a cache can result in the output step being CACHED
+      register: secrets_1
 
-- name: cleanup
-  docker_image_remove:
-    name: "{{ iname }}"
+    - name: cleanup
+      docker_image_remove:
+        name: "{{ iname }}"
 
-- name: Show image information
-  debug:
-    var: secrets_1.stderr_lines
+    - name: Show image information
+      debug:
+        var: secrets_1.stderr_lines
 
-- assert:
-    that:
-      - secrets_1 is changed
-      - (docker_image_build_secret_value | b64encode) in secrets_1.stderr
+    - assert:
+        that:
+          - secrets_1 is changed
+          - (docker_image_build_secret_value | b64encode) in secrets_1.stderr
 
 ####################################################################
 ## outputs #########################################################

--- a/tests/integration/targets/docker_image_build/tasks/tests/options.yml
+++ b/tests/integration/targets/docker_image_build/tasks/tests/options.yml
@@ -202,3 +202,37 @@
       - labels_1 is changed
       - labels_1.image.Config.Labels.FOO == 'BAR'
       - labels_1.image.Config.Labels["this is a label"] == "this is the label's value"
+
+####################################################################
+## secrets #########################################################
+####################################################################
+
+- name: Generate secret
+  set_fact:
+    docker_image_build_secret_value: this is my secret {{ '%0x' % ((2**32) | random) }}
+
+- name: Build image with secrets
+  docker_image_build:
+    name: "{{ iname }}"
+    path: "{{ remote_tmp_dir }}/files"
+    dockerfile: "SecretsDockerfile"
+    pull: false
+    secrets:
+      - id: my-awesome-secret
+        type: value
+        value: '{{ docker_image_build_secret_value }}'
+    nocache: true  # using a cache can result in the output step being CACHED
+  register: secrets_1
+
+- name: cleanup
+  docker_image_remove:
+    name: "{{ iname }}"
+
+- name: Show image information
+  debug:
+    var: secrets_1.stderr_lines
+
+- assert:
+    that:
+      - secrets_1 is changed
+      - (docker_image_build_secret_value | b64encode) in secrets_1.stderr

--- a/tests/integration/targets/docker_image_build/tasks/tests/options.yml
+++ b/tests/integration/targets/docker_image_build/tasks/tests/options.yml
@@ -236,3 +236,52 @@
     that:
       - secrets_1 is changed
       - (docker_image_build_secret_value | b64encode) in secrets_1.stderr
+
+####################################################################
+## outputs #########################################################
+####################################################################
+
+- name: Make sure the image is not there
+  docker_image_remove:
+    name: "{{ iname }}"
+
+- name: Make sure the image tarball is not there
+  file:
+    path: "{{ remote_tmp_dir }}/container.tar"
+    state: absent
+
+- name: Build image with outputs
+  docker_image_build:
+    name: "{{ iname }}"
+    path: "{{ remote_tmp_dir }}/files"
+    dockerfile: "Dockerfile"
+    pull: false
+    outputs:
+      - type: tar
+        dest: "{{ remote_tmp_dir }}/container.tar"
+  register: outputs_1
+
+- name: cleanup (should not be changed)
+  docker_image_remove:
+    name: "{{ iname }}"
+  register: outputs_1_cleanup
+
+- name: Gather information on tarball
+  stat:
+    path: "{{ remote_tmp_dir }}/container.tar"
+  register: outputs_1_stat
+
+- name: Show image information
+  debug:
+    var: outputs_1.image
+
+- name: Show tarball information
+  debug:
+    var: outputs_1_stat.stat
+
+- assert:
+    that:
+      - outputs_1 is changed
+      - outputs_1.image | length == 0
+      - outputs_1_cleanup is not changed
+      - outputs_1_stat.stat.exists

--- a/tests/integration/targets/docker_image_build/templates/SecretsDockerfile
+++ b/tests/integration/targets/docker_image_build/templates/SecretsDockerfile
@@ -1,0 +1,7 @@
+# Copyright (c) 2024, Felix Fontein
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+FROM {{ docker_test_image_busybox }}
+RUN --mount=type=secret,id=my-awesome-secret \
+    cat /run/secrets/my-awesome-secret | base64

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -11,3 +11,4 @@ plugins/modules/docker_compose_v2.py validate-modules:return-syntax-error
 plugins/modules/docker_compose_v2_pull.py validate-modules:return-syntax-error
 plugins/modules/docker_container.py import-2.6!skip # Import uses Python 2.7+ syntax
 plugins/modules/docker_container_copy_into.py validate-modules:undocumented-parameter # _max_file_size_for_diff is used by the action plugin
+plugins/modules/docker_image_build.py validate-modules:invalid-documentation

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -3,3 +3,4 @@ plugins/modules/current_container_facts.py validate-modules:return-syntax-error
 plugins/modules/docker_compose_v2.py validate-modules:return-syntax-error
 plugins/modules/docker_compose_v2_pull.py validate-modules:return-syntax-error
 plugins/modules/docker_container_copy_into.py validate-modules:undocumented-parameter # _max_file_size_for_diff is used by the action plugin
+plugins/modules/docker_image_build.py validate-modules:invalid-documentation

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,3 +1,4 @@
 .azure-pipelines/scripts/publish-codecov.py replace-urlopen
 plugins/modules/docker_compose_v2.py validate-modules:return-syntax-error
 plugins/modules/docker_container_copy_into.py validate-modules:undocumented-parameter # _max_file_size_for_diff is used by the action plugin
+plugins/modules/docker_image_build.py validate-modules:invalid-documentation

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,2 +1,3 @@
 .azure-pipelines/scripts/publish-codecov.py replace-urlopen
 plugins/modules/docker_container_copy_into.py validate-modules:undocumented-parameter # _max_file_size_for_diff is used by the action plugin
+plugins/modules/docker_image_build.py validate-modules:invalid-documentation

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,2 +1,3 @@
 .azure-pipelines/scripts/publish-codecov.py replace-urlopen
 plugins/modules/docker_container_copy_into.py validate-modules:undocumented-parameter # _max_file_size_for_diff is used by the action plugin
+plugins/modules/docker_image_build.py validate-modules:invalid-documentation

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,1 +1,2 @@
 plugins/modules/docker_container_copy_into.py validate-modules:undocumented-parameter # _max_file_size_for_diff is used by the action plugin
+plugins/modules/docker_image_build.py validate-modules:invalid-documentation


### PR DESCRIPTION
##### SUMMARY
Implements three new features:
- Allow to specify multiple platforms.
- Allow to specify build secrets.
- Allow to specify build outputs. The `load` option from #808 corresponds to `type=docker`, and the `push` option from #808 to `type=image` with `push=true`.

Also adds a note that the module isn't really idempotent in the classical sense.

Closes #808.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docker_image_build
