### PR TITLE
[stable-2] Use registry image from ghcr.io.

### DIFF
--- a/tests/integration/targets/setup_docker/vars/main.yml
+++ b/tests/integration/targets/setup_docker/vars/main.yml
@@ -8,4 +8,4 @@ docker_test_image_busybox: quay.io/ansible/docker-test-containers:busybox
 docker_test_image_alpine: quay.io/ansible/docker-test-containers:alpine3.8
 docker_test_image_alpine_different: quay.io/ansible/docker-test-containers:alpine3.7
 docker_test_image_registry_nginx: quay.io/ansible/docker-test-containers:nginx-alpine
-docker_test_image_registry: registry:2.6.1
+docker_test_image_registry: ghcr.io/ansible-collections/community.docker/docker-distribution:2.8.3


### PR DESCRIPTION
##### SUMMARY
That's the only image we use from docker.io for stable-2.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
Docker test images
