### PR TITLE
Force requests<2.32.0 for docker-compose v1

### DIFF
--- a/tests/integration/targets/setup_docker_compose_v1/vars/Alpine.yml
+++ b/tests/integration/targets/setup_docker_compose_v1/vars/Alpine.yml
@@ -9,3 +9,5 @@ docker_compose_pip_packages:
   - docker-compose
   # Force PyYAML to 5.3.1
   - PyYAML==5.3.1
+  # Force requests to < 2.32.0 (https://github.com/docker/docker-py/issues/3256)
+  - requests<2.32.0


### PR DESCRIPTION
##### SUMMARY
Since docker-compose v1 will never get an update, and its Docker SDK for Python needs to stick to an older version, we also have to restrict requests.

Ref: https://github.com/docker/docker-py/issues/3256

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
docker-compose v1 tests
