### PR TITLE
Remove no_log from setup_remote_tmp_dir

### DIFF
--- a/tests/integration/targets/setup_remote_tmp_dir/tasks/default-cleanup.yml
+++ b/tests/integration/targets/setup_remote_tmp_dir/tasks/default-cleanup.yml
@@ -7,4 +7,3 @@
   ansible.builtin.file:
     path: "{{ remote_tmp_dir }}"
     state: absent
-  no_log: true


### PR DESCRIPTION
##### SUMMARY
I've seen this task tail too often, without any information shown because of `no_log`.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
