### PR TITLE
Fix error for "Cannot locate specified Dockerfile"

### DIFF
--- a/changelogs/fragments/1185-fix.yml
+++ b/changelogs/fragments/1185-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "docker_image - fix 'Cannot locate specified Dockerfile' error (https://github.com/ansible-collections/community.docker/pull/1184)."

--- a/plugins/modules/docker_image.py
+++ b/plugins/modules/docker_image.py
@@ -906,7 +906,9 @@ class ImageManager(DockerBaseClass):
             if key not in CONTAINER_LIMITS_KEYS:
                 raise DockerException(f"Invalid container_limits key {key}")
 
-        dockerfile = self.dockerfile
+        dockerfile: tuple[str, str | None] | tuple[None, None] | str | None = (
+            self.dockerfile
+        )
         if self.build_path.startswith(
             ("http://", "https://", "git://", "github.com/", "git@")
         ):
@@ -924,7 +926,8 @@ class ImageManager(DockerBaseClass):
                             [line.strip() for line in f.read().splitlines()],
                         )
                     )
-            dockerfile_data = process_dockerfile(dockerfile, self.build_path)
+            dockerfile_data = process_dockerfile(self.dockerfile, self.build_path)
+            dockerfile = dockerfile_data
             context = tar(
                 self.build_path, exclude=exclude, dockerfile=dockerfile_data, gzip=False
             )


### PR DESCRIPTION
##### SUMMARY

In 3350283bcc37319adecd14c344305d2a8a5cd927, a subtle bug was introduced by renaming this variable. For image builds that go down the `else` branch, they never set this variable, which is then referenced below when constructing the `params` dict. This results in a very confusing bug from the Docker backend when trying to construct images:

> An unexpected Docker error occurred: 500 Server Error for
> http+docker://localhost/v1.51/build?t=molecule_local%2Fubuntu%3A24.04&q=False&nocache=False&rm=True&forcerm=True&pull=True&dockerfile=%2Fhome%2Fci%2F.ansible%2Ftmp%2Fmolecule.IaMj.install-github%2FDockerfile_ubuntu_24_04:
> Internal Server Error ("Cannot locate specified Dockerfile:
> /home/ci/.ansible/tmp/molecule.IaMj.install-github/Dockerfile_ubuntu_24_04")

Within the Docker daemon logs, the actual error presents itself like this:

> level=debug msg="FIXME: Got an API for which error does not match any
> expected type!!!" error="Cannot locate specified Dockerfile:
> $HOME/.ansible/tmp/molecule.5DrS.install-package/Dockerfile_ubuntu_24_04"
> error_type="*errors.fundamental" module=api

Unfortunately, these are all red herrings and the actual cause of the problem isn't Docker itself or the missing file, but in fact the `docker_image` module not passing the correct parameter data here.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

`docker_image`

##### ADDITIONAL INFORMATION

I originally came across the problem via Molecule, which suddenly started failing to test Ansible roles on our CI server with the above errors. I can reproduce the error easily simply by running `molecule create`. With the above fix in place, happily the error no longer occurs.