### PR TITLE
[stable-2] docker_container: prevent infinite loop if removal_wait_timeout is specified

### DIFF
--- a/changelogs/fragments/922-docker_container-wait-fix.yml
+++ b/changelogs/fragments/922-docker_container-wait-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "docker_container - fix possible infinite loop if ``removal_wait_timeout`` is set (https://github.com/ansible-collections/community.docker/pull/922)."

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -2900,7 +2900,7 @@ class ContainerManager(DockerBaseClass):
                 self.fail(msg.format(container_id, state))
             # Wait
             if max_wait is not None:
-                if total_wait > max_wait:
+                if total_wait > max_wait or delay < 1E-4:
                     msg = 'Timeout of {1} seconds exceeded while waiting for container "{0}"'
                     self.fail(msg.format(container_id, max_wait))
                 if total_wait + delay > max_wait:


### PR DESCRIPTION
##### SUMMARY
Backport of #922 to stable-2.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container
