### PR TITLE
docker_compose_v2: ContainerName is also missing in 2.37.1

### DIFF
--- a/tests/integration/targets/docker_compose_v2/tasks/tests/build.yml
+++ b/tests/integration/targets/docker_compose_v2/tasks/tests/build.yml
@@ -112,7 +112,7 @@
           - present_1.containers[0].Name == (pname ~ '-' ~ cname ~ '-1')
           - present_1.images | length == 1
           - >-
-            docker_compose_version is version('2.37.0', '==') or
+            docker_compose_version is version('2.37.0', '>=') or
             present_1.images[0].ContainerName == (pname ~ '-' ~ cname ~ '-1')
           - present_1.images[0].Repository == iname
           - present_1.images[0].Tag == "latest"

--- a/tests/integration/targets/docker_compose_v2/tasks/tests/container-exit.yml
+++ b/tests/integration/targets/docker_compose_v2/tasks/tests/container-exit.yml
@@ -63,7 +63,7 @@
           - present_1.containers[0].ExitCode == 0
           - present_1.images | length == 1
           - >-
-            docker_compose_version is version('2.37.0', '==') or
+            docker_compose_version is version('2.37.0', '>=') or
             present_1.images[0].ContainerName == (pname ~ '-' ~ cname ~ '-1')
           - present_1.images[0].Repository == (docker_test_image_alpine | split(':') | first)
           - present_1.images[0].Tag == (docker_test_image_alpine | split(':') | last)

--- a/tests/integration/targets/docker_compose_v2/tasks/tests/definition.yml
+++ b/tests/integration/targets/docker_compose_v2/tasks/tests/definition.yml
@@ -84,7 +84,7 @@
           - present_1.containers[0].Image == docker_test_image_alpine
           - present_1.images | length == 1
           - >-
-            docker_compose_version is version('2.37.0', '==') or
+            docker_compose_version is version('2.37.0', '>=') or
             present_1.images[0].ContainerName == (pname ~ '-' ~ cname ~ '-1')
           - present_1.images[0].Repository == (docker_test_image_alpine | split(':') | first)
           - present_1.images[0].Tag == (docker_test_image_alpine | split(':') | last)

--- a/tests/integration/targets/docker_compose_v2/tasks/tests/start-stop.yml
+++ b/tests/integration/targets/docker_compose_v2/tasks/tests/start-stop.yml
@@ -101,7 +101,7 @@
           - present_1.containers[0].Image == docker_test_image_alpine
           - present_1.images | length == 1
           - >-
-            docker_compose_version is version('2.37.0', '==') or
+            docker_compose_version is version('2.37.0', '>=') or
             present_1.images[0].ContainerName == (pname ~ '-' ~ cname ~ '-1')
           - present_1.images[0].Repository == (docker_test_image_alpine | split(':') | first)
           - present_1.images[0].Tag == (docker_test_image_alpine | split(':') | last)


### PR DESCRIPTION
##### SUMMARY
Ref: https://github.com/docker/compose/issues/12940

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
docker_compose_v2 tests
