### PR TITLE
docker_swarm_service: add support for replicated jobs

### DIFF
--- a/changelogs/fragments/1108-replicated-job-support.yml
+++ b/changelogs/fragments/1108-replicated-job-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - docker_swarm_service - Add support for ``replicated-job`` mode for Swarm services (https://github.com/ansible-collections/community.docker/issues/626)

--- a/changelogs/fragments/1108-replicated-job-support.yml
+++ b/changelogs/fragments/1108-replicated-job-support.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - docker_swarm_service - Add support for ``replicated-job`` mode for Swarm services (https://github.com/ansible-collections/community.docker/issues/626)
+  - docker_swarm_service - add support for ``replicated-job`` mode for Swarm services (https://github.com/ansible-collections/community.docker/issues/626, https://github.com/ansible-collections/community.docker/pull/1108).

--- a/plugins/modules/docker_swarm_service.py
+++ b/plugins/modules/docker_swarm_service.py
@@ -242,6 +242,7 @@ options:
     choices:
       - replicated
       - global
+      - replicated-job
   mounts:
     description:
       - List of dictionaries describing the service mounts.
@@ -400,7 +401,7 @@ options:
     type: bool
   replicas:
     description:
-      - Number of containers instantiated in the service. Valid only if O(mode=replicated).
+      - Number of containers instantiated in the service. Valid only if O(mode=replicated) or O(mode=replicated-job).
       - If set to V(-1), and service is not present, service replicas will be set to V(1).
       - If set to V(-1), and service is present, service replicas will be unchanged.
       - Corresponds to the C(--replicas) option of C(docker service create).
@@ -2210,6 +2211,9 @@ class DockerServiceManager(object):
             ds.replicas = mode['Replicated']['Replicas']
         elif 'Global' in mode.keys():
             ds.mode = 'global'
+        elif 'ReplicatedJob' in mode.keys():
+            ds.mode = to_text('replicated-job', encoding='utf-8')
+            ds.replicas = mode['ReplicatedJob']['TotalCompletions']
         else:
             raise Exception('Unknown service mode: %s' % mode)
 
@@ -2605,7 +2609,7 @@ def main():
         mode=dict(
             type='str',
             default='replicated',
-            choices=['replicated', 'global']
+            choices=['replicated', 'global', 'replicated-job']
         ),
         replicas=dict(type='int', default=-1),
         endpoint_mode=dict(type='str', choices=['vip', 'dnsrr']),

--- a/plugins/modules/docker_swarm_service.py
+++ b/plugins/modules/docker_swarm_service.py
@@ -2758,6 +2758,12 @@ def main():
             ) is not None,
             usage_msg='set rollback_config.order'
         ),
+        mode=dict(
+            docker_py_version='6.0.0',
+            docker_api_version='1.41',
+            detect_usage=lambda c: c.module.get('mode') == 'replicated-job',
+            usage_msg='set mode'
+        ),
     )
     required_if = [
         ('state', 'present', ['image'])

--- a/plugins/modules/docker_swarm_service.py
+++ b/plugins/modules/docker_swarm_service.py
@@ -237,7 +237,7 @@ options:
       - Service replication mode.
       - Service will be removed and recreated when changed.
       - Corresponds to the C(--mode) option of C(docker service create).
-      - The value V(replicated-job) was added in community.docker 4.7.0 and requires API version >= 1.41.
+      - The value V(replicated-job) was added in community.docker 4.7.0, and requires API version >= 1.41 and Docker SDK for Python >= 6.0.0.
     type: str
     default: replicated
     choices:
@@ -2758,7 +2758,7 @@ def main():
             ) is not None,
             usage_msg='set rollback_config.order'
         ),
