### PR TITLE
Doc fix for docker_container image_name_mismatch

### DIFF
--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -470,8 +470,8 @@ options:
       - Determines what the module does if the image matches, but the image name in the container's configuration
         does not match the image name provided to the module.
       - "This is ignored if C(image: ignore) is set in O(comparisons)."
-      - If set to V(recreate) the container will be recreated.
-      - If set to V(ignore) (currently the default) the container will not be recreated because of this. It might still get recreated for other reasons.
+      - If set to V(recreate) (currently the default) the container will be recreated.
+      - If set to V(ignore) the container will not be recreated because of this. It might still get recreated for other reasons.
         This has been the default behavior of the module for a long time, but might not be what users expect.
       - The default changed from V(ignore) to V(recreate) in community.docker 4.0.0.
     type: str

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -470,7 +470,7 @@ options:
       - Determines what the module does if the image matches, but the image name in the container's configuration
         does not match the image name provided to the module.
       - "This is ignored if C(image: ignore) is set in O(comparisons)."
-      - If set to V(recreate) (currently the default) the container will be recreated.
+      - If set to V(recreate) (default) the container will be recreated.
       - If set to V(ignore) the container will not be recreated because of this. It might still get recreated for other reasons.
         This has been the default behavior of the module for a long time, but might not be what users expect.
       - The default changed from V(ignore) to V(recreate) in community.docker 4.0.0.


### PR DESCRIPTION
##### SUMMARY
Make the description of the `image_name_mismatch` parameter of the `docker_container` module more consistent.
Contained conflicting statements about the default value, see 2 lines below the changes.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docker_container

##### ADDITIONAL INFORMATION

Could not find an existing issue for this. Should I raise an issue first, even for this trivial change?
