### PR TITLE
CLI modules: improve docker version/info output processing, avoid querying for API version if it's not needed

### DIFF
--- a/changelogs/fragments/935-cli-errors.yml
+++ b/changelogs/fragments/935-cli-errors.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "docker_compose_v2* modules, docker_image_build - provide better error message when required fields are not present in ``docker version``
+     or ``docker info`` output. This can happen if Podman is used instead of Docker
+     (https://github.com/ansible-collections/community.docker/issues/891, https://github.com/ansible-collections/community.docker/pull/935)."

--- a/plugins/module_utils/common_cli.py
+++ b/plugins/module_utils/common_cli.py
@@ -49,7 +49,7 @@ class DockerException(Exception):
 
 
 class AnsibleDockerClientBase(object):
-    def __init__(self, common_args, min_docker_api_version=None):
+    def __init__(self, common_args, min_docker_api_version=None, needs_api_version=True):
         self._environment = {}
         if common_args['tls_hostname']:
             self._environment['DOCKER_TLS_HOSTNAME'] = common_args['tls_hostname']
@@ -85,13 +85,19 @@ class AnsibleDockerClientBase(object):
         dummy, self._version, dummy = self.call_cli_json('version', '--format', '{{ json . }}', check_rc=True)
         self._info = None
 
-        if not isinstance(self._version.get('Server'), dict) or not isinstance(self._version['Server'].get('ApiVersion'), string_types):
-            self.fail('Cannot determine Docker Daemon information. Are you maybe using podman instead of docker?')
-        self.docker_api_version_str = to_native(self._version['Server']['ApiVersion'])
-        self.docker_api_version = LooseVersion(self.docker_api_version_str)
-        min_docker_api_version = min_docker_api_version or '1.25'
-        if self.docker_api_version < LooseVersion(min_docker_api_version):
-            self.fail('Docker API version is %s. Minimum version required is %s.' % (self.docker_api_version_str, min_docker_api_version))
+        if needs_api_version:
+            if not isinstance(self._version.get('Server'), dict) or not isinstance(self._version['Server'].get('ApiVersion'), string_types):
+                self.fail('Cannot determine Docker Daemon information. Are you maybe using podman instead of docker?')
+            self.docker_api_version_str = to_native(self._version['Server']['ApiVersion'])
+            self.docker_api_version = LooseVersion(self.docker_api_version_str)
+            min_docker_api_version = min_docker_api_version or '1.25'
+            if self.docker_api_version < LooseVersion(min_docker_api_version):
+                self.fail('Docker API version is %s. Minimum version required is %s.' % (self.docker_api_version_str, min_docker_api_version))
+        else:
+            self.docker_api_version_str = None
+            self.docker_api_version = None
+            if min_docker_api_version is not None:
+                self.fail('Internal error: cannot have needs_api_version=False with min_docker_api_version not None')
 
     def log(self, msg, pretty_print=False):
         pass
@@ -273,7 +279,7 @@ class AnsibleDockerClientBase(object):
 class AnsibleModuleDockerClient(AnsibleDockerClientBase):
     def __init__(self, argument_spec=None, supports_check_mode=False, mutually_exclusive=None,
                  required_together=None, required_if=None, required_one_of=None, required_by=None,
-                 min_docker_api_version=None, fail_results=None):
+                 min_docker_api_version=None, fail_results=None, needs_api_version=True):
 
         # Modules can put information in here which will always be returned
         # in case client.fail() is called.
@@ -310,7 +316,9 @@ class AnsibleModuleDockerClient(AnsibleDockerClientBase):
         self.diff = self.module._diff
 
         common_args = dict((k, self.module.params[k]) for k in DOCKER_COMMON_ARGS)
-        super(AnsibleModuleDockerClient, self).__init__(common_args, min_docker_api_version=min_docker_api_version)
+        super(AnsibleModuleDockerClient, self).__init__(
+            common_args, min_docker_api_version=min_docker_api_version, needs_api_version=needs_api_version,
+        )
 
     # def call_cli(self, *args, check_rc=False, data=None, cwd=None, environ_update=None):
     def call_cli(self, *args, **kwargs):

--- a/plugins/modules/docker_compose_v2.py
+++ b/plugins/modules/docker_compose_v2.py
@@ -636,6 +636,7 @@ def main():
     client = AnsibleModuleDockerClient(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        needs_api_version=False,
         **argspec_ex
     )
 

--- a/plugins/modules/docker_compose_v2_pull.py
+++ b/plugins/modules/docker_compose_v2_pull.py
@@ -151,6 +151,7 @@ def main():
     client = AnsibleModuleDockerClient(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        needs_api_version=False,
         **argspec_ex
     )
 

--- a/plugins/modules/docker_image_build.py
+++ b/plugins/modules/docker_image_build.py
@@ -539,6 +539,7 @@ def main():
     client = AnsibleModuleDockerClient(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        needs_api_version=False,
     )
 
     try:


### PR DESCRIPTION
##### SUMMARY
Improve `docker version` / `docker info` output processing to fail with nicer error messages if the required information is not present. This can happen if `podman` is used instead of `docker`.

Also aovid querying for the API version if it's not needed (which is the case for all current CLI based modules).

Ref: #891

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/common_cli.py
CLI based modules
