### PR TITLE
add `--yes` parameter to `docker compose up`

### DIFF
--- a/changelogs/fragments/1045-docker-compose-up-yes.yaml
+++ b/changelogs/fragments/1045-docker-compose-up-yes.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - docker_compose_v2 - add ``yes`` parameter for ``docker compose up`` (https://github.com/ansible-collections/community.docker/pull/1045).
+  - docker_compose_v2 - add ``assume_yes`` parameter for ``docker compose up`` (https://github.com/ansible-collections/community.docker/pull/1045).

--- a/changelogs/fragments/1045-docker-compose-up-yes.yaml
+++ b/changelogs/fragments/1045-docker-compose-up-yes.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - docker_compose_v2 - add ``yes`` parameter for ``docker compose up`` (https://github.com/ansible-collections/community.docker/pull/1045).

--- a/plugins/modules/docker_compose_v2.py
+++ b/plugins/modules/docker_compose_v2.py
@@ -163,7 +163,7 @@ options:
   yes:
     description:
       - When O(yes=true), pass C(--yes) to assume "yes" as answer to all prompts and run non-interactively.
-    type: int
+    type: bool
     version_added: TODO
 
 author:

--- a/plugins/modules/docker_compose_v2.py
+++ b/plugins/modules/docker_compose_v2.py
@@ -160,6 +160,11 @@ options:
       - When O(wait=true), wait at most this amount of seconds.
     type: int
     version_added: 3.8.0
+  yes:
+    description:
+      - When O(yes=true), pass C(--yes) to assume "yes" as answer to all prompts and run non-interactively.
+    type: int
+    version_added: TODO
 
 author:
   - Felix Fontein (@felixfontein)
@@ -465,6 +470,7 @@ class ServicesManager(BaseComposeManager):
         self.scale = parameters['scale'] or {}
         self.wait = parameters['wait']
         self.wait_timeout = parameters['wait_timeout']
+        self.yes = parameters['yes']
 
         for key, value in self.scale.items():
             if not isinstance(key, string_types):
@@ -522,6 +528,8 @@ class ServicesManager(BaseComposeManager):
             args.append('--no-start')
         if dry_run:
             args.append('--dry-run')
+        if self.yes:
+            args.append('--yes')
         args.append('--')
         for service in self.services:
             args.append(service)
@@ -656,6 +664,7 @@ def main():
         wait=dict(type='bool', default=False),
         wait_timeout=dict(type='int'),
         ignore_build_events=dict(type='bool', default=True),
+        yes=dict(type='bool', default=False),
     )
     argspec_ex = common_compose_argspec_ex()
     argument_spec.update(argspec_ex.pop('argspec'))

--- a/plugins/modules/docker_compose_v2.py
+++ b/plugins/modules/docker_compose_v2.py
@@ -453,6 +453,8 @@ from ansible_collections.community.docker.plugins.module_utils.compose_v2 import
     is_failed,
 )
 
+from ansible_collections.community.docker.plugins.module_utils.version import LooseVersion
+
 
 class ServicesManager(BaseComposeManager):
     def __init__(self, client):
@@ -474,7 +476,8 @@ class ServicesManager(BaseComposeManager):
         self.scale = parameters['scale'] or {}
         self.wait = parameters['wait']
         self.wait_timeout = parameters['wait_timeout']
-        self.yes = parameters['assume_yes']
+        if self.compose_version >= LooseVersion('2.32.0'):
+          self.yes = parameters['assume_yes']
 
         for key, value in self.scale.items():
             if not isinstance(key, string_types):

--- a/plugins/modules/docker_compose_v2.py
+++ b/plugins/modules/docker_compose_v2.py
@@ -163,6 +163,9 @@ options:
   yes:
     description:
       - When O(yes=true), pass C(--yes) to assume "yes" as answer to all prompts and run non-interactively.
+      - Right now a prompt is asked whenever a non-matching volume should be re-created. O(yes=false)
+        results in the question being answered by "no", which will simply re-use the existing volume.
+      - This option is only available on Docker Compose 2.32.0 or newer.
     type: bool
     default: false
     version_added: TODO

--- a/plugins/modules/docker_compose_v2.py
+++ b/plugins/modules/docker_compose_v2.py
@@ -160,7 +160,7 @@ options:
       - When O(wait=true), wait at most this amount of seconds.
     type: int
     version_added: 3.8.0
-  yes:
+  assume_yes:
     description:
       - When O(yes=true), pass C(--yes) to assume "yes" as answer to all prompts and run non-interactively.
       - Right now a prompt is asked whenever a non-matching volume should be re-created. O(yes=false)
@@ -474,7 +474,7 @@ class ServicesManager(BaseComposeManager):
         self.scale = parameters['scale'] or {}
         self.wait = parameters['wait']
         self.wait_timeout = parameters['wait_timeout']
-        self.yes = parameters['yes']
+        self.yes = parameters['assume_yes']
 
         for key, value in self.scale.items():
             if not isinstance(key, string_types):
@@ -668,7 +668,7 @@ def main():
         wait=dict(type='bool', default=False),
         wait_timeout=dict(type='int'),
         ignore_build_events=dict(type='bool', default=True),
-        yes=dict(type='bool', default=False),
+        assume_yes=dict(type='bool', default=False),
     )
     argspec_ex = common_compose_argspec_ex()
     argument_spec.update(argspec_ex.pop('argspec'))

