### PR TITLE
docker_compose_v2: use --yes when available instead of -y

### DIFF
--- a/changelogs/fragments/1060-compose-yes.yml
+++ b/changelogs/fragments/1060-compose-yes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "docker_compose_v2 - use ``--yes`` instead of ``-y`` from Docker Compose 2.34.0 on (https://github.com/ansible-collections/community.docker/pull/1060)."

--- a/plugins/modules/docker_compose_v2.py
+++ b/plugins/modules/docker_compose_v2.py
@@ -162,7 +162,7 @@ options:
     version_added: 3.8.0
   assume_yes:
     description:
-      - When O(assume_yes=true), pass C(-y) to assume "yes" as answer to all prompts and run non-interactively.
+      - When O(assume_yes=true), pass C(-y)/C(--yes) to assume "yes" as answer to all prompts and run non-interactively.
       - Right now a prompt is asked whenever a non-matching volume should be re-created. O(assume_yes=false)
         results in the question being answered by "no", which will simply re-use the existing volume.
       - This option is only available on Docker Compose 2.32.0 or newer.
@@ -537,8 +537,9 @@ class ServicesManager(BaseComposeManager):
         if dry_run:
             args.append('--dry-run')
         if self.yes:
-            # Note that the long form is '--y', and not '--yes' as one would expect. Since this looks like a bug we're using the short form.
-            args.append('-y')
+            # Note that for Docker Compose 2.32.x and 2.33.x, the long form is '--y' and not '--yes'.
+            # This was fixed in Docker Compose 2.34.0 (https://github.com/docker/compose/releases/tag/v2.34.0).
+            args.append('-y' if self.compose_version < LooseVersion('2.34.0') else '--yes')
         args.append('--')
         for service in self.services:
             args.append(service)

--- a/tests/integration/targets/docker_compose_v2/tasks/tests/start-stop.yml
+++ b/tests/integration/targets/docker_compose_v2/tasks/tests/start-stop.yml
@@ -84,6 +84,13 @@
         state: present
       register: present_3
 
+    - name: Present with --yes
+      docker_compose_v2:
+        project_src: '{{ project_src }}'
+        state: present
+        assume_yes: true
+      when: docker_compose_version is version('2.32.0', '>=')
+
     - assert:
         that:
           - present_1_check is changed


### PR DESCRIPTION
##### SUMMARY
Ref: https://github.com/ansible-collections/community.docker/pull/1054#issuecomment-2731018837

CC @jonasgeiler

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_compose_v2
