### PR TITLE
[stable-2] Docker Compose v1 tests: restrict API version to 1.44 if default API version is 1.45+ (#881)

### DIFF
--- a/changelogs/fragments/881-docker-compose-v1-api-version.yml
+++ b/changelogs/fragments/881-docker-compose-v1-api-version.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "docker_compose - make sure that the module uses the ``api_version`` parameter (https://github.com/ansible-collections/community.docker/pull/881)."

--- a/plugins/modules/docker_compose.py
+++ b/plugins/modules/docker_compose.py
@@ -659,6 +659,9 @@ class ContainerManager(DockerBaseClass):
         for key, value in client.module.params.items():
             setattr(self, key, value)
 
+        if self.api_version:
+            os.environ['COMPOSE_API_VERSION'] = self.api_version
+
         self.check_mode = client.check_mode
 
         if not self.debug:

--- a/tests/integration/targets/docker_compose/tasks/main.yml
+++ b/tests/integration/targets/docker_compose/tasks/main.yml
@@ -15,7 +15,11 @@
     msg: "Using container name prefix {{ cname_prefix }}"
 
 # Run the tests
-- block:
+- module_defaults:
+    community.docker.docker_compose:
+      api_version: '{{ omit if docker_api_version is version("1.45", "<") else "1.44" }}'
+
+  block:
   - include_tasks: run-test.yml
     with_fileglob:
     - "tests/*.yml"


### PR DESCRIPTION
##### SUMMARY
Manual backport of #881 to stable-2.

##### ISSUE TYPE
- Bugfix Pull Request
- Test Pull Request

##### COMPONENT NAME
docker_compose
