### PR TITLE
fix: typo in scenario_guide.rst

### DIFF
--- a/docs/docsite/rst/scenario_guide.rst
+++ b/docs/docsite/rst/scenario_guide.rst
@@ -95,7 +95,7 @@ The following example shows how the module default group can be used in a playbo
 .. code-block:: yaml+jinja
 
     ---
-    - name: Pull and image and start the container
+    - name: Pull image and start the container
       hosts: localhost
       gather_facts: false
       module_defaults:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
the duplication typo in listing
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
scenario_guide.rst

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Pull and image and start the container
  hosts: localhost
```
- name: Pull image and start the container
  hosts: localhost