### PR TITLE
Docker Compose v1 tests: restrict API version to 1.44 if default API version is 1.45+

### DIFF
--- a/changelogs/fragments/881-docker-compose-v1-api-version.yml
+++ b/changelogs/fragments/881-docker-compose-v1-api-version.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "docker_compose - make sure that the module uses the ``api_version`` parameter (https://github.com/ansible-collections/community.docker/pull/881)."

--- a/plugins/modules/docker_compose.py
+++ b/plugins/modules/docker_compose.py
@@ -675,6 +675,9 @@ class ContainerManager(DockerBaseClass):
         for key, value in client.module.params.items():
             setattr(self, key, value)
 
+        if self.api_version:
+            os.environ['COMPOSE_API_VERSION'] = self.api_version
+
         self.check_mode = client.check_mode
 
         if not self.debug:

--- a/tests/integration/targets/docker_compose/tasks/main.yml
+++ b/tests/integration/targets/docker_compose/tasks/main.yml
@@ -19,7 +19,11 @@
     msg: "Using container name prefix {{ cname_prefix }}"
 
 # Run the tests
-- block:
+- module_defaults:
+    community.docker.docker_compose:
+      api_version: '{{ omit if docker_api_version is version("1.45", "<") else "1.44" }}'
+
+  block:
     - include_tasks: run-test.yml
       with_fileglob:
         - "tests/*.yml"


### PR DESCRIPTION
##### SUMMARY
Now that GHA uses a newer Docker which supports API version 1.45+, the docker-compose v1 tests fail because 1.45 removed some fields that docker-compose sometimes relies on.

Telling docker-compose to use API version 1.44 in that case should fix it.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
docker_compose tests
