### PR TITLE
[stable-2] Fix docker_image tests with Docker SDK for Python 7.1.0; restrict requests in EE dependencies to < 2.32.0

### DIFF
--- a/changelogs/fragments/872-ee-requests.yml
+++ b/changelogs/fragments/872-ee-requests.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - "EE requirements - restrict ``requests`` dependency to ``< 2.32.0`` since later versions are incompatible with
+     Docker SDK for Python < 7.1.0, which we depend on (https://github.com/ansible-collections/community.docker/pull/872)."
+known_issues:
+  - "EE requirements - ``requests < 2.32.0`` is vulnerable to `CVE-2024-35195 <https://github.com/advisories/GHSA-9wx4-h78v-vm56>`__.
+     This does not affect Docker SDK for Python, but might affect other users of ``requests``
+     (https://github.com/ansible-collections/community.docker/pull/872)."

--- a/meta/ee-requirements.txt
+++ b/meta/ee-requirements.txt
@@ -1,2 +1,3 @@
 docker<7.0.0
+requests<2.32.0
 docker-compose

--- a/tests/integration/targets/docker_image/tasks/tests/options.yml
+++ b/tests/integration/targets/docker_image/tasks/tests/options.yml
@@ -299,7 +299,8 @@
     api_version: "1.22"
   register: load_image_4
   # Moby 25.0.0 (API version 1.44) dropped support for older API versions
-  when: docker_api_version is version('1.44', '<')
+  # Docker SDK for Python 7.1.0 also dropped support for older API versions
+  when: docker_api_version is version('1.44', '<') and docker_py_version is version('7.1.0', '<')
 
 - name: load image (ID, idempotency)
   docker_image:
@@ -320,7 +321,7 @@
     - '"Detected no loaded images. Archive potentially corrupt?" == load_image_3.msg'
     - load_image_5 is not changed
 
-- when: docker_api_version is version('1.44', '<')
+- when: docker_api_version is version('1.44', '<') and docker_py_version is version('7.1.0', '<')
   assert:
     that:
     - load_image_4 is changed


### PR DESCRIPTION
##### SUMMARY
Docker SDK for Python 7.1.0 drops support for API versions < 1.24. The test uses API version 1.22, so it has to be disabled for Docker SDK for Python >= 7.1.0.

We need to restrict requests in the EE requirements to < 2.32.0 since we have to restrict Docker SDK for Python to < 7.0.0. (The latter is due to later versions of Docker SDK for Python no longer supporting Docker Compose.)

Please only use EEs based on community.docker 2.x.y if you absolutely have to, and if you're sure that [CVE-2024-35195](https://github.com/advisories/GHSA-9wx4-h78v-vm56) doesn't affect the code running in that EE.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
docker_image