-        mode=dict(
+        mode_replicated_job=dict(
             docker_py_version='6.0.0',
             docker_api_version='1.41',
             detect_usage=lambda c: c.module.params.get('mode') == 'replicated-job',

--- a/plugins/modules/docker_swarm_service.py
+++ b/plugins/modules/docker_swarm_service.py
@@ -237,6 +237,7 @@ options:
       - Service replication mode.
       - Service will be removed and recreated when changed.
       - Corresponds to the C(--mode) option of C(docker service create).
+      - The value V(replicated-job) was added in community.docker 4.7.0 and requires API version >= 1.41.
     type: str
     default: replicated
     choices:

--- a/plugins/modules/docker_swarm_service.py
+++ b/plugins/modules/docker_swarm_service.py
@@ -2761,7 +2761,7 @@ def main():
         mode=dict(
             docker_py_version='6.0.0',
             docker_api_version='1.41',
-            detect_usage=lambda c: c.module.get('mode') == 'replicated-job',
+            detect_usage=lambda c: c.module.params.get('mode') == 'replicated-job',
             usage_msg='set mode'
         ),
     )

--- a/tests/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/tests/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -1307,11 +1307,51 @@
     state: absent
   diff: false
 
+- name: mode
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: "{{ docker_test_image_alpine }}"
+    resolve_image: false
+    command: '/bin/sh -v -c "sleep 10m"'
+    mode: "replicated-job"
+    replicas: 1
+  register: mode_4
+
+- name: mode (idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: "{{ docker_test_image_alpine }}"
+    resolve_image: false
+    command: '/bin/sh -v -c "sleep 10m"'
+    mode: "replicated-job"
+    replicas: 1
+  register: mode_5
+
+- name: mode (change)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: "{{ docker_test_image_alpine }}"
+    resolve_image: false
+    command: '/bin/sh -v -c "sleep 10m"'
+    mode: "replicated"
+    replicas: 1
+  register: mode_6
+
+- name: cleanup
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    state: absent
+  diff: false
+
+
 - assert:
     that:
       - mode_1 is changed
       - mode_2 is not changed
       - mode_3 is changed
+      - mode_4 is changed
+      - mode_5 is not changed
+      - mode_6 is changed
 
 ####################################################################
 ## stop_grace_period ###############################################

--- a/tests/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/tests/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -1352,6 +1352,11 @@
       - mode_6 is changed
   when: docker_api_version is version('1.41', '>=') and docker_py_version is version('6.0.0', '>=')
 
+- assert:
+    that:
+      - mode_4 is failed
+      - "'Minimum version required' in mode_4.msg"
+  when: docker_api_version is version('1.41', '<') or docker_py_version is version('6.0.0', '<')
 
 ####################################################################
 ## stop_grace_period ###############################################

--- a/tests/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/tests/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -1348,7 +1348,7 @@
 - assert:
     that:
       - mode_4 is changed
-      - mode_5 is not changed
+      - mode_5 is not changed and mode_5 is not failed
       - mode_6 is changed
   when: docker_api_version is version('1.41', '>=') and docker_py_version is version('6.0.0', '>=')
 

--- a/tests/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/tests/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -1301,13 +1301,7 @@
     replicas: 1
   register: mode_3
 
-- name: cleanup
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    state: absent
-  diff: false
-
-- name: mode
+- name: mode (change)
   docker_swarm_service:
     name: "{{ service_name }}"
     image: "{{ docker_test_image_alpine }}"
@@ -1316,6 +1310,7 @@
     mode: "replicated-job"
     replicas: 1
   register: mode_4
+  ignore_errors: true
 
 - name: mode (idempotency)
   docker_swarm_service:
@@ -1326,6 +1321,7 @@
     mode: "replicated-job"
     replicas: 1
   register: mode_5
+  ignore_errors: true
 
 - name: mode (change)
   docker_swarm_service:
@@ -1343,15 +1339,19 @@
     state: absent
   diff: false
 
-
 - assert:
     that:
       - mode_1 is changed
       - mode_2 is not changed
       - mode_3 is changed
+
+- assert:
+    that:
       - mode_4 is changed
       - mode_5 is not changed
       - mode_6 is changed
+  when: docker_api_version is version('1.41', '>=') and docker_py_version is version('6.0.0', '>=')
+
 
 ####################################################################
 ## stop_grace_period ###############################################


### PR DESCRIPTION
##### SUMMARY

This PR adds the support for the `replicated-job` mode for swarm services

Fixes #626 

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

docker_swarm_service

##### ADDITIONAL INFORMATION

The following task creates a replicated job:

```
- name: Run service
  become: true
  become_method: sudo
  community.docker.docker_swarm_service:
    name: "test_name"
    image: "bash"
    replicas: "1"
    mode: "replicated-job"
    command: "true"
```

```
TASK [test : Run service] ******************************************************************************************************************
ok: [host]

docker service ls | grep test_name
nvwqjwaoowgx   test_name                  replicated job   0/1 (1/1 completed)    bash 
```


There was also a bug when removing the job:

```
- name: Create replicated mode service
  ansible.builtin.command:
    cmd: >
      docker service create
      --name test_name
      --mode replicated-job
      --replicas 1
      bash
      "true"

- name: test service
  community.docker.docker_swarm_service:
    name: "test_name"
    state: absent

"Error looking for service named test_name: Unknown service mode: {'ReplicatedJob': {'MaxConcurrent': 1, 'TotalCompletions': 1}}"}
```
