### PR TITLE
CI: make sure that Docker SDK for Python is installed for docker_stack* tests

### DIFF
--- a/tests/integration/targets/docker_stack/meta/main.yml
+++ b/tests/integration/targets/docker_stack/meta/main.yml
@@ -5,4 +5,5 @@
 
 dependencies:
   - setup_docker
+  - setup_docker_sdk_for_python  # needed for the Swarm modules
   - setup_remote_tmp_dir

--- a/tests/integration/targets/docker_stack_info/meta/main.yml
+++ b/tests/integration/targets/docker_stack_info/meta/main.yml
@@ -5,4 +5,5 @@
 
 dependencies:
   - setup_docker
+  - setup_docker_sdk_for_python  # needed for the Swarm modules
   - setup_remote_tmp_dir

--- a/tests/integration/targets/docker_stack_task_info/meta/main.yml
+++ b/tests/integration/targets/docker_stack_task_info/meta/main.yml
@@ -5,4 +5,5 @@
 
 dependencies:
   - setup_docker
+  - setup_docker_sdk_for_python  # needed for the Swarm modules
   - setup_remote_tmp_dir


### PR DESCRIPTION
##### SUMMARY
Prevents failing CI in #895.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
docker_stack* tests
