### PR TITLE
CI: Move ansible-core 2.16 from AZP to GHA

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -95,17 +95,6 @@ stages:
               test: '2.17/sanity/1'
             - name: Units
               test: '2.17/units/1'
-  - stage: Ansible_2_16
-    displayName: Sanity & Units 2.16
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: '2.16/sanity/1'
-            - name: Units
-              test: '2.16/units/1'
 
 ### Docker
   - stage: Docker_devel
@@ -173,25 +162,6 @@ stages:
               test: ubuntu2004
             - name: Alpine 3.19
               test: alpine319
-          groups:
-            - 4
-            - 5
-  - stage: Docker_2_16
-    displayName: Docker 2.16
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.16/linux/{0}
-          targets:
-            - name: Fedora 38
-              test: fedora38
-            - name: CentOS 7
-              test: centos7
-            - name: openSUSE 15
-              test: opensuse15
-            - name: Alpine 3
-              test: alpine3
           groups:
             - 4
             - 5
@@ -287,24 +257,6 @@ stages:
             - 3
             - 4
             - 5
-  - stage: Remote_2_16
-    displayName: Remote 2.16
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.16/{0}
-          targets:
-            - name: RHEL 8.8
-              test: rhel/8.8
-            - name: RHEL 7.9
-              test: rhel/7.9
-          groups:
-            - 1
-            - 2
-            - 3
-            - 4
-            - 5
 
   ## Finally
 
@@ -315,17 +267,14 @@ stages:
       - Ansible_2_19
       - Ansible_2_18
       - Ansible_2_17
-      - Ansible_2_16
       - Remote_devel
       - Remote_2_19
       - Remote_2_18
       - Remote_2_17
-      - Remote_2_16
       - Docker_devel
       - Docker_2_19
       - Docker_2_18
       - Docker_2_17
-      - Docker_2_16
       - Docker_community_devel
     jobs:
       - template: templates/coverage.yml

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -32,4 +32,4 @@ jobs:
     with:
       change-detection-in-prs: true
       upload-codecov: true
-      max-ansible-core: "2.15"
+      max-ansible-core: "2.16"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 [![Documentation](https://img.shields.io/badge/docs-brightgreen.svg)](https://docs.ansible.com/ansible/devel/collections/community/docker/)
 [![Build Status](https://dev.azure.com/ansible/community.docker/_apis/build/status/CI?branchName=main)](https://dev.azure.com/ansible/community.docker/_build?definitionId=25)
-[![EOL CI](https://github.com/ansible-collections/community.docker/actions/workflows/ansible-test.yml/badge.svg?branch=main)](https://github.com/ansible-collections/community.docker/actions)
 [![Nox CI](https://github.com/ansible-collections/community.docker/actions/workflows/nox.yml/badge.svg?branch=main)](https://github.com/ansible-collections/community.docker/actions)
 [![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/community.docker)](https://codecov.io/gh/ansible-collections/community.docker)
 [![REUSE status](https://api.reuse.software/badge/github.com/ansible-collections/community.docker)](https://api.reuse.software/info/github.com/ansible-collections/community.docker)

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -94,6 +94,11 @@ ansible_core = "2.15"
 target = [ "azp/4/", "azp/5/" ]
 docker = [ "fedora37" ]
 
+[[sessions.ansible_test_integration.sessions]]
+ansible_core = "2.16"
+target = [ "azp/4/", "azp/5/" ]
+docker = [ "fedora38", "centos7", "opensuse15", "alpine3" ]
+
 [[sessions.ee_check.execution_environments]]
 name = "devel-ubi-9"
 description = "ansible-core devel @ RHEL UBI 9"


### PR DESCRIPTION
##### SUMMARY
ansible-core 2.16 has been EOL for some time now. Also remove dead badge from README.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
