### PR TITLE
Avoid six in plugin code

### DIFF
--- a/changelogs/fragments/1137-six.yml
+++ b/changelogs/fragments/1137-six.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Avoid usage of deprecated ``ansible.module_utils.six`` in all code that does not have to support Python 2 (https://github.com/ansible-collections/community.docker/pull/1137)."

--- a/plugins/connection/docker.py
+++ b/plugins/connection/docker.py
@@ -117,10 +117,9 @@ import os
 import os.path
 import subprocess
 import re
+from shlex import quote as shlex_quote
 
 from ansible.errors import AnsibleError, AnsibleFileNotFound, AnsibleConnectionFailure
-from ansible.module_utils.six.moves import shlex_quote
-from ansible.module_utils.six import string_types
 from ansible.module_utils.common.process import get_bin_path
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
@@ -249,7 +248,7 @@ class Connection(ConnectionBase):
         if self.get_option('extra_env'):
             for k, v in self.get_option('extra_env').items():
                 for val, what in ((k, 'Key'), (v, 'Value')):
-                    if not isinstance(val, string_types):
+                    if not isinstance(val, (str, bytes)):
                         raise AnsibleConnectionFailure(
                             'Non-string {0} found for extra_env option. Ambiguous env options must be '
                             'wrapped in quotes to avoid them being interpreted. {1}: {2!r}'

--- a/plugins/connection/docker_api.py
+++ b/plugins/connection/docker_api.py
@@ -110,7 +110,6 @@ import os.path
 
 from ansible.errors import AnsibleFileNotFound, AnsibleConnectionFailure
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
-from ansible.module_utils.six import string_types
 from ansible.plugins.connection import ConnectionBase
 from ansible.utils.display import Display
 
@@ -244,7 +243,7 @@ class Connection(ConnectionBase):
             data['Env'] = []
             for k, v in self.get_option('extra_env').items():
                 for val, what in ((k, 'Key'), (v, 'Value')):
-                    if not isinstance(val, string_types):
+                    if not isinstance(val, (str, bytes)):
                         raise AnsibleConnectionFailure(
                             'Non-string {0} found for extra_env option. Ambiguous env options must be '
                             'wrapped in quotes to avoid them being interpreted. {1}: {2!r}'

--- a/plugins/connection/nsenter.py
+++ b/plugins/connection/nsenter.py
@@ -47,7 +47,6 @@ import fcntl
 
 import ansible.constants as C
 from ansible.errors import AnsibleError
-from ansible.module_utils.six import binary_type, text_type
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.plugins.connection import ConnectionBase
 from ansible.utils.display import Display
@@ -111,7 +110,7 @@ class Connection(ConnectionBase):
             "--",
         ]
 
-        if isinstance(cmd, (text_type, binary_type)):
+        if isinstance(cmd, (str, bytes)):
             cmd_parts = nsenter_cmd_parts + [cmd]
             cmd = to_bytes(" ".join(cmd_parts))
         else:
@@ -138,8 +137,8 @@ class Connection(ConnectionBase):
 
         p = subprocess.Popen(
             cmd,
-            shell=isinstance(cmd, (text_type, binary_type)),
-            executable=executable if isinstance(cmd, (text_type, binary_type)) else None,
+            shell=isinstance(cmd, (str, bytes)),
+            executable=executable if isinstance(cmd, (str, bytes)) else None,
             cwd=self.cwd,
             stdin=stdin,
             stdout=subprocess.PIPE,

--- a/plugins/plugin_utils/unsafe.py
+++ b/plugins/plugin_utils/unsafe.py
@@ -7,7 +7,6 @@ __metaclass__ = type
 
 import re
 
-from ansible.module_utils.six import binary_type, text_type
 from collections.abc import Mapping, Set
 from ansible.module_utils.common.collections import is_sequence
 from ansible.utils.unsafe_proxy import (
@@ -29,11 +28,11 @@ def make_unsafe(value):
         return set(make_unsafe(elt) for elt in value)
     elif is_sequence(value):
         return type(value)(make_unsafe(elt) for elt in value)
-    elif isinstance(value, binary_type):
+    elif isinstance(value, bytes):
         if _RE_TEMPLATE_CHARS_BYTES.search(value):
             value = _make_unsafe(value)
         return value
-    elif isinstance(value, text_type):
+    elif isinstance(value, str):
         if _RE_TEMPLATE_CHARS.search(value):
             value = _make_unsafe(value)
         return value

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,6 +1,3 @@
-plugins/connection/docker.py pylint:ansible-bad-import-from
-plugins/connection/docker_api.py pylint:ansible-bad-import-from
-plugins/connection/nsenter.py pylint:ansible-bad-import-from
 plugins/module_utils/_api/_import_helper.py pylint:ansible-bad-import-from
 plugins/module_utils/_api/api/client.py pylint:ansible-bad-import-from
 plugins/module_utils/_api/api/client.py pylint:use-yield-from  # suggested construct does not work with Python 2
@@ -38,7 +35,5 @@ plugins/modules/docker_context_info.py pylint:ansible-bad-import-from
 plugins/modules/docker_stack.py pylint:ansible-bad-import-from
 plugins/modules/docker_swarm_service.py pylint:ansible-bad-import-from
 plugins/modules/docker_volume.py pylint:ansible-bad-import-from
-plugins/plugin_utils/unsafe.py pylint:ansible-bad-import-from
-tests/unit/plugins/connection/test_docker.py pylint:ansible-bad-import-from
 tests/unit/plugins/module_utils/_api/utils/test_utils.py pylint:ansible-bad-import-from
 tests/unit/plugins/module_utils/test_copy.py pylint:use-yield-from  # suggested construct does not work with Python 2

--- a/tests/unit/plugins/connection/test_docker.py
+++ b/tests/unit/plugins/connection/test_docker.py
@@ -14,7 +14,6 @@ from ansible_collections.community.internal_test_tools.tests.unit.compat import 
 from ansible.errors import AnsibleError
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader
-from ansible.module_utils.six import PY2
 
 
 class TestDockerConnectionClass(unittest.TestCase):
@@ -38,8 +37,7 @@ class TestDockerConnectionClass(unittest.TestCase):
     def test_docker_connection_module_too_old(self, mock_new_docker_version, mock_old_docker_version):
         self.dc._version = None
         self.dc.remote_user = 'foo'
-        (self.assertRaisesRegexp if PY2 else self.assertRaisesRegex)(
-            AnsibleError, '^docker connection type requires docker 1.3 or higher$', self.dc._get_actual_user)
+        self.assertRaisesRegex(AnsibleError, '^docker connection type requires docker 1.3 or higher$', self.dc._get_actual_user)
 
     @mock.patch('ansible_collections.community.docker.plugins.connection.docker.Connection._old_docker_version',
                 return_value=('false', 'garbage', '', 1))
@@ -57,5 +55,4 @@ class TestDockerConnectionClass(unittest.TestCase):
     def test_docker_connection_module_wrong_cmd(self, mock_new_docker_version, mock_old_docker_version):
         self.dc._version = None
         self.dc.remote_user = 'foo'
-        (self.assertRaisesRegexp if PY2 else self.assertRaisesRegex)(
-            AnsibleError, '^Docker version check (.*?) failed:', self.dc._get_actual_user)
+        self.assertRaisesRegex(AnsibleError, '^Docker version check (.*?) failed:', self.dc._get_actual_user)


### PR DESCRIPTION
##### SUMMARY
ansible.module_utils.six is deprecated in ansible-core 2.20.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
various
