### PR TITLE
bugfix: surface CLI rc/stderr in call_cli_json instead of opaque JSONDecodeError

### DIFF
--- a/changelogs/fragments/fix-call-cli-json-rc-check.yml
+++ b/changelogs/fragments/fix-call-cli-json-rc-check.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "CLI-based modules - when the docker CLI exits non-zero and produces no parseable JSON on stdout, surface the CLI's own ``stderr`` and exit code instead of the misleading ``Expecting value: line 1 column 1 (char 0)`` ``JSONDecodeError``. This addresses cases such as a stale ``Config.Image`` SHA causing ``docker compose images --format json`` to fail with ``Error response from daemon: No such image: ...`` on stderr and empty stdout (https://github.com/ansible-collections/community.docker/issues/1216)."

--- a/plugins/module_utils/_common_cli.py
+++ b/plugins/module_utils/_common_cli.py
@@ -178,6 +178,30 @@ class AnsibleDockerClientBase:
     ) -> tuple[int, bytes, bytes]:
         pass
 
+    def _fail_with_cli_error(
+        self,
+        args: t.Sequence[str],
+        rc: int,
+        stdout: bytes,
+        stderr: bytes,
+    ) -> t.NoReturn:
+        """Fail with a clear message that leads with the CLI's own error output
+        and exit code. Used when stdout could not be parsed as JSON *and* the
+        CLI exited non-zero -- in that situation the underlying CLI error
+        (which lives in stderr) is the real cause and is far more informative
+        than the downstream JSON parsing failure.
+        """
+        cmd = self._compose_cmd_str(args)
+        self.fail(
+            f"Error while executing {cmd}: command exited with rc={rc}.\n"
+            f"Error output:\n{to_text(stderr)}\n"
+            f"Standard output:\n{to_text(stdout)}",
+            cmd=cmd,
+            rc=rc,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
     def call_cli_json(
         self,
         *args: str,
@@ -195,6 +219,13 @@ class AnsibleDockerClientBase:
         try:
             data = json.loads(stdout)
         except Exception as exc:  # pylint: disable=broad-exception-caught
+            # If JSON parsing failed and the CLI also exited non-zero, the real
+            # cause is almost certainly in stderr (e.g. "No such image:
+            # sha256:..." with rc=1 and empty stdout). Surface the CLI's error
+            # instead of a misleading JSONDecodeError such as
+            # "Expecting value: line 1 column 1 (char 0)".
+            if rc != 0:
+                self._fail_with_cli_error(args, rc, stdout, stderr)
             self.fail(
                 f"Error while parsing JSON output of {self._compose_cmd_str(args)}: {exc}\nJSON output: {to_text(stdout)}\n\nError output:\n{to_text(stderr)}",
                 cmd=self._compose_cmd_str(args),
@@ -225,6 +256,10 @@ class AnsibleDockerClientBase:
                 if line.startswith(b"{"):
                     result.append(json.loads(line))
         except Exception as exc:  # pylint: disable=broad-exception-caught
+            # See call_cli_json: prefer the CLI's own error message when the
+            # command failed and the JSON stream is unparseable.
+            if rc != 0:
+                self._fail_with_cli_error(args, rc, stdout, stderr)
             self.fail(
                 f"Error while parsing JSON output of {self._compose_cmd_str(args)}: {exc}\nJSON output: {to_text(stdout)}\n\nError output:\n{to_text(stderr)}",
                 cmd=self._compose_cmd_str(args),

--- a/tests/unit/plugins/module_utils/test__common_cli.py
+++ b/tests/unit/plugins/module_utils/test__common_cli.py
@@ -1,0 +1,161 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from ansible_collections.community.docker.plugins.module_utils._common_cli import (
+    AnsibleDockerClientBase,
+)
+
+
+class _FailCalled(Exception):
+    """Raised by the test stub's fail() so tests can inspect the failure."""
+
+    def __init__(self, msg: str, **kwargs: t.Any) -> None:
+        super().__init__(msg)
+        self.msg = msg
+        self.kwargs = kwargs
+
+
+class _StubClient(AnsibleDockerClientBase):
+    """Minimal AnsibleDockerClientBase subclass for unit testing the JSON
+    helpers without spinning up an AnsibleModule or invoking the real docker
+    CLI. We deliberately skip the parent __init__ since it calls call_cli_json
+    against `docker version` during construction.
+    """
+
+    def __init__(self, rc: int, stdout: bytes, stderr: bytes) -> None:  # pylint: disable=super-init-not-called
+        self._rc = rc
+        self._stdout = stdout
+        self._stderr = stderr
+        self._cli = "/usr/bin/docker"
+        self._cli_base = [self._cli]
+        self.warnings: list[str] = []
+
+    def call_cli(
+        self,
+        *args: str,
+        check_rc: bool = False,
+        data: bytes | None = None,
+        cwd: str | None = None,
+        environ_update: dict[str, str] | None = None,
+    ) -> tuple[int, bytes, bytes]:
+        return self._rc, self._stdout, self._stderr
+
+    def fail(self, msg: str, **kwargs: t.Any) -> t.NoReturn:
+        raise _FailCalled(msg, **kwargs)
+
+    def warn(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+    def deprecate(
+        self,
+        msg: str,
+        version: str | None = None,
+        date: str | None = None,
+        collection_name: str | None = None,
+    ) -> None:
+        pass
+
+
+# --- call_cli_json -----------------------------------------------------------
+
+
+def test_call_cli_json_success_returns_parsed_data() -> None:
+    client = _StubClient(rc=0, stdout=b'{"foo": "bar"}', stderr=b"")
+    rc, data, stderr = client.call_cli_json("anything")
+    assert rc == 0
+    assert data == {"foo": "bar"}
+    assert stderr == b""
+
+
+def test_call_cli_json_nonzero_rc_with_valid_json_still_returns() -> None:
+    """`docker image inspect <missing>` returns rc=1 with stdout `[]`; the
+    helper must keep returning so callers can detect the missing image."""
+    client = _StubClient(rc=1, stdout=b"[]", stderr=b"Error: No such image: foo")
+    rc, data, stderr = client.call_cli_json("image", "inspect", "foo")
+    assert rc == 1
+    assert data == []
+    assert b"No such image" in stderr
+
+
+def test_call_cli_json_nonzero_rc_with_empty_stdout_surfaces_cli_error() -> None:
+    """Regression test for the bug where rc!=0 + empty stdout produced an
+    opaque "Expecting value: line 1 column 1 (char 0)" JSONDecodeError that
+    hid the real CLI failure that lived in stderr."""
+    stderr = b"Error response from daemon: No such image: sha256:c02a671fd71657"
+    client = _StubClient(rc=1, stdout=b"", stderr=stderr)
+    with pytest.raises(_FailCalled) as excinfo:
+        client.call_cli_json("compose", "images", "--format", "json")
+
+    msg = excinfo.value.msg
+    # The user-facing message must lead with the CLI failure and include
+    # stderr; it must NOT be a generic JSON parsing error.
+    assert "rc=1" in msg
+    assert "No such image" in msg
+    assert "Expecting value" not in msg
+    assert "Error while parsing JSON output" not in msg
+    # Machine-readable fields should still be populated.
+    assert excinfo.value.kwargs["rc"] == 1
+    assert excinfo.value.kwargs["stderr"] == stderr
+    assert excinfo.value.kwargs["stdout"] == b""
+
+
+def test_call_cli_json_zero_rc_with_unparseable_stdout_keeps_json_error() -> None:
+    """When the CLI succeeded but emitted garbage, the JSON parse error is
+    actually the relevant message -- preserve the existing behavior."""
+    client = _StubClient(rc=0, stdout=b"not json", stderr=b"")
+    with pytest.raises(_FailCalled) as excinfo:
+        client.call_cli_json("info", "--format", "{{ json . }}")
+    assert "Error while parsing JSON output" in excinfo.value.msg
+
+
+# --- call_cli_json_stream ----------------------------------------------------
+
+
+def test_call_cli_json_stream_success_returns_parsed_lines() -> None:
+    client = _StubClient(
+        rc=0, stdout=b'{"a": 1}\n{"b": 2}\n', stderr=b""
+    )
+    rc, data, stderr = client.call_cli_json_stream("ps", "--format", "json")
+    assert rc == 0
+    assert data == [{"a": 1}, {"b": 2}]
+    assert stderr == b""
+
+
+def test_call_cli_json_stream_nonzero_rc_with_bad_line_surfaces_cli_error() -> None:
+    """Regression test: the streaming variant of call_cli_json must also
+    surface the CLI's stderr when rc!=0 and a JSON line fails to parse."""
+    stderr = b"Error response from daemon: connection refused"
+    client = _StubClient(rc=2, stdout=b"{this is not json}\n", stderr=stderr)
+    with pytest.raises(_FailCalled) as excinfo:
+        client.call_cli_json_stream("ps", "--format", "json")
+    msg = excinfo.value.msg
+    assert "rc=2" in msg
+    assert "connection refused" in msg
+    assert "Error while parsing JSON output" not in msg
+    assert excinfo.value.kwargs["rc"] == 2
+    assert excinfo.value.kwargs["stderr"] == stderr
+
+
+def test_call_cli_json_stream_zero_rc_with_bad_line_keeps_json_error() -> None:
+    client = _StubClient(rc=0, stdout=b"{this is not json}\n", stderr=b"")
+    with pytest.raises(_FailCalled) as excinfo:
+        client.call_cli_json_stream("ps", "--format", "json")
+    assert "Error while parsing JSON output" in excinfo.value.msg
+
+
+# --- warn_on_stderr behaviour preserved -------------------------------------
+
+
+def test_call_cli_json_warn_on_stderr_still_warns() -> None:
+    client = _StubClient(rc=0, stdout=b"{}", stderr=b"some warning")
+    rc, data, stderr = client.call_cli_json("any", warn_on_stderr=True)
+    assert rc == 0
+    assert data == {}
+    assert "some warning" in client.warnings


### PR DESCRIPTION
## Summary

When the docker CLI exits non-zero with empty or non-JSON stdout, the
real cause -- the daemon's error message on stderr -- is hidden behind
an opaque `Expecting value: line 1 column 1 (char 0)` `JSONDecodeError`
emitted by `json.loads(stdout)` inside `call_cli_json` /
`call_cli_json_stream` in `plugins/module_utils/_common_cli.py`.

This is the same class of problem already discussed in
#1216 and partially mitigated in #1221 (which started appending
stderr to the error message). The leading message a user sees is still
"Error while parsing JSON output of ...: Expecting value: line 1 column
1 (char 0)", which sends operators chasing a phantom JSON bug instead
of the real CLI failure that lives in stderr.

### Symptom seen in the wild

`community.docker.docker_compose_v2` running against a host whose
compose project referenced a stale `Config.Image` SHA produced:

```
docker compose images --format json
  rc:     1
  stdout: ""
  stderr: "Error response from daemon: No such image: sha256:c02a671fd71657..."
```

The module then ran `json.loads("")` and raised
`Expecting value: line 1 column 1 (char 0)`, completely hiding the
clear "No such image" diagnostic from the daemon. Multiple rounds of
debugging were required before the real cause was identified.

### Fix

In both `call_cli_json` and `call_cli_json_stream`, when JSON parsing
fails *and* the CLI also exited with `rc != 0`, raise an error that
leads with the CLI's exit code and stderr instead of the JSON parse
error. A small helper `_fail_with_cli_error` centralises the message
format. Machine-readable `cmd` / `rc` / `stdout` / `stderr` fields are
populated the same way as the existing error path.

Behavior is unchanged when:
- `stdout` parses successfully (the regular happy path), or
- `stdout` parses successfully but `rc != 0` -- e.g. `docker image
  inspect <missing>` returning `rc=1` with stdout `[]`. The `find_image`
  / `find_image_by_id` call sites that rely on this continue to work.

The fix only changes the *message text and contents* on the error path
that today produces the misleading `JSONDecodeError`.

### Changelog fragment

`changelogs/fragments/fix-call-cli-json-rc-check.yml`:

```yaml
bugfixes:
  - "CLI-based modules - when the docker CLI exits non-zero and produces no parseable JSON on stdout, surface the CLI's own ``stderr`` and exit code instead of the misleading ``Expecting value: line 1 column 1 (char 0)`` ``JSONDecodeError``. ..."
```

## Test plan

Added `tests/unit/plugins/module_utils/test__common_cli.py` with the
following cases:

- [x] `call_cli_json`: success with valid JSON returns parsed data.
- [x] `call_cli_json`: `rc=1` with valid JSON stdout `[]` (the `docker image inspect <missing>` shape) still returns; does **not** short-circuit -- preserves `find_image` semantics.
- [x] `call_cli_json`: `rc=1` with empty stdout + stderr like `No such image: sha256:...` now fails with a message containing `rc=1` and the stderr text, **not** `Expecting value` and **not** `Error while parsing JSON output`. Machine-readable `rc`/`stderr`/`stdout` fields are populated.
- [x] `call_cli_json`: `rc=0` with unparseable stdout keeps the existing `Error while parsing JSON output` message (the JSON parse error is the relevant one here).
- [x] `call_cli_json_stream`: success returns parsed lines.
- [x] `call_cli_json_stream`: `rc=2` with a malformed JSON line + `connection refused` stderr surfaces the CLI's `rc=2` / stderr instead of the JSON parse error.
- [x] `call_cli_json_stream`: `rc=0` with a malformed JSON line keeps the existing JSON parsing error message.
- [x] `call_cli_json`: `warn_on_stderr=True` still calls `self.warn(stderr)` on the success path.

Tests are pure unit tests against a minimal `AnsibleDockerClientBase`
subclass that overrides `call_cli` / `fail` / `warn`; no docker daemon
is required and no new dependencies are introduced.

Refs https://github.com/ansible-collections/community.docker/issues/1216