### PR TITLE
docker_compose_v2* modules: use `--progress json` for Compose 2.29.0+

### DIFF
--- a/changelogs/fragments/931-compose-2.29.0-json.yml
+++ b/changelogs/fragments/931-compose-2.29.0-json.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "docker_compose_v2* modules - support Docker Compose 2.29.0's ``json`` progress writer to avoid having to parse text output (https://github.com/ansible-collections/community.docker/pull/931)."

--- a/plugins/module_utils/compose_v2.py
+++ b/plugins/module_utils/compose_v2.py
@@ -392,7 +392,22 @@ def parse_json_events(stderr, warn_function=None):
                     .format(line, exc)
                 )
             continue
-        if line_data.get('error'):
+        if line_data.get('tail'):
+            resource_type = ResourceType.UNKNOWN
+            msg = line_data.get('text')
+            status = 'Error'
+            if isinstance(msg, str) and msg.lower().startswith('warning:'):
+                # For some reason, Writer.TailMsgf() is always used for errors *except* in one place,
+                # where its message is prepended with 'WARNING: ' (in pkg/compose/pull.go).
+                status = 'Warning'
+                msg = msg[len('warning:'):].lstrip()
+            event = Event(
+                resource_type,
+                None,
+                status,
+                msg,
+            )
+        elif line_data.get('error'):
             resource_type = ResourceType.UNKNOWN
             event = Event(
                 resource_type,

--- a/plugins/module_utils/compose_v2.py
+++ b/plugins/module_utils/compose_v2.py
@@ -493,7 +493,7 @@ def parse_events(stderr, dry_run=False, warn_function=None):
             index_event = _find_last_event_for(events, match.group('resource_id'))
             if index_event is not None:
                 index, event = index_event
-                events[-1] = _concat_event_msg(event, match.group('msg'))
+                events[index] = _concat_event_msg(event, match.group('msg'))
         event, parsed = _extract_logfmt_event(line, warn_function=warn_function)
         if event is not None:
             events.append(event)

--- a/plugins/module_utils/compose_v2.py
+++ b/plugins/module_utils/compose_v2.py
@@ -377,7 +377,7 @@ def parse_json_events(stderr, warn_function=None):
                 continue
             if warn_function:
                 warn_function(
-                    'Found non-JSON line: {0!r}. Please report this at '
+                    'Cannot parse event from non-JSON line: {0!r}. Please report this at '
                     'https://github.com/ansible-collections/community.docker/issues/new?assignees=&labels=&projects=&template=bug_report.md'
                     .format(line)
                 )
@@ -412,9 +412,9 @@ def parse_json_events(stderr, warn_function=None):
                 except KeyError:
                     if warn_function:
                         warn_function(
-                            'Unknown resource type {0!r}. Please report this at '
+                            'Unknown resource type {0!r} in line {1!r}. Please report this at '
                             'https://github.com/ansible-collections/community.docker/issues/new?assignees=&labels=&projects=&template=bug_report.md'
-                            .format(resource_type_str)
+                            .format(resource_type_str, line)
                         )
                     resource_type = ResourceType.UNKNOWN
             elif text in DOCKER_STATUS_PULL:

--- a/tests/integration/targets/docker_compose_v2/tasks/tests/definition.yml
+++ b/tests/integration/targets/docker_compose_v2/tasks/tests/definition.yml
@@ -77,7 +77,7 @@
     - assert:
         that:
           - present_1_check is changed
-          - present_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_1_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_1 is changed
           - present_1.containers | length == 1
           - present_1.containers[0].Name == pname ~ '-' ~ cname ~ '-1'
@@ -86,15 +86,15 @@
           - present_1.images[0].ContainerName == pname ~ '-' ~ cname ~ '-1'
           - present_1.images[0].Repository == (docker_test_image_alpine | split(':') | first)
           - present_1.images[0].Tag == (docker_test_image_alpine | split(':') | last)
-          - present_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_1.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_2_check is not changed
-          - present_2_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_2_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_2 is not changed
-          - present_2.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_2.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_3_check is changed
-          - present_3_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_3_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_3 is changed
-          - present_3.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_3.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
 
 ####################################################################
 ## Absent ##########################################################
@@ -133,13 +133,13 @@
     - assert:
         that:
           - absent_1_check is changed
-          - absent_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - absent_1_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - absent_1 is changed
-          - absent_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - absent_1.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - absent_2_check is not changed
-          - absent_2_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - absent_2_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - absent_2 is not changed
-          - absent_2.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - absent_2.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
 
 ####################################################################
 ## Stopping and starting ###########################################
@@ -259,30 +259,30 @@
     - assert:
         that:
           - present_1_check is changed
-          - present_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_1_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_1 is changed
-          - present_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_1.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_2_check is not changed
-          - present_2_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_2_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_2 is not changed
-          - present_2.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_2.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_3_check is changed
-          - present_3_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_3_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_3 is changed
-          - present_3.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_3.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_4_check is not changed
-          - present_4_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_4_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_4 is not changed
-          - present_4.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_4.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_5_check is changed
-          - present_5_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_5_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_5 is changed
-          - present_5.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_5.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_6_check is changed
-          - present_6_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_6_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_6 is changed
-          - present_6.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_6.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_7_check is changed
-          - present_7_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_7_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_7 is changed
-          - present_7.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_7.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0

--- a/tests/integration/targets/docker_compose_v2/tasks/tests/pull.yml
+++ b/tests/integration/targets/docker_compose_v2/tasks/tests/pull.yml
@@ -84,16 +84,16 @@
         that:
           - present_1_check is failed or present_1_check is changed
           - present_1_check is changed or present_1_check.msg.startswith('General error:')
-          - present_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_1_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_1 is failed
           - present_1.msg.startswith('General error:')
-          - present_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_1.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_2_check is failed
           - present_2_check.msg.startswith('Error when processing ' ~ cname ~ ':')
-          - present_2_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_2_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_2 is failed
           - present_2.msg.startswith('Error when processing ' ~ cname ~ ':')
-          - present_2.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_2.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
 
 ####################################################################
 ## Regular image ###################################################
@@ -194,32 +194,32 @@
           - present_1_check is changed
           - present_1_check.actions | selectattr('status', 'eq', 'Pulling') | first
           - present_1_check.actions | selectattr('status', 'eq', 'Creating') | first
-          - present_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_1_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_1 is changed
           - present_1.actions | selectattr('status', 'eq', 'Pulling') | first
           - present_1.actions | selectattr('status', 'eq', 'Creating') | first
-          - present_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_1.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_2_check is not changed
-          - present_2_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_2_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_2 is not changed
-          - present_2.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_2.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_3_check is changed
           - present_3_check.actions | selectattr('status', 'eq', 'Pulling') | first
           - present_3_check.actions | selectattr('status', 'eq', 'Creating') | length == 0
           - present_3_check.actions | selectattr('status', 'eq', 'Recreating') | length == 0
-          - present_3_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_3_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_3 is not changed
           - present_3.actions | selectattr('status', 'eq', 'Pulling') | first
           - present_3.actions | selectattr('status', 'eq', 'Creating') | length == 0
           - present_3.actions | selectattr('status', 'eq', 'Recreating') | length == 0
-          - present_3.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_3.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_4_check is changed
           - present_4_check.actions | selectattr('status', 'eq', 'Pulling') | length == 0
-          - present_4_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_4_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_4 is changed
           - present_4.actions | selectattr('status', 'eq', 'Pulling') | length == 0
-          - present_4.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_4.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_5_check is not changed
-          - present_5_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_5_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_5 is not changed
-          - present_5.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_5.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0

--- a/tests/integration/targets/docker_compose_v2/tasks/tests/start-stop.yml
+++ b/tests/integration/targets/docker_compose_v2/tasks/tests/start-stop.yml
@@ -89,7 +89,7 @@
     - assert:
         that:
           - present_1_check is changed
-          - present_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_1_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_1 is changed
           - present_1.containers | length == 1
           - present_1.containers[0].Name == pname ~ '-' ~ cname ~ '-1'
@@ -98,15 +98,15 @@
           - present_1.images[0].ContainerName == pname ~ '-' ~ cname ~ '-1'
           - present_1.images[0].Repository == (docker_test_image_alpine | split(':') | first)
           - present_1.images[0].Tag == (docker_test_image_alpine | split(':') | last)
-          - present_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_1.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_2_check is not changed
-          - present_2_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_2_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_2 is not changed
-          - present_2.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_2.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_3_check is changed
-          - present_3_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_3_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_3 is changed
-          - present_3.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_3.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
 
 ####################################################################
 ## Absent ##########################################################
@@ -141,13 +141,13 @@
     - assert:
         that:
           - absent_1_check is changed
-          - absent_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - absent_1_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - absent_1 is changed
-          - absent_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - absent_1.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - absent_2_check is not changed
-          - absent_2_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - absent_2_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - absent_2 is not changed
-          - absent_2.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - absent_2.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
 
 ####################################################################
 ## Stopping and starting ###########################################
@@ -257,30 +257,30 @@
     - assert:
         that:
           - present_1_check is changed
-          - present_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_1_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_1 is changed
-          - present_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_1.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_2_check is not changed
-          - present_2_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_2_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_2 is not changed
-          - present_2.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_2.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_3_check is changed
-          - present_3_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_3_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_3 is changed
-          - present_3.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_3.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_4_check is not changed
-          - present_4_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_4_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_4 is not changed
-          - present_4.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_4.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_5_check is changed
-          - present_5_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_5_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_5 is changed
-          - present_5.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_5.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_6_check is changed
-          - present_6_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_6_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_6 is changed
-          - present_6.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_6.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_7_check is changed
-          - present_7_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_7_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - present_7 is changed
-          - present_7.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - present_7.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0

--- a/tests/integration/targets/docker_compose_v2_pull/tasks/tests/pull.yml
+++ b/tests/integration/targets/docker_compose_v2_pull/tasks/tests/pull.yml
@@ -65,10 +65,10 @@
         that:
           - pull_1_check is failed or pull_1_check is changed
           - pull_1_check is changed or pull_1_check.msg.startswith('Error when processing ')
-          - pull_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - pull_1_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
           - pull_1 is failed
           - pull_1.msg.startswith('Error when processing ')
-          - pull_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+          - pull_1.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
 
 ####################################################################
 ## Regular image ###################################################
@@ -141,26 +141,26 @@
             that:
               - pull_1_check is changed
               - pull_1_check.actions | selectattr('status', 'eq', 'Pulling') | first
-              - pull_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+              - pull_1_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
               - pull_1 is changed
               - pull_1.actions | selectattr('status', 'eq', 'Pulling') | first
-              - pull_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+              - pull_1.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
               - pull_2_check is not changed
-              - pull_2_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+              - pull_2_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
               - pull_2 is not changed
-              - pull_2.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+              - pull_2.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
               - pull_3_check is changed
               - pull_3_check.actions | selectattr('status', 'eq', 'Pulling') | first
-              - pull_3_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+              - pull_3_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
               - pull_3 is changed
               - pull_3.actions | selectattr('status', 'eq', 'Pulling') | first
-              - pull_3.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+              - pull_3.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
               - pull_4_check is changed
               - pull_4_check.actions | selectattr('status', 'eq', 'Pulling') | first
-              - pull_4_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+              - pull_4_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
               - pull_4 is not changed
               - pull_4.actions | selectattr('status', 'eq', 'Pulling') | first
-              - pull_4.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+              - pull_4.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
 
     - when: docker_compose_version is version('2.22.0', '<')
       block:
@@ -194,13 +194,13 @@
             that:
               - pull_1_check is changed
               - pull_1_check.actions | selectattr('status', 'eq', 'Pulling') | first
-              - pull_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+              - pull_1_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
               - pull_1 is changed
               - pull_1.actions | selectattr('status', 'eq', 'Pulling') | first
-              - pull_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+              - pull_1.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
               - pull_2_check is changed
               - pull_2_check.actions | selectattr('status', 'eq', 'Pulling') | first
-              - pull_2_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+              - pull_2_check.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0
               - pull_2 is not changed
               - pull_2.actions | selectattr('status', 'eq', 'Pulling') | first
-              - pull_2.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
+              - pull_2.warnings | default([]) | select('regex', 'Cannot parse event from ') | length == 0


### PR DESCRIPTION
##### SUMMARY
Compose 2.29.0 is out: https://github.com/docker/compose/releases/tag/v2.29.0

It features `--progress json` output (https://github.com/docker/compose/pull/11478), which makes it easier to parse its output.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docker_compose_v2*
