### PR TITLE
docker_compose_v2* modules: check for unparsable messages in integration tests

### DIFF
--- a/tests/integration/targets/docker_compose_v2/tasks/tests/definition.yml
+++ b/tests/integration/targets/docker_compose_v2/tasks/tests/definition.yml
@@ -77,6 +77,7 @@
     - assert:
         that:
           - present_1_check is changed
+          - present_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_1 is changed
           - present_1.containers | length == 1
           - present_1.containers[0].Name == pname ~ '-' ~ cname ~ '-1'
@@ -85,10 +86,15 @@
           - present_1.images[0].ContainerName == pname ~ '-' ~ cname ~ '-1'
           - present_1.images[0].Repository == (docker_test_image_alpine | split(':') | first)
           - present_1.images[0].Tag == (docker_test_image_alpine | split(':') | last)
+          - present_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_2_check is not changed
+          - present_2_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_2 is not changed
+          - present_2.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_3_check is changed
+          - present_3_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_3 is changed
+          - present_3.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
 
 ####################################################################
 ## Absent ##########################################################
@@ -127,9 +133,13 @@
     - assert:
         that:
           - absent_1_check is changed
+          - absent_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - absent_1 is changed
+          - absent_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - absent_2_check is not changed
+          - absent_2_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - absent_2 is not changed
+          - absent_2.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
 
 ####################################################################
 ## Stopping and starting ###########################################
@@ -249,16 +259,30 @@
     - assert:
         that:
           - present_1_check is changed
+          - present_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_1 is changed
+          - present_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_2_check is not changed
+          - present_2_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_2 is not changed
+          - present_2.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_3_check is changed
+          - present_3_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_3 is changed
+          - present_3.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_4_check is not changed
+          - present_4_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_4 is not changed
+          - present_4.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_5_check is changed
+          - present_5_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_5 is changed
+          - present_5.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_6_check is changed
+          - present_6_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_6 is changed
+          - present_6.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_7_check is changed
+          - present_7_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_7 is changed
+          - present_7.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0

--- a/tests/integration/targets/docker_compose_v2/tasks/tests/pull.yml
+++ b/tests/integration/targets/docker_compose_v2/tasks/tests/pull.yml
@@ -84,12 +84,16 @@
         that:
           - present_1_check is failed or present_1_check is changed
           - present_1_check is changed or present_1_check.msg.startswith('General error:')
+          - present_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_1 is failed
           - present_1.msg.startswith('General error:')
+          - present_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_2_check is failed
           - present_2_check.msg.startswith('Error when processing ' ~ cname ~ ':')
+          - present_2_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_2 is failed
           - present_2.msg.startswith('Error when processing ' ~ cname ~ ':')
+          - present_2.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
 
 ####################################################################
 ## Regular image ###################################################
@@ -190,22 +194,32 @@
           - present_1_check is changed
           - present_1_check.actions | selectattr('status', 'eq', 'Pulling') | first
           - present_1_check.actions | selectattr('status', 'eq', 'Creating') | first
+          - present_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_1 is changed
           - present_1.actions | selectattr('status', 'eq', 'Pulling') | first
           - present_1.actions | selectattr('status', 'eq', 'Creating') | first
+          - present_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_2_check is not changed
+          - present_2_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_2 is not changed
+          - present_2.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_3_check is changed
           - present_3_check.actions | selectattr('status', 'eq', 'Pulling') | first
           - present_3_check.actions | selectattr('status', 'eq', 'Creating') | length == 0
           - present_3_check.actions | selectattr('status', 'eq', 'Recreating') | length == 0
+          - present_3_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_3 is not changed
           - present_3.actions | selectattr('status', 'eq', 'Pulling') | first
           - present_3.actions | selectattr('status', 'eq', 'Creating') | length == 0
           - present_3.actions | selectattr('status', 'eq', 'Recreating') | length == 0
+          - present_3.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_4_check is changed
           - present_4_check.actions | selectattr('status', 'eq', 'Pulling') | length == 0
+          - present_4_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_4 is changed
           - present_4.actions | selectattr('status', 'eq', 'Pulling') | length == 0
+          - present_4.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_5_check is not changed
+          - present_5_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_5 is not changed
+          - present_5.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0

