### PR TITLE
CI: use new container images for Compose v2 pull tests

### DIFF
--- a/tests/integration/targets/docker_compose_v2/tasks/tests/pull.yml
+++ b/tests/integration/targets/docker_compose_v2/tasks/tests/pull.yml
@@ -13,12 +13,12 @@
       services:
         {{ cname }}:
           image: {{ non_existing_image }}
-    test_service_alpine: |
+    test_service_simple: |
       version: '3'
       services:
         {{ cname }}:
-          image: {{ docker_test_image_alpine }}
-          command: /bin/sh -c 'sleep 10m'
+          image: {{ docker_test_image_simple_1 }}
+          command: 10m
           stop_grace_period: 1s
 
   block:
@@ -37,7 +37,7 @@
         name: '{{ item }}'
       loop:
         - '{{ non_existing_image }}'
-        - '{{ docker_test_image_alpine }}'
+        - '{{ docker_test_image_simple_1 }}'
 
 ####################################################################
 ## Missing image ###################################################
@@ -95,10 +95,10 @@
 ## Regular image ###################################################
 ####################################################################
 
-    - name: Template project file with Alpine image
+    - name: Template project file with simple image
       copy:
         dest: '{{ project_src }}/docker-compose.yml'
-        content: '{{ test_service_alpine }}'
+        content: '{{ test_service_simple }}'
 
     - name: Present with pull=missing (check)
       docker_compose_v2:

--- a/tests/integration/targets/docker_compose_v2_pull/tasks/tests/pull.yml
+++ b/tests/integration/targets/docker_compose_v2_pull/tasks/tests/pull.yml
@@ -13,12 +13,12 @@
       services:
         {{ cname }}:
           image: {{ non_existing_image }}
-    test_service_alpine: |
+    test_service_simple: |
       version: '3'
       services:
         {{ cname }}:
-          image: {{ docker_test_image_alpine }}
-          command: /bin/sh -c 'sleep 10m'
+          image: {{ docker_test_image_simple_1 }}
+          command: 10m
           stop_grace_period: 1s
 
   block:
@@ -37,7 +37,7 @@
         name: '{{ item }}'
       loop:
         - '{{ non_existing_image }}'
-        - '{{ docker_test_image_alpine }}'
+        - '{{ docker_test_image_simple_1 }}'
 
 ####################################################################
 ## Missing image ###################################################
@@ -72,10 +72,10 @@
 ## Regular image ###################################################
 ####################################################################
 
-    - name: Template project file with Alpine image
+    - name: Template project file with simple image
       copy:
         dest: '{{ project_src }}/docker-compose.yml'
-        content: '{{ test_service_alpine }}'
+        content: '{{ test_service_simple }}'
 
     - when: docker_compose_version is version('2.22.0', '>=')
       block:
@@ -107,7 +107,7 @@
 
         - name: Make sure image is not around
           docker_image_remove:
-            name: '{{ docker_test_image_alpine }}'
+            name: '{{ docker_test_image_simple_1 }}'
 
         - name: Pull with policy=always (check)
           docker_compose_v2_pull:

--- a/tests/integration/targets/setup_docker/vars/main.yml
+++ b/tests/integration/targets/setup_docker/vars/main.yml
@@ -17,3 +17,5 @@ docker_test_image_alpine: quay.io/ansible/docker-test-containers:alpine3.8
 docker_test_image_alpine_different: quay.io/ansible/docker-test-containers:alpine3.7
 docker_test_image_registry_nginx: quay.io/ansible/docker-test-containers:nginx-alpine
 docker_test_image_registry: registry:2.6.1
+docker_test_image_simple_1: ghcr.io/ansible-collections/simple-1:tag
+docker_test_image_simple_2: ghcr.io/ansible-collections/simple-2:tag


### PR DESCRIPTION
##### SUMMARY
This hopefully makes these tests a lot more stable in CI.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
docker_compose_v2 tests
docker_compose_v2_pull tests
