### PR TITLE
docker_compose_v2*: make sure that one of project_src and definition is provided

### DIFF
--- a/changelogs/fragments/886-compose-v2-req.yml
+++ b/changelogs/fragments/886-compose-v2-req.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "docker_compose_v2* modules - there was no check to make sure that one of ``project_src`` and ``definition`` is provided. The modules crashed if none were provided (https://github.com/ansible-collections/community.docker/issues/885, https://github.com/ansible-collections/community.docker/pull/886)."

--- a/plugins/doc_fragments/compose_v2.py
+++ b/plugins/doc_fragments/compose_v2.py
@@ -18,7 +18,7 @@ options:
           - Path to a directory containing a Compose file
             (C(compose.yml), C(compose.yaml), C(docker-compose.yml), or C(docker-compose.yaml)).
           - If O(files) is provided, will look for these files in this directory instead.
-          - Mutually exclusive with O(definition).
+          - Mutually exclusive with O(definition). One of O(project_src) and O(definition) must be provided.
         type: path
     project_name:
         description:
@@ -37,7 +37,7 @@ options:
     definition:
         description:
           - Compose file describing one or more services, networks and volumes.
-          - Mutually exclusive with O(project_src) and O(files).
+          - Mutually exclusive with O(project_src) and O(files). One of O(project_src) and O(definition) must be provided.
           - If provided, PyYAML must be available to this module, and O(project_name) must be specified.
           - Note that a temporary directory will be created and deleted afterwards when using this option.
         type: dict

--- a/plugins/module_utils/compose_v2.py
+++ b/plugins/module_utils/compose_v2.py
@@ -518,6 +518,9 @@ def common_compose_argspec_ex():
             ('definition', 'project_src'),
             ('definition', 'files')
         ],
+        required_one_of=[
+            ('definition', 'project_src'),
+        ],
         required_by={
             'definition': ('project_name', ),
         },


### PR DESCRIPTION
##### SUMMARY
Fixes #885.

This bug got introduced when `project_src` was no longer made required in 9e8c367c47e6fbc094c68a4326b4a66fd21c4b59.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
compose_v2 docs fragment and module utils
