### PR TITLE
CI: Start using Ubuntu VMs instead of RHEL VMs

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -228,6 +228,8 @@ stages:
           targets:
             - name: RHEL 9.6 with Docker SDK, urllib3, requests from sources
               test: rhel/9.6-dev-latest
+            - name: Ubuntu 24.04
+              test: ubuntu/24.04
           groups:
             - 1
             - 2
@@ -244,6 +246,8 @@ stages:
           targets:
             - name: RHEL 9.5
               test: rhel/9.5
+            - name: Ubuntu 22.04
+              test: ubuntu/22.04
           groups:
             - 1
             - 2
@@ -290,8 +294,6 @@ stages:
         parameters:
           testFormat: 2.16/{0}
           targets:
-            - name: RHEL 9.2
-              test: rhel/9.2
             - name: RHEL 8.8
               test: rhel/8.8
             - name: RHEL 7.9

--- a/tests/integration/targets/docker_config/tasks/test_docker_config.yml
+++ b/tests/integration/targets/docker_config/tasks/test_docker_config.yml
@@ -4,14 +4,14 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - block:
-    - shell: "docker info --format '{% raw %}{{json .}}{% endraw %}' | python -m json.tool"
+    - shell: "docker info --format '{% raw %}{{json .}}{% endraw %}' | {{ ansible_python_interpreter }} -m json.tool"
 
     - name: Make sure we're not already using Docker swarm
       docker_swarm:
         state: absent
         force: true
 
-    - shell: "docker info --format '{% raw %}{{json .}}{% endraw %}' | python -m json.tool"
+    - shell: "docker info --format '{% raw %}{{json .}}{% endraw %}' | {{ ansible_python_interpreter }} -m json.tool"
 
     - name: Create a Swarm cluster
       docker_swarm:

--- a/tests/integration/targets/setup_podman/tasks/main.yml
+++ b/tests/integration/targets/setup_podman/tasks/main.yml
@@ -57,7 +57,7 @@
               systemd_service:
                 name: "{{ podman_socket_service }}"
                 state: started
-                scope: "{{ 'global' if podman_user_id.stdout == '0' else 'user' }}"
+                scope: "{{ 'global' if podman_user_id.stdout == '0' and ansible_facts.os_family == 'RedHat' else 'user' }}"
               environment:
                 XDG_RUNTIME_DIR: "{{ '/run' if podman_user_id.stdout == '0' else ('/run/user/' ~ podman_user_id.stdout) }}"
 


### PR DESCRIPTION
##### SUMMARY
Looks like RHEL 10 won't support Docker anymore, so we'll have to do something else to run the tests that require VMs.

This PR adds Ubuntu 24.04 with devel, and Ubuntu 22.04 with stable-2.19, and removes one of the RHEL 9 VM tests instead.

Closes #1081.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
