### PR TITLE
fix: docker_compose_v2_run: labels

### DIFF
--- a/changelogs/fragments/1034-do-not-sanitize-labels.yaml
+++ b/changelogs/fragments/1034-do-not-sanitize-labels.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - docker_compose_v2_run - the module has a conflict between the type of parameter it expects and the one it tries to sanitize. Fix removes the label sanitization step because they are already validated by the parameter definition (https://github.com/ansible-collections/community.docker/pull/1034).

--- a/plugins/modules/docker_compose_v2_run.py
+++ b/plugins/modules/docker_compose_v2_run.py
@@ -253,8 +253,6 @@ from ansible_collections.community.docker.plugins.module_utils.compose_v2 import
     common_compose_argspec_ex,
 )
 
-from ansible_collections.community.docker.plugins.module_utils.util import sanitize_labels
-
 
 class ExecManager(BaseComposeManager):
     def __init__(self, client):
@@ -424,7 +422,6 @@ def main():
         needs_api_version=False,
         **argspec_ex
     )
-    sanitize_labels(client.module.params['labels'], 'labels', client)
 
     try:
         manager = ExecManager(client)


### PR DESCRIPTION
##### SUMMARY
Fixes the support for labels. Without these changes, the module has a conflict between the type of parameter it expects and the one it tries to sanitize.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_compose_v2_run

##### ADDITIONAL INFORMATION

