### PR TITLE
module docker_compose_v2_run: fix env argument

### DIFF
--- a/changelogs/fragments/992-module-docker_compose_v2_run-fix-env-argument.yml
+++ b/changelogs/fragments/992-module-docker_compose_v2_run-fix-env-argument.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- "fix missing ``--env`` flag in modules ``docker_compose_v2_run`` and ``docker_compose_v2_exec`` while assembling env arguments"
+- "docker_compose_v2_exec, docker_compose_v2_run - fix missing ``--env`` flag while assembling env arguments (https://github.com/ansible-collections/community.docker/pull/992)."

--- a/changelogs/fragments/992-module-docker_compose_v2_run-fix-env-argument.yml
+++ b/changelogs/fragments/992-module-docker_compose_v2_run-fix-env-argument.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "fix missing ``--env`` flag in modules ``docker_compose_v2_run`` and ``docker_compose_v2_exec`` while assembling env arguments"

--- a/plugins/modules/docker_compose_v2_exec.py
+++ b/plugins/modules/docker_compose_v2_exec.py
@@ -229,6 +229,7 @@ class ExecManager(BaseComposeManager):
             args.append('--no-TTY')
         if self.env:
             for name, value in list(self.env.items()):
+                args.append('--env')
                 args.append('{0}={1}'.format(name, value))
         args.append('--')
         args.append(self.service)

--- a/plugins/modules/docker_compose_v2_run.py
+++ b/plugins/modules/docker_compose_v2_run.py
@@ -346,6 +346,7 @@ class ExecManager(BaseComposeManager):
             args.append('--no-TTY')
         if self.env:
             for name, value in list(self.env.items()):
+                args.append('--env')
                 args.append('{0}={1}'.format(name, value))
         args.append('--')
         args.append(self.service)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In the get_run_cmd definition, the self.env loop adds --env before every argument while iterating through.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_compose_v2_run

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Without the additional change, it cannot take arguments as variables and fails.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

[failed.log](https://github.com/user-attachments/files/17830707/failed.log) 
[succes.log](https://github.com/user-attachments/files/17830708/succes.log)
