### PR TITLE
Python code modernization, 5/n (selectors is now part of stdlib)

### DIFF
--- a/plugins/module_utils/_socket_helper.py
+++ b/plugins/module_utils/_socket_helper.py
@@ -11,9 +11,10 @@ import fcntl
 import os
 import os.path
 import socket as pysocket
+import typing as t
 
 
-def make_file_unblocking(file):
+def make_file_unblocking(file) -> None:
     fcntl.fcntl(
         file.fileno(),
         fcntl.F_SETFL,
@@ -21,7 +22,7 @@ def make_file_unblocking(file):
     )
 
 
-def make_file_blocking(file):
+def make_file_blocking(file) -> None:
     fcntl.fcntl(
         file.fileno(),
         fcntl.F_SETFL,
@@ -29,7 +30,7 @@ def make_file_blocking(file):
     )
 
 
-def make_unblocking(sock):
+def make_unblocking(sock) -> None:
     if hasattr(sock, "_sock"):
         sock._sock.setblocking(0)
     elif hasattr(sock, "setblocking"):
@@ -38,11 +39,11 @@ def make_unblocking(sock):
         make_file_unblocking(sock)
 
 
-def _empty_writer(msg):
+def _empty_writer(msg: str) -> None:
     pass
 
 
-def shutdown_writing(sock, log=_empty_writer):
+def shutdown_writing(sock, log: t.Callable[[str], None] = _empty_writer) -> None:
     # FIXME: This does **not work with SSLSocket**! Apparently SSLSocket does not allow to send
     #        a close_notify TLS alert without completely shutting down the connection.
     #        Calling sock.shutdown(pysocket.SHUT_WR) simply turns of TLS encryption and from that
@@ -62,7 +63,7 @@ def shutdown_writing(sock, log=_empty_writer):
         log("No idea how to signal end of writing")
 
 
-def write_to_socket(sock, data):
+def write_to_socket(sock, data: bytes) -> None:
     if hasattr(sock, "_send_until_done"):
         # WrappedSocket (urllib3/contrib/pyopenssl) does not have `send`, but
         # only `sendall`, which uses `_send_until_done` under the hood.

--- a/plugins/modules/docker_container_exec.py
+++ b/plugins/modules/docker_container_exec.py
@@ -163,7 +163,6 @@ exec_id:
   version_added: 2.1.0
 """
 
-import selectors
 import shlex
 import traceback
 
@@ -276,7 +275,7 @@ def main():
                 )
                 try:
                     with DockerSocketHandlerModule(
-                        exec_socket, client.module, selectors
+                        exec_socket, client.module
                     ) as exec_socket_handler:
                         if stdin:
                             exec_socket_handler.write(to_bytes(stdin))

--- a/plugins/plugin_utils/_socket_handler.py
+++ b/plugins/plugin_utils/_socket_handler.py
@@ -7,8 +7,6 @@
 
 from __future__ import annotations
 
-import selectors
-
 from ansible_collections.community.docker.plugins.module_utils._socket_handler import (
     DockerSocketHandlerBase,
 )
@@ -16,6 +14,4 @@ from ansible_collections.community.docker.plugins.module_utils._socket_handler i
 
 class DockerSocketHandler(DockerSocketHandlerBase):
     def __init__(self, display, sock, log=None, container=None):
-        super().__init__(
-            sock, selectors, log=lambda msg: display.vvvv(msg, host=container)
-        )
+        super().__init__(sock, log=lambda msg: display.vvvv(msg, host=container))


### PR DESCRIPTION
##### SUMMARY
No need to pass selectors around.

Follow-up to #1141, #1156, #1157, #1162.

##### ISSUE TYPE
- Refactor Pull Request

##### COMPONENT NAME
various
