### PR TITLE
Support ansible-test integration tests for arm64

### DIFF
--- a/tests/integration/targets/setup_docker/tasks/Debian.yml
+++ b/tests/integration/targets/setup_docker/tasks/Debian.yml
@@ -17,22 +17,9 @@
 - name: Add gpg key
   shell: curl -fsSL https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg >key && apt-key add key
 
-- name: Debug architecture
-  debug:
-    msg: '{{ ansible_architecture }}'
-
-- name: Set default arch amd64 for Docker repo
-  set_fact:
-    docker_arch: amd64
-
-- name: Set arch arm64 for Docker repo when on aarch64
-  set_fact:
-    docker_arch: arm64
-  when: ansible_architecture == 'aarch64'
-
 - name: Add Docker repo
   apt_repository:
-    repo: deb [arch={{ docker_arch }}] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable
+    repo: deb [arch={{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable
     state: present
 
 - block:

--- a/tests/integration/targets/setup_docker/tasks/Debian.yml
+++ b/tests/integration/targets/setup_docker/tasks/Debian.yml
@@ -17,9 +17,22 @@
 - name: Add gpg key
   shell: curl -fsSL https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg >key && apt-key add key
 
+- name: Debug architecture
+  debug:
+    msg: '{{ ansible_architecture }}'
+
+- name: Set default arch amd64 for Docker repo
+  set_fact:
+    docker_arch: amd64
+
+- name: Set arch arm64 for Docker repo when on aarch64
+  set_fact:
+    docker_arch: arm64
+  when: ansible_architecture == 'aarch64'
+
 - name: Add Docker repo
   apt_repository:
-    repo: deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable
+    repo: deb [arch={{ docker_arch }}] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable
     state: present
 
 - block:


### PR DESCRIPTION
##### SUMMARY
The `ansible-test integration` tests are currently failing when run with the `--docker` environment on a Debian-based OS running on `arm64` architecture.

This is because the step that adds the Docker repository to `apt` is currently hardcoded to add only the `amd64` repository.

So, in later steps when we try to use `apt` to find and install the `docker-ce-cli` package, this step fails on `arm64` hosts with this error message: `No package matching 'docker-ce-cli' is available`.

This PR updates the test setup steps for Debian-based hosts to detect the host's architecture and add a repository that supports this architecture.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`tests/integration/targets/setup_docker/tasks/Debian.yml`

##### ADDITIONAL INFORMATION


<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
How to reproduce the issue:

- Run `ansible-test integration --docker` on a Debian-based host with `arm64` architecture
- Expected: Tests should pass
- Actual: Tests fail with this error:
```
TASK [setup_docker : Install Docker CE] ****************************************
fatal: [testhost]: FAILED! => {"changed": false, "msg": "No package matching 'docker-ce-cli' is available"}
```

<!--- Paste verbatim command output below, e.g. before and after your change -->

##### BEHAVIOR BEFORE/AFTER THIS FIX

**Before:**
```
ansible-test integration --docker
...
...
...
TASK [setup_docker : Install Docker CE] ****************************************
fatal: [testhost]: FAILED! => {"changed": false, "msg": "No package matching 'docker-ce-cli' is available"}
```

**After:**
```
ansible-test integration --docker
...
...
...
TASK [setup_docker : Install Docker CE] ****************************************
changed: [testhost]
```