### PR TITLE
docker_compose_v2: fix tests

### DIFF
--- a/tests/integration/targets/docker_compose_v2/tasks/tests/build.yml
+++ b/tests/integration/targets/docker_compose_v2/tasks/tests/build.yml
@@ -121,7 +121,7 @@
           - present_2.warnings | default([]) | select('regex', ' Please report this at ') | length == 0
           - present_3_check is changed
           - present_3_check.warnings | default([]) | select('regex', ' Please report this at ') | length == 0
-          - ((present_3 is changed) if docker_compose_version is version('2.31.0', '>=') else (present_3 is not changed))
+          - ((present_3 is changed) if docker_compose_version is version('2.31.0', '>=') and docker_compose_version is version('2.32.2', '<') else (present_3 is not changed))
           - present_3.warnings | default([]) | select('regex', ' Please report this at ') | length == 0
           - present_4_check is changed
           - present_4_check.warnings | default([]) | select('regex', ' Please report this at ') | length == 0

--- a/tests/integration/targets/docker_compose_v2/tasks/tests/pull.yml
+++ b/tests/integration/targets/docker_compose_v2/tasks/tests/pull.yml
@@ -9,12 +9,10 @@
     non_existing_image: does-not-exist:latest
     project_src: "{{ remote_tmp_dir }}/{{ pname }}"
     test_service_non_existing: |
-      version: '3'
       services:
         {{ cname }}:
           image: {{ non_existing_image }}
     test_service_simple: |
-      version: '3'
       services:
         {{ cname }}:
           image: {{ docker_test_image_simple_1 }}

--- a/tests/integration/targets/docker_compose_v2/tasks/tests/start-stop.yml
+++ b/tests/integration/targets/docker_compose_v2/tasks/tests/start-stop.yml
@@ -8,14 +8,12 @@
     cname: "{{ name_prefix }}-container"
     project_src: "{{ remote_tmp_dir }}/{{ pname }}"
     test_service: |
-      version: '3'
       services:
         {{ cname }}:
           image: "{{ docker_test_image_alpine }}"
           command: '/bin/sh -c "sleep 10m"'
           stop_grace_period: 1s
     test_service_mod: |
-      version: '3'
       services:
         {{ cname }}:
           image: "{{ docker_test_image_alpine }}"


### PR DESCRIPTION
##### SUMMARY
docker-compose 2.32.2 has been released, which contains https://github.com/docker/compose/pull/12442. That PR stops image building from emitting "building" events, which no longer triggers a "changed" result in one case.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
docker_compose_v2
