### PR TITLE
fix: use correct flag for `assume_yes`

### DIFF
--- a/plugins/modules/docker_compose_v2.py
+++ b/plugins/modules/docker_compose_v2.py
@@ -162,7 +162,7 @@ options:
     version_added: 3.8.0
   assume_yes:
     description:
-      - When O(assume_yes=true), pass C(--yes) to assume "yes" as answer to all prompts and run non-interactively.
+      - When O(assume_yes=true), pass C(--y) to assume "yes" as answer to all prompts and run non-interactively.
       - Right now a prompt is asked whenever a non-matching volume should be re-created. O(assume_yes=false)
         results in the question being answered by "no", which will simply re-use the existing volume.
       - This option is only available on Docker Compose 2.32.0 or newer.
@@ -537,7 +537,7 @@ class ServicesManager(BaseComposeManager):
         if dry_run:
             args.append('--dry-run')
         if self.yes:
-            args.append('--yes')
+            args.append('--y')
         args.append('--')
         for service in self.services:
             args.append(service)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The correct flag is `--y`, not `--yes`, as mentioned in my comment on #1045.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_compose_v2

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

For some reason the flag is called `--y`, not `--yes` as is usual. I think this might be a mistake from the Docker maintainers, but for now this is a bug and causes an error if `--yes` is used.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
# (Not sure I understand what belong in here)
```
