### PR TITLE
ansible-core 2.20: avoid deprecated functionality

### DIFF
--- a/changelogs/fragments/1117-deprecations.yml
+++ b/changelogs/fragments/1117-deprecations.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Avoid deprecated functionality in ansible-core 2.20 (https://github.com/ansible-collections/community.docker/pull/1117)."

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -14,7 +14,7 @@ import sys
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils.common._collections_compat import Mapping, Sequence
+from ansible.module_utils.six.moves.collections_abc import Mapping, Sequence
 from ansible.module_utils.six import string_types
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_TRUE, BOOLEANS_FALSE
 

--- a/plugins/module_utils/common_api.py
+++ b/plugins/module_utils/common_api.py
@@ -12,7 +12,7 @@ import os
 import re
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils.common._collections_compat import Mapping, Sequence
+from ansible.module_utils.six.moves.collections_abc import Mapping, Sequence
 from ansible.module_utils.six import string_types
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_TRUE, BOOLEANS_FALSE
 

--- a/plugins/modules/docker_container_copy_into.py
+++ b/plugins/modules/docker_container_copy_into.py
@@ -171,7 +171,7 @@ import os
 import stat
 import traceback
 
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.common.validation import check_type_int
 from ansible.module_utils.six import integer_types, string_types
 

--- a/plugins/plugin_utils/unsafe.py
+++ b/plugins/plugin_utils/unsafe.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 import re
 
 from ansible.module_utils.six import binary_type, text_type
-from ansible.module_utils.common._collections_compat import Mapping, Set
+from collections.abc import Mapping, Set
 from ansible.module_utils.common.collections import is_sequence
 from ansible.utils.unsafe_proxy import (
     AnsibleUnsafe,


### PR DESCRIPTION
##### SUMMARY
ansible.module_utils._text and ansible.module_utils.common._collections_compat have been deprecated.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
various
