### PR TITLE
docker_container: add "device_cgroup_rules" option

### DIFF
--- a/changelogs/fragments/910-docker_container-device_cgroup_rules.yml
+++ b/changelogs/fragments/910-docker_container-device_cgroup_rules.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "docker_container - add support for ``device_cgroup_rules`` (https://github.com/ansible-collections/community.docker/pull/910)."

--- a/plugins/module_utils/module_container/base.py
+++ b/plugins/module_utils/module_container/base.py
@@ -895,6 +895,11 @@ OPTION_DEVICE_REQUESTS = (
     ))
 )
 
+OPTION_DEVICE_CGROUP_RULES = (
+    OptionGroup()
+    .add_option('device_cgroup_rules', type='list', elements='str')
+)
+
 OPTION_DNS_SERVERS = (
     OptionGroup()
     .add_option('dns_servers', type='list', elements='str')
@@ -1194,6 +1199,7 @@ OPTIONS = [
     OPTION_DEVICE_READ_IOPS,
     OPTION_DEVICE_WRITE_IOPS,
     OPTION_DEVICE_REQUESTS,
+    OPTION_DEVICE_CGROUP_RULES,
     OPTION_DNS_SERVERS,
     OPTION_DNS_OPTS,
     OPTION_DNS_SEARCH_DOMAINS,

--- a/plugins/module_utils/module_container/docker_api.py
+++ b/plugins/module_utils/module_container/docker_api.py
@@ -44,6 +44,7 @@ from ansible_collections.community.docker.plugins.module_utils.module_container.
     OPTION_DEVICE_READ_IOPS,
     OPTION_DEVICE_WRITE_IOPS,
     OPTION_DEVICE_REQUESTS,
+    OPTION_DEVICE_CGROUP_RULES,
     OPTION_DNS_SERVERS,
     OPTION_DNS_OPTS,
     OPTION_DNS_SEARCH_DOMAINS,
@@ -1289,6 +1290,8 @@ OPTION_DEVICE_WRITE_IOPS.add_engine('docker_api', DockerAPIEngine.host_config_va
 
 OPTION_DEVICE_REQUESTS.add_engine('docker_api', DockerAPIEngine.host_config_value(
     'DeviceRequests', min_api_version='1.40', preprocess_value=_preprocess_device_requests))
+
+OPTION_DEVICE_CGROUP_RULES.add_engine('docker_api', DockerAPIEngine.host_config_value('DeviceCgroupRules', min_api_version='1.28'))
 
 OPTION_DNS_SERVERS.add_engine('docker_api', DockerAPIEngine.host_config_value('Dns'))
 

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -299,6 +299,12 @@ options:
           - Driver-specific options.
         type: dict
     version_added: 0.1.0
+  device_cgroup_rules:
+    description:
+      - List of cgroup rules to apply to the container.
+    type: list
+    elements: str
+    version_added: 3.11.0
   dns_opts:
     description:
       - List of DNS options.

--- a/tests/integration/targets/docker_container/tasks/tests/options.yml
+++ b/tests/integration/targets/docker_container/tasks/tests/options.yml
@@ -1144,6 +1144,66 @@
   when: docker_api_version is version('1.40', '<')
 
 ####################################################################
+## device_cgroup_rules ###################################################
+####################################################################
+
+- name: device_cgroup_rules
+  docker_container:
+    image: "{{ docker_test_image_alpine }}"
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    force_kill: true
+    device_cgroup_rules:
+    - "c 42:* rmw"
+  register: device_cgroup_rules_1
+  ignore_errors: true
+
+- name: cgroupns_mode (idempotency)
+  docker_container:
+    image: "{{ docker_test_image_alpine }}"
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    force_kill: true
+    device_cgroup_rules:
+    - "c 42:* rmw"
+  register: device_cgroup_rules_2
+  ignore_errors: true
+
+- name: cgroupns_mode (changed)
+  docker_container:
+    image: "{{ docker_test_image_alpine }}"
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    force_kill: true
+    device_cgroup_rules:
+    - "c 189:* rmw"
+  register: device_cgroup_rules_3
+  ignore_errors: true
+
+- name: cleanup
+  docker_container:
+    name: "{{ cname }}"
+    state: absent
+    force_kill: true
+  diff: false
+
+- assert:
+    that:
+    - device_cgroup_rules_1 is changed
+    - device_cgroup_rules_2 is not changed
+    - device_cgroup_rules_3 is changed
+  when: docker_api_version is version('1.28', '>=')
+- assert:
+    that:
+    - device_cgroup_rules_1 is failed
+    - |
+      ('API version is ' ~ docker_api_version ~ '.') in device_cgroup_rules_1.msg and 'Minimum version required is 1.28 ' in device_cgroup_rules_1.msg
+  when: docker_api_version is version('1.28', '<')
+
+####################################################################
 ## dns_opts ########################################################
 ####################################################################
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds a new option `device_cgroup_rules` (`HostConfig.DeviceCgroupRules` in the [API](https://docs.docker.com/engine/api/v1.28/#tag/Container/operation/ContainerCreate) `>=v1.28`) - allows specifying a list of cgroup rules (https://docs.docker.com/reference/cli/docker/container/run/#device-cgroup-rule).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_container

