### PR TITLE
docker_container: add driver_opts and gw_priority

### DIFF
--- a/changelogs/fragments/1142-docker-container-network-driver-opts.yml
+++ b/changelogs/fragments/1142-docker-container-network-driver-opts.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "docker_container - add ``driver_opts`` option in ``networks`` (https://github.com/ansible-collections/community.docker/issues/1142, https://github.com/ansible-collections/community.docker/pull/1143)."
+  - "docker_container - add ``gw_priority`` option in ``networks`` (https://github.com/ansible-collections/community.docker/issues/1142, https://github.com/ansible-collections/community.docker/pull/1143)."

--- a/plugins/module_utils/_module_container/base.py
+++ b/plugins/module_utils/_module_container/base.py
@@ -1144,6 +1144,8 @@ OPTION_NETWORK = (
             aliases=dict(type="list", elements="str"),
             links=dict(type="list", elements="str"),
             mac_address=dict(type="str"),
+            driver_opts=dict(type="dict"),
+            gw_priority=dict(type="int"),
         ),
     )
 )

--- a/plugins/modules/docker_container.py
+++ b/plugins/modules/docker_container.py
@@ -751,6 +751,21 @@ options:
             Daemon at least in some cases. When passed on creation, this seems to work better.
         type: str
         version_added: 3.6.0
+      driver_opts:
+        description:
+          - Dictionary of driver options for this network endpoint.
+          - Allows setting endpoint-specific driver options like C(com.docker.network.endpoint.ifname) to set a custom network interface name.
+          - Requires Docker API version 1.32 or newer.
+        type: dict
+        version_added: 5.0.0
+      gw_priority:
+        description:
+          - Gateway priority for this network endpoint.
+          - When a container is connected to multiple networks, this controls which network's gateway is used as the default gateway.
+          - Higher values indicate higher priority.
+          - Requires Docker API version 1.48 or newer.
+        type: int
+        version_added: 5.0.0
   networks_cli_compatible:
     description:
       - If O(networks_cli_compatible=true) (default), this module will behave as C(docker run --network) and will B(not) add


### PR DESCRIPTION
##### SUMMARY
Fixes #1142

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Would allow users to change the driver_opts and gateway priority like this:
```yaml
    - name: Create WireGuard Easy container with custom network interface names
      community.docker.docker_container:
        name: wg-easy
        image: ghcr.io/wg-easy/wg-easy:15
        state: started
        env:
          WG_DEVICE: eth0
        networks:
          # Frontend network will use eth1 as interface name with higher gateway priority
          - name: frontend
            driver_opts:
              com.docker.network.endpoint.ifname: eth1
            gw_priority: 0
          # WG network will use eth0 as interface name with static IPs
          - name: wg
            driver_opts:
              com.docker.network.endpoint.ifname: eth0
            ipv4_address: 10.42.42.42
            ipv6_address: fdcc:ad94:bacf:61a3::2a
            gw_priority: 1
```

##### ADDITIONAL INFORMATION
Not sure what else to include here, it is just exposing settings not previously exposed in the module.
