### PR TITLE
CI: Bump Alpine 3.21 to 3.22 and Fedora 41 to 42

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -116,14 +116,14 @@ stages:
         parameters:
           testFormat: devel/linux/{0}
           targets:
-            - name: Fedora 41
-              test: fedora41
+            - name: Fedora 42
+              test: fedora42
             - name: Ubuntu 22.04
               test: ubuntu2204
             - name: Ubuntu 24.04
               test: ubuntu2404
-            - name: Alpine 3.21
-              test: alpine321
+            - name: Alpine 3.22
+              test: alpine322
           groups:
             - 4
             - 5
@@ -135,8 +135,10 @@ stages:
         parameters:
           testFormat: 2.19/linux/{0}
           targets:
-            - name: Ubuntu 24.04
-              test: ubuntu2404
+            - name: Fedora 42
+              test: fedora41
+            - name: Alpine 3.21
+              test: alpine321
           groups:
             - 4
             - 5
@@ -222,8 +224,8 @@ stages:
         parameters:
           testFormat: devel/{0}
           targets:
-            - name: RHEL 9.5 with Docker SDK, urllib3, requests from sources
-              test: rhel/9.5-dev-latest
+            - name: RHEL 9.6 with Docker SDK, urllib3, requests from sources
+              test: rhel/9.6-dev-latest
           groups:
             - 1
             - 2


### PR DESCRIPTION
##### SUMMARY
ansible-core devel updated its CI containers.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
