### PR TITLE
add `renew_anon_volumes` parameter to `docker compose up`

### DIFF
--- a/changelogs/fragments/977-renew_anon_volumes.yaml
+++ b/changelogs/fragments/977-renew_anon_volumes.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - docker_compose_v2 - add renew_anon_volumes parameter for docker compose up

--- a/changelogs/fragments/977-renew_anon_volumes.yaml
+++ b/changelogs/fragments/977-renew_anon_volumes.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - docker_compose_v2 - add renew_anon_volumes parameter for docker compose up
+  - docker_compose_v2 - add ``renew_anon_volumes`` parameter for ``docker compose up`` (https://github.com/ansible-collections/community.docker/pull/977).

--- a/plugins/modules/docker_compose_v2.py
+++ b/plugins/modules/docker_compose_v2.py
@@ -631,7 +631,7 @@ def main():
         pull=dict(type='str', choices=['always', 'missing', 'never', 'policy'], default='policy'),
         build=dict(type='str', choices=['always', 'never', 'policy'], default='policy'),
         recreate=dict(type='str', default='auto', choices=['always', 'never', 'auto']),
-        renew_anon_volumes=dict(type='bool',default=False),
+        renew_anon_volumes=dict(type='bool', default=False),
         remove_images=dict(type='str', choices=['all', 'local']),
         remove_volumes=dict(type='bool', default=False),
         remove_orphans=dict(type='bool', default=False),

--- a/plugins/modules/docker_compose_v2.py
+++ b/plugins/modules/docker_compose_v2.py
@@ -95,10 +95,11 @@ options:
       - auto
   renew_anon_volumes:
     description:
-      - Whether to recreate instead of reuse anonymous volumes from previous containers
-      - V(true) is equivalent to the C(--renew-anon-volumes) or C(-V) option of C(docker compose up)
+      - Whether to recreate instead of reuse anonymous volumes from previous containers.
+      - V(true) is equivalent to the C(--renew-anon-volumes) option of C(docker compose up).
     type: bool
     default: false
+    version_added: 4.0.0
   remove_images:
     description:
       - Use with O(state=absent) to remove all images or only local images.

--- a/plugins/modules/docker_compose_v2.py
+++ b/plugins/modules/docker_compose_v2.py
@@ -93,6 +93,12 @@ options:
       - always
       - never
       - auto
+  renew_anon_volumes:
+    description:
+      - Whether to recreate instead of reuse anonymous volumes from previous containers
+      - V(true) is equivalent to the C(--renew-anon-volumes) or C(-V) option of C(docker compose up)
+    type: bool
+    default: false
   remove_images:
     description:
       - Use with O(state=absent) to remove all images or only local images.
@@ -437,6 +443,7 @@ class ServicesManager(BaseComposeManager):
         self.remove_images = parameters['remove_images']
         self.remove_volumes = parameters['remove_volumes']
         self.remove_orphans = parameters['remove_orphans']
+        self.renew_anon_volumes = parameters['renew_anon_volumes']
         self.timeout = parameters['timeout']
         self.services = parameters['services'] or []
         self.scale = parameters['scale'] or {}
@@ -479,6 +486,8 @@ class ServicesManager(BaseComposeManager):
             args.append('--force-recreate')
         if self.recreate == 'never':
             args.append('--no-recreate')
+        if self.renew_anon_volumes:
+            args.append('--renew-anon-volumes')
         if not self.dependencies:
             args.append('--no-deps')
         if self.timeout is not None:
@@ -621,6 +630,7 @@ def main():
         pull=dict(type='str', choices=['always', 'missing', 'never', 'policy'], default='policy'),
         build=dict(type='str', choices=['always', 'never', 'policy'], default='policy'),
         recreate=dict(type='str', default='auto', choices=['always', 'never', 'auto']),
+        renew_anon_volumes=dict(type='bool',default=False),
         remove_images=dict(type='str', choices=['all', 'local']),
         remove_volumes=dict(type='bool', default=False),
         remove_orphans=dict(type='bool', default=False),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add a variable for the `docker compose up` parameter `renew_anon_volumes` to recreate anonymous volumes when recreating containers on `docker compose up`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_compose_v2

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
As far as I am aware there was no way to set this option using the community.docker collection before

usage example:
```
    - name: Start compose environment and renew anon volumes
      community.docker.docker_compose_v2:
        project_src: compose
        renew_anon_volumes: true
        state: present
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
output of example playbook in [test repository](https://github.com/z-bsod/community.docker.cleanup-test)
```paste below
% ansible-playbook test.yml
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match
'all'

PLAY [localhost] ******************************************************************************************************

TASK [Gathering Facts] ************************************************************************************************
ok: [localhost]

TASK [Build images] ***************************************************************************************************
ok: [localhost] => (item=1)
ok: [localhost] => (item=2)
ok: [localhost] => (item=3)

TASK [Start compose with image version 1] *****************************************************************************
changed: [localhost]

TASK [create file in image] *******************************************************************************************
changed: [localhost]

TASK [get folder contents] ********************************************************************************************
changed: [localhost]

TASK [Output folder contents] *****************************************************************************************
ok: [localhost] => {
    "folder.stdout": "total 0\n-rw-r--r-- 1 root root 0 Oct 17 06:51 image_v1"
}

TASK [start image with image version 2] *******************************************************************************
changed: [localhost]

TASK [get folder contents of v2 container] ****************************************************************************
changed: [localhost]

TASK [Output folder contents] *****************************************************************************************
ok: [localhost] => {
    "folder.stdout": "total 0\n-rw-r--r-- 1 root root 0 Oct 17 06:51 image_v1"
}

TASK [start image with image version 3 and cleanup parameter] *********************************************************
changed: [localhost]

TASK [get folder contents of v3 container] ****************************************************************************
changed: [localhost]

TASK [Output folder contents] *****************************************************************************************
ok: [localhost] => {
    "folder.stdout": "total 0"
}

PLAY RECAP ************************************************************************************************************
localhost                  : ok=12   changed=7    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

ansible-playbook test.yml  4,59s user 2,84s system 25% cpu 28,629 total
 
```
