### PR TITLE
docker_host_info: correctly set can_talk_is_docker

### DIFF
--- a/changelogs/fragments/995-docker_host_info-return.yml
+++ b/changelogs/fragments/995-docker_host_info-return.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "docker_host_info - ensure that the module always returns ``can_talk_to_docker``, and that it provides the correct value even if ``api_version`` is specified (https://github.com/ansible-collections/community.docker/issues/993, https://github.com/ansible-collections/community.docker/pull/995)."

--- a/plugins/modules/docker_host_info.py
+++ b/plugins/modules/docker_host_info.py
@@ -249,6 +249,9 @@ class DockerHostManager(DockerBaseClass):
         listed_objects = ['volumes', 'networks', 'containers', 'images']
 
         self.results['host_info'] = self.get_docker_host_info()
+        # At this point we definitely know that we can talk to the Docker daemon
+        self.results['can_talk_to_docker'] = True
+        self.client.fail_results['can_talk_to_docker'] = True
 
         if self.client.module.params['disk_usage']:
             self.results['disk_usage'] = self.get_docker_disk_usage_facts()
@@ -363,7 +366,9 @@ def main():
             can_talk_to_docker=False,
         ),
     )
-    client.fail_results['can_talk_to_docker'] = True
+    if client.module.params['api_version'] is None or client.module.params['api_version'].lower() == 'auto':
+        # At this point we know that we can talk to Docker, since we asked it for the API version
+        client.fail_results['can_talk_to_docker'] = True
 
     try:
         results = dict(

--- a/tests/integration/targets/docker_host_info/tasks/test_host_info.yml
+++ b/tests/integration/targets/docker_host_info/tasks/test_host_info.yml
@@ -20,12 +20,39 @@
   - name: assert reading docker host facts when docker is running
     assert:
       that:
-         - 'output.host_info.Name is string'
-         - 'output.containers is not defined'
-         - 'output.networks is not defined'
-         - 'output.volumes is not defined'
-         - 'output.images is not defined'
-         - 'output.disk_usage is not defined'
+        - output.host_info.Name is string
+        - output.containers is not defined
+        - output.networks is not defined
+        - output.volumes is not defined
+        - output.images is not defined
+        - output.disk_usage is not defined
+        - output.can_talk_to_docker is true
+
+- block:
+  - name: Get info on Docker host with invalid api_version
+    docker_host_info:
+      api_version: 1.999.999
+    register: output
+    ignore_errors: true
+
+  - name: assert can_talk_is_docker is false
+    assert:
+      that:
+        - output is failed
+        - output.can_talk_to_docker is false
+
+- block:
+  - name: Get info on Docker host with invalid docker_host
+    docker_host_info:
+      docker_host: tcp://127.0.0.1:80
+    register: output
+    ignore_errors: true
+
+  - name: assert can_talk_is_docker is false
+    assert:
+      that:
+        - output is failed
+        - output.can_talk_to_docker is false
 
 # Container and volume are created so that all lists are non-empty:
 # * container and volume lists are non-emtpy because of the created objects;


### PR DESCRIPTION
##### SUMMARY
Fixes #993.

Also if a valid `api_version` is supplied that's not supported by the Daemon, the value was set wrongly in the past.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_host_info