--- a/plugins/modules/docker_compose_v2.py
+++ b/plugins/modules/docker_compose_v2.py
@@ -476,10 +476,9 @@ class ServicesManager(BaseComposeManager):
         self.scale = parameters['scale'] or {}
         self.wait = parameters['wait']
         self.wait_timeout = parameters['wait_timeout']
-        if self.compose_version >= LooseVersion('2.32.0'):
-          self.yes = parameters['assume_yes']
-        else:
-          self.yes = False
+        self.yes = parameters['assume_yes']
+        if self.compose_version >= LooseVersion('2.32.0') and self.yes:
+            self.fail('assume_yes=true needs Docker Compose 2.32.0 or newer, not version %s' % (self.compose_version, ))
 
         for key, value in self.scale.items():
             if not isinstance(key, string_types):

--- a/plugins/modules/docker_compose_v2.py
+++ b/plugins/modules/docker_compose_v2.py
@@ -164,6 +164,7 @@ options:
     description:
       - When O(yes=true), pass C(--yes) to assume "yes" as answer to all prompts and run non-interactively.
     type: bool
+    default: false
     version_added: TODO
 
 author:

--- a/plugins/modules/docker_compose_v2.py
+++ b/plugins/modules/docker_compose_v2.py
@@ -162,9 +162,9 @@ options:
     version_added: 3.8.0
   assume_yes:
     description:
-      - When O(yes=true), pass C(--yes) to assume "yes" as answer to all prompts and run non-interactively.
-      - Right now a prompt is asked whenever a non-matching volume should be re-created. O(yes=false)
-        results in the question being answered by "no", which will simply re-use the existing volume.
+      - When O(assume_yes=true), pass C(--yes) to assume "yes" as answer to all prompts and run non-interactively.
+      - Right now a prompt is asked whenever a non-matching volume should be re-created. O(assume_yes=false)
+        results in the question not being answered, which will hang as it waits for stdin.
       - This option is only available on Docker Compose 2.32.0 or newer.
     type: bool
     default: false

--- a/plugins/modules/docker_compose_v2.py
+++ b/plugins/modules/docker_compose_v2.py
@@ -168,7 +168,7 @@ options:
       - This option is only available on Docker Compose 2.32.0 or newer.
     type: bool
     default: false
-    version_added: TODO
+    version_added: 4.5.0
 
 author:
   - Felix Fontein (@felixfontein)

--- a/plugins/modules/docker_compose_v2.py
+++ b/plugins/modules/docker_compose_v2.py
@@ -478,6 +478,8 @@ class ServicesManager(BaseComposeManager):
         self.wait_timeout = parameters['wait_timeout']
         if self.compose_version >= LooseVersion('2.32.0'):
           self.yes = parameters['assume_yes']
+        else:
+          self.yes = False
 
         for key, value in self.scale.items():
             if not isinstance(key, string_types):

--- a/plugins/modules/docker_compose_v2.py
+++ b/plugins/modules/docker_compose_v2.py
@@ -164,7 +164,7 @@ options:
     description:
       - When O(assume_yes=true), pass C(--yes) to assume "yes" as answer to all prompts and run non-interactively.
       - Right now a prompt is asked whenever a non-matching volume should be re-created. O(assume_yes=false)
-        results in the question not being answered, which will hang as it waits for stdin.
+        results in the question being answered by "no", which will simply re-use the existing volume.
       - This option is only available on Docker Compose 2.32.0 or newer.
     type: bool
     default: false


### PR DESCRIPTION
##### SUMMARY

Add a variable for the `docker compose up` parameter `yes` to assume "yes" as answer to all prompts and run non-interactively. This prevents issues where the module hangs if a volume spec changes in the compose file.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

docker_compose_v2

##### ADDITIONAL INFORMATION

```yaml
    - name: Start compose environment with yes
      community.docker.docker_compose_v2:
        project_src: compose
        assume_yes: true
        state: present
```
