### PR TITLE
docker, nsenter connections: avoid losing data from events if multiple arrive at the same time

### DIFF
--- a/changelogs/fragments/1158-select-fix.yml
+++ b/changelogs/fragments/1158-select-fix.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "docker, nsenter connection plugins - fix handling of ``become`` plugin password prompt handling in case multiple events arrive at the same time
+     (https://github.com/ansible-collections/community.docker/pull/1158)."

--- a/plugins/connection/docker.py
+++ b/plugins/connection/docker.py
@@ -425,21 +425,24 @@ class Connection(ConnectionBase):
                             + to_native(become_output)
                         )
 
-                    chunk = None
+                    chunks = b""
                     for key, event in events:
                         if key.fileobj == p.stdout:
                             chunk = p.stdout.read()
+                            if chunk:
+                                chunks += chunk
                         elif key.fileobj == p.stderr:
                             chunk = p.stderr.read()
-                    # TODO: avoid chunk being set multiple times!
+                            if chunk:
+                                chunks += chunk
 
-                    if not chunk:
+                    if not chunks:
                         stdout, stderr = p.communicate()
                         raise AnsibleError(
                             "privilege output closed while waiting for password prompt:\n"
                             + to_native(become_output)
                         )
-                    become_output += chunk
+                    become_output += chunks
             finally:
                 selector.close()
 

--- a/plugins/connection/nsenter.py
+++ b/plugins/connection/nsenter.py
@@ -177,21 +177,24 @@ class Connection(ConnectionBase):
                             + to_native(become_output)
                         )
 
-                    chunk = None
+                    chunks = b""
                     for key, event in events:
                         if key.fileobj == p.stdout:
                             chunk = p.stdout.read()
+                            if chunk:
+                                chunks += chunk
                         elif key.fileobj == p.stderr:
                             chunk = p.stderr.read()
-                    # TODO: avoid chunk being set multiple times!
+                            if chunk:
+                                chunks += chunk
 
-                    if not chunk:
+                    if not chunks:
                         stdout, stderr = p.communicate()
                         raise AnsibleError(
                             "privilege output closed while waiting for password prompt:\n"
                             + to_native(become_output)
                         )
-                    become_output += chunk
+                    become_output += chunks
             finally:
                 selector.close()
 


### PR DESCRIPTION
##### SUMMARY
If there is more than one event, the data read from previous ones is overridden.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker connection
nsenter connection
