### PR TITLE
antsibull-nox: use community.crypto 2.x.y for ansible-core < 2.17

### DIFF
--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -6,6 +6,14 @@
 "community.internal_test_tools" = "git+https://github.com/ansible-collections/community.internal_test_tools.git,main"
 "community.library_inventory_filtering_v1" = "git+https://github.com/ansible-collections/community.library_inventory_filtering.git,stable-1"
 
+[collection_sources_per_ansible.'2.15']
+# community.crypto's main branch needs ansible-core >= 2.17
+"community.crypto" = "git+https://github.com/ansible-collections/community.crypto.git,stable-2"
+
+[collection_sources_per_ansible.'2.16']
+# community.crypto's main branch needs ansible-core >= 2.17
+"community.crypto" = "git+https://github.com/ansible-collections/community.crypto.git,stable-2"
+
 [sessions]
 
 [sessions.lint]


### PR DESCRIPTION
##### SUMMARY
Ref: https://github.com/ansible-community/antsibull-nox/pull/77

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
