### PR TITLE
CI: fix certificates for HTTPS connection tests

### DIFF
--- a/tests/integration/targets/generic_connection_tests/tasks/main.yml
+++ b/tests/integration/targets/generic_connection_tests/tasks/main.yml
@@ -75,8 +75,15 @@
           commonName: Ansible test CA for Docker HTTPS connection tests
         useCommonNameForSAN: false
         basic_constraints:
-        - 'CA:TRUE'
+          - 'CA:TRUE'
         basic_constraints_critical: true
+        key_usage:
+          - digitalSignature
+          - Certificate Sign
+        key_usage_critical: true
+        extended_key_usage:
+          - serverAuth  # the same as "TLS Web Server Authentication"
+        extended_key_usage_critical: true
 
     - name: Create CA certificate
       community.crypto.x509_certificate:
@@ -90,7 +97,7 @@
         path: '{{ remote_tmp_dir }}/cert.csr'
         privatekey_path: '{{ remote_tmp_dir }}/cert.key'
         subject_alt_name:
-        - DNS:daemon-tls.ansible.com
+          - DNS:daemon-tls.ansible.com
         subject_alt_name_critical: true
 
     - name: Create frontend certificate

--- a/tests/integration/targets/generic_connection_tests/tasks/main.yml
+++ b/tests/integration/targets/generic_connection_tests/tasks/main.yml
@@ -71,6 +71,9 @@
       community.crypto.openssl_csr:
         path: '{{ remote_tmp_dir }}/ca.csr'
         privatekey_path: '{{ remote_tmp_dir }}/ca.key'
+        subject:
+          commonName: Ansible test CA for Docker HTTPS connection tests
+        useCommonNameForSAN: false
         basic_constraints:
         - 'CA:TRUE'
         basic_constraints_critical: true

--- a/tests/integration/targets/generic_connection_tests/tasks/main.yml
+++ b/tests/integration/targets/generic_connection_tests/tasks/main.yml
@@ -91,6 +91,7 @@
         privatekey_path: '{{ remote_tmp_dir }}/cert.key'
         subject_alt_name:
         - DNS:daemon-tls.ansible.com
+        subject_alt_name_critical: true
 
     - name: Create frontend certificate
       community.crypto.x509_certificate:


### PR DESCRIPTION
##### SUMMARY
The nightly tests fail:
- https://dev.azure.com/ansible/community.docker/_build/results?buildId=142626&view=logs&j=5103c6fb-9cc4-5248-0e82-10ff2d8c0629&t=9bf852ac-ce74-56a9-daff-f57286d07281 
- https://dev.azure.com/ansible/community.docker/_build/results?buildId=142626&view=logs&j=fffffedb-9d94-5f57-8ddd-84efc8fa0998&t=ffe8ea15-3044-5773-d237-cc00042167d6

Likely cause: https://community.letsencrypt.org/t/fyi-breaking-changes-in-python-urllib3-2-4-0/236234

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
HTTPS connection tests
