### PR TITLE
Re-enable RHEL 8 in CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -248,9 +248,8 @@ stages:
           targets:
             - name: RHEL 9.2
               test: rhel/9.2
-            # Currently always hangs in group 2
-            # - name: RHEL 8.8
-            #   test: rhel/8.8
+            - name: RHEL 8.8
+              test: rhel/8.8
             - name: RHEL 7.9
               test: rhel/7.9
           groups:

--- a/tests/integration/targets/setup_podman/vars/RedHat-8.yml
+++ b/tests/integration/targets/setup_podman/vars/RedHat-8.yml
@@ -1,0 +1,9 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# While CentOS 8 has podman, there's a strange conflict resolution issue with it
+# TODO: try to fix that issue!
+has_podman: false
+podman_packages: []


### PR DESCRIPTION
##### SUMMARY
RHEL 8 was disabled a longer time ago since it hung in one CI group. Now that would have been the last RHEL 8.x test running, but it isn't, so we have no coverage at all for RHEL 8 (only for RHEL 7 and 9).

This is potentially a problem, see #1033.

Let's try to get this working again (and maybe figure out what goes wrong in #1033).

##### ISSUE TYPE
- Bugfix Pull Request
- Test Pull Request

##### COMPONENT NAME
CI
