### PR TITLE
Remove link to Google Groups mailing list

### DIFF
--- a/docs/docsite/links.yml
+++ b/docs/docsite/links.yml
@@ -28,9 +28,6 @@ communication:
     - topic: General usage and support questions
       network: Libera
       channel: '#ansible'
-  mailing_lists:
-    - topic: Ansible Project List
-      url: https://groups.google.com/g/ansible-project
   forums:
     - topic: "Ansible Forum: General usage and support questions"
       # The following URL directly points to the "Get Help" section


### PR DESCRIPTION
##### SUMMARY
It's being removed: https://groups.google.com/g/ansible-project/c/B0oKR0aQqXs

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/links.yml