### PR TITLE
CI: Skip certain tests on Docker 27.0.0+

### DIFF
--- a/tests/integration/targets/docker_container/tasks/main.yml
+++ b/tests/integration/targets/docker_container/tasks/main.yml
@@ -32,6 +32,10 @@
 - debug:
     msg: "Using container name prefix {{ cname_prefix }}"
 
+- name: Retrieve docker host info
+  docker_host_info:
+  register: docker_host_info
+
 # Run the tests
 - block:
     - include_tasks: run-test.yml

--- a/tests/integration/targets/docker_container/tasks/tests/options.yml
+++ b/tests/integration/targets/docker_container/tasks/tests/options.yml
@@ -3890,6 +3890,7 @@ avoid such warnings, please quote the value.' in (log_options_2.warnings | defau
     - '[fe80::1%test]:90:90/tcp'
     force_kill: true
   register: published_ports_5
+  when: docker_host_info.host_info.ServerVersion is version('27.0.0', '<')
 
 - name: published_ports (ports with IP addresses, idempotent)
   docker_container:
@@ -3902,6 +3903,7 @@ avoid such warnings, please quote the value.' in (log_options_2.warnings | defau
     - '[::1]:9003:9003/tcp'
     - '[fe80::1%test]:90:90/tcp'
   register: published_ports_6
+  when: docker_host_info.host_info.ServerVersion is version('27.0.0', '<')
 
 - name: published_ports (no published ports)
   docker_container:
@@ -3977,8 +3979,8 @@ avoid such warnings, please quote the value.' in (log_options_2.warnings | defau
     - published_ports_2 is not changed
     - published_ports_3 is not changed
     - published_ports_4 is changed
-    - published_ports_5 is changed
-    - published_ports_6 is not changed
+    - (published_ports_5 is changed and published_ports_5 is not skipped) or published_ports_5 is skipped
+    - (published_ports_6 is not changed and published_ports_6 is not skipped) or published_ports_6 is skipped
     - published_ports_7 is changed
     - published_ports_8 is changed
     - published_ports_9 is changed

--- a/tests/integration/targets/docker_container/tasks/tests/ports.yml
+++ b/tests/integration/targets/docker_container/tasks/tests/ports.yml
@@ -185,64 +185,66 @@
 ## published_ports: IPv6 addresses #################################
 ####################################################################
 
-- name: published_ports -- IPv6
-  docker_container:
-    image: "{{ docker_test_image_alpine }}"
-    command: '/bin/sh -c "sleep 10m"'
-    name: "{{ cname }}"
-    state: started
-    published_ports:
-    - "[::1]:9001:9001"
-    force_kill: true
-  register: published_ports_1
+- when: docker_host_info.host_info.ServerVersion is version('27.0.0', '<')
+  block:
+    - name: published_ports -- IPv6
+      docker_container:
+        image: "{{ docker_test_image_alpine }}"
+        command: '/bin/sh -c "sleep 10m"'
+        name: "{{ cname }}"
+        state: started
+        published_ports:
+        - "[::1]:9001:9001"
+        force_kill: true
+      register: published_ports_1
 
-- name: published_ports -- IPv6 (idempotency)
-  docker_container:
-    image: "{{ docker_test_image_alpine }}"
-    command: '/bin/sh -c "sleep 10m"'
-    name: "{{ cname }}"
-    state: started
-    published_ports:
-    - "[::1]:9001:9001"
-    force_kill: true
-  register: published_ports_2
+    - name: published_ports -- IPv6 (idempotency)
+      docker_container:
+        image: "{{ docker_test_image_alpine }}"
+        command: '/bin/sh -c "sleep 10m"'
+        name: "{{ cname }}"
+        state: started
+        published_ports:
+        - "[::1]:9001:9001"
+        force_kill: true
+      register: published_ports_2
 
-- name: published_ports -- IPv6 (different IP)
-  docker_container:
-    image: "{{ docker_test_image_alpine }}"
-    command: '/bin/sh -c "sleep 10m"'
-    name: "{{ cname }}"
-    state: started
-    published_ports:
-    - "127.0.0.1:9001:9001"
-    force_kill: true
-  register: published_ports_3
+    - name: published_ports -- IPv6 (different IP)
+      docker_container:
+        image: "{{ docker_test_image_alpine }}"
+        command: '/bin/sh -c "sleep 10m"'
+        name: "{{ cname }}"
+        state: started
+        published_ports:
+        - "127.0.0.1:9001:9001"
+        force_kill: true
+      register: published_ports_3
 
-- name: published_ports -- IPv6 (hostname)
-  docker_container:
-    image: "{{ docker_test_image_alpine }}"
-    command: '/bin/sh -c "sleep 10m"'
-    name: "{{ cname }}"
-    state: started
-    published_ports:
-    - "localhost:9001:9001"
-    force_kill: true
-  register: published_ports_4
-  ignore_errors: true
+    - name: published_ports -- IPv6 (hostname)
+      docker_container:
+        image: "{{ docker_test_image_alpine }}"
+        command: '/bin/sh -c "sleep 10m"'
+        name: "{{ cname }}"
+        state: started
+        published_ports:
+        - "localhost:9001:9001"
+        force_kill: true
+      register: published_ports_4
+      ignore_errors: true
 
-- name: cleanup
-  docker_container:
-    name: "{{ cname }}"
-    state: absent
-    force_kill: true
-  diff: false
+    - name: cleanup
+      docker_container:
+        name: "{{ cname }}"
+        state: absent
+        force_kill: true
+      diff: false
 
-- assert:
-    that:
-    - published_ports_1 is changed
-    - published_ports_2 is not changed
-    - published_ports_3 is changed
-    - published_ports_4 is failed
+    - assert:
+        that:
+        - published_ports_1 is changed
+        - published_ports_2 is not changed
+        - published_ports_3 is changed
+        - published_ports_4 is failed
 
 ####################################################################
 ## publish_all_ports ###############################################


### PR DESCRIPTION
##### SUMMARY
Some docker_container tests fail now with:
```
14:01     "msg": "Error starting container 6b4b06c5e7b506f57dbd30eabe3c64c73bb389a4f63ceca78989aa46e81f1547: 500 Server Error for http+docker://localhost/v1.46/containers/6b4b06c5e7b506f57dbd30eabe3c64c73bb389a4f63ceca78989aa46e81f1547/start: Internal Server Error (\"driver failed programming external connectivity on endpoint ansible-docker-test-a6ba8f2f-options (e5b87fee0e6254dedbbce0368ddd5fa61566e4a5a21df79ea9afd40aa2fad916): NAT is disabled, omit host address in port mapping [::1]:9003:9003/tcp, or use [::]::9003 to open port 9003 for IPv6-only\nhost port must not be specified in mapping [::1]:9003:9003/tcp because NAT is disabled\")"
```
This is probably related to https://github.com/moby/moby/pull/47871.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
docker_container tests