--- a/tests/integration/targets/docker_compose_v2/tasks/tests/start-stop.yml
+++ b/tests/integration/targets/docker_compose_v2/tasks/tests/start-stop.yml
@@ -89,6 +89,7 @@
     - assert:
         that:
           - present_1_check is changed
+          - present_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_1 is changed
           - present_1.containers | length == 1
           - present_1.containers[0].Name == pname ~ '-' ~ cname ~ '-1'
@@ -97,10 +98,15 @@
           - present_1.images[0].ContainerName == pname ~ '-' ~ cname ~ '-1'
           - present_1.images[0].Repository == (docker_test_image_alpine | split(':') | first)
           - present_1.images[0].Tag == (docker_test_image_alpine | split(':') | last)
+          - present_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_2_check is not changed
+          - present_2_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_2 is not changed
+          - present_2.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_3_check is changed
+          - present_3_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_3 is changed
+          - present_3.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
 
 ####################################################################
 ## Absent ##########################################################
@@ -135,9 +141,13 @@
     - assert:
         that:
           - absent_1_check is changed
+          - absent_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - absent_1 is changed
+          - absent_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - absent_2_check is not changed
+          - absent_2_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - absent_2 is not changed
+          - absent_2.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
 
 ####################################################################
 ## Stopping and starting ###########################################
@@ -247,16 +257,30 @@
     - assert:
         that:
           - present_1_check is changed
+          - present_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_1 is changed
+          - present_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_2_check is not changed
+          - present_2_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_2 is not changed
+          - present_2.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_3_check is changed
+          - present_3_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_3 is changed
+          - present_3.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_4_check is not changed
+          - present_4_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_4 is not changed
+          - present_4.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_5_check is changed
+          - present_5_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_5 is changed
+          - present_5.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_6_check is changed
+          - present_6_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_6 is changed
+          - present_6.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_7_check is changed
+          - present_7_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - present_7 is changed
+          - present_7.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0

--- a/tests/integration/targets/docker_compose_v2_pull/tasks/tests/pull.yml
+++ b/tests/integration/targets/docker_compose_v2_pull/tasks/tests/pull.yml
@@ -65,8 +65,10 @@
         that:
           - pull_1_check is failed or pull_1_check is changed
           - pull_1_check is changed or pull_1_check.msg.startswith('Error when processing ')
+          - pull_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
           - pull_1 is failed
           - pull_1.msg.startswith('Error when processing ')
+          - pull_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
 
 ####################################################################
 ## Regular image ###################################################
@@ -139,18 +141,26 @@
             that:
               - pull_1_check is changed
               - pull_1_check.actions | selectattr('status', 'eq', 'Pulling') | first
+              - pull_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
               - pull_1 is changed
               - pull_1.actions | selectattr('status', 'eq', 'Pulling') | first
+              - pull_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
               - pull_2_check is not changed
+              - pull_2_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
               - pull_2 is not changed
+              - pull_2.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
               - pull_3_check is changed
               - pull_3_check.actions | selectattr('status', 'eq', 'Pulling') | first
+              - pull_3_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
               - pull_3 is changed
               - pull_3.actions | selectattr('status', 'eq', 'Pulling') | first
+              - pull_3.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
               - pull_4_check is changed
               - pull_4_check.actions | selectattr('status', 'eq', 'Pulling') | first
+              - pull_4_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
               - pull_4 is not changed
               - pull_4.actions | selectattr('status', 'eq', 'Pulling') | first
+              - pull_4.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
 
     - when: docker_compose_version is version('2.22.0', '<')
       block:
@@ -184,9 +194,13 @@
             that:
               - pull_1_check is changed
               - pull_1_check.actions | selectattr('status', 'eq', 'Pulling') | first
+              - pull_1_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
               - pull_1 is changed
               - pull_1.actions | selectattr('status', 'eq', 'Pulling') | first
+              - pull_1.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
               - pull_2_check is changed
               - pull_2_check.actions | selectattr('status', 'eq', 'Pulling') | first
+              - pull_2_check.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0
               - pull_2 is not changed
               - pull_2.actions | selectattr('status', 'eq', 'Pulling') | first
+              - pull_2.warnings | default([]) | select('regex', 'Cannot parse event from line:') | length == 0


### PR DESCRIPTION
##### SUMMARY
Flag such messages in CI so we can fix them before they impact too many users.

Extracted from #931.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
docker_compose_v2* integration tests
