### PR TITLE
Announce dropping support for ansible-core < 2.15 in next major release

### DIFF
--- a/changelogs/fragments/deprecate-eol-ansible-core.yml
+++ b/changelogs/fragments/deprecate-eol-ansible-core.yml
@@ -1,0 +1,4 @@
+deprecated_features:
+  - "The collection deprecates support for all ansible-core versions that are currently End of Life,
+     `according to the ansible-core support matrix <https://docs.ansible.com/ansible-core/devel/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix>`__.
+     This means that the next major release of the collection will no longer support ansible-core 2.11, ansible-core 2.12, ansible-core 2.13, and ansible-core 2.14."


### PR DESCRIPTION
##### SUMMARY
I'm currently planning to create a new major release (4.0.0) in end of October/early November (for the [Ansible 11 feature freeze](https://github.com/ansible/ansible-documentation/pull/1729/files#diff-ab10938f3dd83f5f07caae060c1a23ae22c440849658ae8fce8c58d8ed3f5872R31)), and for that I'd like to drop support for older ansible-core releases. I'm following community.general's lead here, which drops support for all such versions which have been End of Life for some time (compare the [ansible-core support matrix](https://docs.ansible.com/ansible-core/devel/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix)).

This means that support for ansible-core 2.11, ansible-core 2.12, ansible-core 2.13, and ansible-core 2.14 will be dropped. This will shrink the CI matrix, and allow to remove some workarounds for some specific older versions.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelog
