### PR TITLE
docker_container_copy_into: warn about octal modes

### DIFF
--- a/plugins/modules/docker_container_copy_into.py
+++ b/plugins/modules/docker_container_copy_into.py
@@ -95,6 +95,7 @@ options:
     description:
       - The file mode to use when writing the file to disk.
       - Will use the file's mode from the source system if this option is not provided.
+      - Note that if you provide an octal number as a string, Ansible will parse it as a B(decimal) number.
     type: int
   force:
     description:


### PR DESCRIPTION
##### SUMMARY
Ref https://github.com/ansible-collections/community.docker/pull/1071#issuecomment-2832010580

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docker_container_copy_into
