### PR TITLE
[stable-4] docker_container modlue utils: fix method signature

### DIFF
--- a/plugins/module_utils/module_container/base.py
+++ b/plugins/module_utils/module_container/base.py
@@ -202,7 +202,7 @@ class Engine(object):
         pass
 
     @abc.abstractmethod
-    def ignore_mismatching_result(self, module, client, api_version, option, image, container_value, expected_value):
+    def ignore_mismatching_result(self, module, client, api_version, option, image, container_value, expected_value, host_info):
         pass
 
     @abc.abstractmethod


### PR DESCRIPTION
##### SUMMARY
Fixed for `main` in #1170.

This has no practical effect since the only class implementing this simply sets the method to something else.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container module utils
