### PR TITLE
docker_container: pass networks to Daemon on container creation

### DIFF
--- a/changelogs/fragments/933-docker_container-networks.yml
+++ b/changelogs/fragments/933-docker_container-networks.yml
@@ -1,7 +1,11 @@
 minor_changes:
-  - "docker_container - when creating a network, directly pass the networks to connect to to the Docker Daemon.
-     This makes creation more efficient and works around a bug in Docker Daemon that does not use the specified
-     MAC address in at least some cases, though only for creation (https://github.com/ansible-collections/community.docker/pull/933)."
+  - "docker_container - when creating a container, directly pass all networks to connect to to the Docker Daemon
+     for API version 1.44 and newer. This makes creation more efficient and works around a bug in Docker Daemon that
+     does not use the specified MAC address in at least some cases, though only for creation
+     (https://github.com/ansible-collections/community.docker/pull/933)."
+bugfixes:
+  - "docker_container - restore behavior of the module from community.docker 2.x.y that passes the first network
+     to the Docker Deamon while creating the container (https://github.com/ansible-collections/community.docker/pull/933)."
 known_issues:
   - "docker_container - when specifying a MAC address for a container's network, and the network is attached
      after container creation (for example, due to idempotency checks), the MAC address is at least in some

--- a/changelogs/fragments/933-docker_container-networks.yml
+++ b/changelogs/fragments/933-docker_container-networks.yml
@@ -1,0 +1,8 @@
+minor_changes:
+  - "docker_container - when creating a network, directly pass the networks to connect to to the Docker Daemon.
+     This makes creation more efficient and works around a bug in Docker Daemon that does not use the specified
+     MAC address in at least some cases, though only for creation (https://github.com/ansible-collections/community.docker/pull/933)."
+known_issues:
+  - "docker_container - when specifying a MAC address for a container's network, and the network is attached
+     after container creation (for example, due to idempotency checks), the MAC address is at least in some
+     cases ignored by the Docker Daemon (https://github.com/ansible-collections/community.docker/pull/933)."

--- a/plugins/module_utils/module_container/base.py
+++ b/plugins/module_utils/module_container/base.py
@@ -299,6 +299,9 @@ class EngineDriver(object):
     def connect_container_to_network(self, client, container_id, network_id, parameters=None):
         pass
 
+    def create_container_supports_more_than_one_network(self, client):
+        return False
+
     @abc.abstractmethod
     def create_container(self, client, container_name, create_parameters, networks=None):
         pass

--- a/plugins/module_utils/module_container/base.py
+++ b/plugins/module_utils/module_container/base.py
@@ -300,7 +300,7 @@ class EngineDriver(object):
         pass
 
     @abc.abstractmethod
-    def create_container(self, client, container_name, create_parameters):
+    def create_container(self, client, container_name, create_parameters, networks=None):
         pass
 
     @abc.abstractmethod

--- a/plugins/module_utils/module_container/module.py
+++ b/plugins/module_utils/module_container/module.py
@@ -766,12 +766,19 @@ class ContainerManager(DockerBaseClass):
         self.log("create container")
         self.log("image: %s parameters:" % image)
         self.log(create_parameters, pretty_print=True)
-        self.results['actions'].append(dict(created="Created container", create_parameters=create_parameters))
+        networks = {}
+        if self.module.params['networks']:
+            for network in self.module.params['networks']:
+                networks[network['name']] = {
+                    key: value for key, value in network.items()
+                    if key not in ('name', 'id')
+                }
+        self.results['actions'].append(dict(created="Created container", create_parameters=create_parameters, networks=networks))
         self.results['changed'] = True
         new_container = None
         if not self.check_mode:
             try:
-                container_id = self.engine_driver.create_container(self.client, self.param_name, create_parameters)
+                container_id = self.engine_driver.create_container(self.client, self.param_name, create_parameters, networks=networks)
             except Exception as exc:
                 self.fail("Error creating container: %s" % to_native(exc))
             return self._get_container(container_id)

--- a/plugins/module_utils/module_container/module.py
+++ b/plugins/module_utils/module_container/module.py
@@ -767,8 +767,11 @@ class ContainerManager(DockerBaseClass):
         self.log("image: %s parameters:" % image)
         self.log(create_parameters, pretty_print=True)
         networks = {}
-        if self.module.params['networks']:
-            for network in self.module.params['networks']:
+        if self.param_networks_cli_compatible and self.module.params['networks']:
+            network_list = self.module.params['networks']
+            if not self.engine_driver.create_container_supports_more_than_one_network(self.client):
+                network_list = network_list[:1]
+            for network in network_list:
                 networks[network['name']] = {
                     key: value for key, value in network.items()
                     if key not in ('name', 'id')

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -722,6 +722,9 @@ options:
         description:
           - Endpoint MAC address (for example, V(92:d0:c6:0a:29:33)).
           - This is only available for Docker API version 1.44 and later.
+          - Please note that when a container is attached to a network after creation,
+            this is currently ignored by the Docker Daemon at least in some cases.
+            When passed on creation, this seems to work better.
         type: str
         version_added: 3.6.0
   networks_cli_compatible:


### PR DESCRIPTION
##### SUMMARY
This works around https://github.com/moby/moby/issues/48192 at least during container creation. When later updating the networks it doesn't help, unfortunately.

Ref: https://forum.ansible.com/t/setting-a-mac-address-in-a-docker-container/7315/6

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
docker_container
