### PR TITLE
CI: remove Fedora 32 tests (ansible-core 2.11) from CI

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -120,18 +120,6 @@ jobs:
         include:
           # 2.11
           - ansible: '2.11'
-            docker: fedora32
-            python: ''
-            target: azp/4/
-          - ansible: '2.11'
-            docker: fedora32
-            python: ''
-            target: azp/5/
-          - ansible: '2.11'
-            docker: fedora32
-            python: ''
-            target: azp/6/
-          - ansible: '2.11'
             docker: alpine3
             python: ''
             target: azp/4/


### PR DESCRIPTION
##### SUMMARY
These do not work anymore with the latest Docker version. The container simply dies.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
