### PR TITLE
Use nox in AZP CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -49,105 +49,123 @@ resources:
 pool: Standard
 
 stages:
+  - stage: remote_2_18
+    displayName: Remote ansible-core 2.18
+    dependsOn: []
+    variables:
+      entryPoint: tests/utils/shippable/nox.sh
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: rhel/9.7 + azp/1/
+              test: ansible-test-integration-2.18-rhel-9.7-azp-1
+            - name: rhel/9.7 + azp/2/
+              test: ansible-test-integration-2.18-rhel-9.7-azp-2
+            - name: rhel/9.7 + azp/3/
+              test: ansible-test-integration-2.18-rhel-9.7-azp-3
+            - name: rhel/9.7 + azp/4/
+              test: ansible-test-integration-2.18-rhel-9.7-azp-4
+            - name: rhel/9.7 + azp/5/
+              test: ansible-test-integration-2.18-rhel-9.7-azp-5
 
-### Remote
-  - stage: Remote_devel
-    displayName: Remote devel
+  - stage: remote_2_19
+    displayName: Remote ansible-core 2.19
     dependsOn: []
+    variables:
+      entryPoint: tests/utils/shippable/nox.sh
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/{0}
           targets:
-            - name: RHEL 10.1 with Docker SDK, urllib3, requests from sources
-              test: rhel/10.1-dev-latest
-            - name: RHEL 9.7
-              test: rhel/9.7
-            # For some reason, Ubuntu 24.04 is *extremely* slower than RHEL 9.6
-            # - name: Ubuntu 24.04
-            #   test: ubuntu/24.04
-          groups:
-            - 1
-            - 2
-            - 3
-            - 4
-            - 5
-  - stage: Remote_2_21
-    displayName: Remote 2.21
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.21/{0}
-          targets:
-            - name: RHEL 10.1
-              test: rhel/10.1
-            # - name: RHEL 9.7
-            #   test: rhel/9.7
-          groups:
-            - 1
-            - 2
-            - 3
-            - 4
-            - 5
-  - stage: Remote_2_20
-    displayName: Remote 2.20
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.20/{0}
-          targets:
-            - name: RHEL 9.7
-              test: rhel/9.7
-          groups:
-            - 1
-            - 2
-            - 3
-            - 4
-            - 5
-  - stage: Remote_2_19
-    displayName: Remote 2.19
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.19/{0}
-          targets:
-            - name: Ubuntu 22.04
-              test: ubuntu/22.04
-          groups:
-            - 1
-            - 2
-            - 3
-            - 4
-            - 5
-  - stage: Remote_2_18
-    displayName: Remote 2.18
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.18/{0}
-          targets:
-            - name: RHEL 9.7
-              test: rhel/9.7
-          groups:
-            - 1
-            - 2
-            - 3
-            - 4
-            - 5
+            - name: ubuntu/22.04 + azp/1/
+              test: ansible-test-integration-2.19-ubuntu-22.04-azp-1
+            - name: ubuntu/22.04 + azp/2/
+              test: ansible-test-integration-2.19-ubuntu-22.04-azp-2
+            - name: ubuntu/22.04 + azp/3/
+              test: ansible-test-integration-2.19-ubuntu-22.04-azp-3
+            - name: ubuntu/22.04 + azp/4/
+              test: ansible-test-integration-2.19-ubuntu-22.04-azp-4
+            - name: ubuntu/22.04 + azp/5/
+              test: ansible-test-integration-2.19-ubuntu-22.04-azp-5
 
-  ## Finally
+  - stage: remote_2_20
+    displayName: Remote ansible-core 2.20
+    dependsOn: []
+    variables:
+      entryPoint: tests/utils/shippable/nox.sh
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: rhel/9.7 + azp/1/
+              test: ansible-test-integration-2.20-rhel-9.7-azp-1
+            - name: rhel/9.7 + azp/2/
+              test: ansible-test-integration-2.20-rhel-9.7-azp-2
+            - name: rhel/9.7 + azp/3/
+              test: ansible-test-integration-2.20-rhel-9.7-azp-3
+            - name: rhel/9.7 + azp/4/
+              test: ansible-test-integration-2.20-rhel-9.7-azp-4
+            - name: rhel/9.7 + azp/5/
+              test: ansible-test-integration-2.20-rhel-9.7-azp-5
+
+  - stage: remote_2_21
+    displayName: Remote ansible-core 2.21
+    dependsOn: []
+    variables:
+      entryPoint: tests/utils/shippable/nox.sh
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: rhel/10.1 + azp/1/
+              test: ansible-test-integration-2.21-rhel-10.1-azp-1
+            - name: rhel/10.1 + azp/2/
+              test: ansible-test-integration-2.21-rhel-10.1-azp-2
+            - name: rhel/10.1 + azp/3/
+              test: ansible-test-integration-2.21-rhel-10.1-azp-3
+            - name: rhel/10.1 + azp/4/
+              test: ansible-test-integration-2.21-rhel-10.1-azp-4
+            - name: rhel/10.1 + azp/5/
+              test: ansible-test-integration-2.21-rhel-10.1-azp-5
+
+  - stage: remote_devel
+    displayName: Remote ansible-core devel
+    dependsOn: []
+    variables:
+      entryPoint: tests/utils/shippable/nox.sh
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: rhel/10.1 + azp/1/ + sdk-dev-latest
+              test: ansible-test-integration-devel-rhel-10.1-azp-1
+            - name: rhel/10.1 + azp/2/ + sdk-dev-latest
+              test: ansible-test-integration-devel-rhel-10.1-azp-2
+            - name: rhel/10.1 + azp/3/ + sdk-dev-latest
+              test: ansible-test-integration-devel-rhel-10.1-azp-3
+            - name: rhel/10.1 + azp/4/ + sdk-dev-latest
+              test: ansible-test-integration-devel-rhel-10.1-azp-4
+            - name: rhel/10.1 + azp/5/ + sdk-dev-latest
+              test: ansible-test-integration-devel-rhel-10.1-azp-5
+            - name: rhel/9.7 + azp/1/
+              test: ansible-test-integration-devel-rhel-9.7-azp-1
+            - name: rhel/9.7 + azp/2/
+              test: ansible-test-integration-devel-rhel-9.7-azp-2
+            - name: rhel/9.7 + azp/3/
+              test: ansible-test-integration-devel-rhel-9.7-azp-3
+            - name: rhel/9.7 + azp/4/
+              test: ansible-test-integration-devel-rhel-9.7-azp-4
+            - name: rhel/9.7 + azp/5/
+              test: ansible-test-integration-devel-rhel-9.7-azp-5
 
   - stage: Summary
     condition: succeededOrFailed()
     dependsOn:
-      - Remote_devel
-      - Remote_2_21
-      - Remote_2_20
-      - Remote_2_19
-      - Remote_2_18
+      - remote_2_18
+      - remote_2_19
+      - remote_2_20
+      - remote_2_21
+      - remote_devel
     jobs:
       - template: templates/coverage.yml

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -105,6 +105,7 @@ include_devel = true
 session_name_template = "ansible-test-integration-{ansible_core}{dash_docker_short}{dash_remote}{dash_python_version}{dash_target_dashized}"
 display_name_template = "Ⓐ{ansible_core}{plus_docker_short}{plus_remote}{plus_py_python_version}{plus_target}{plus_force_docker_sdk_for_python_dev}{plus_force_docker_sdk_for_python_pypi}"
 description_template = "Run integration tests with ansible-core {ansible_core}{comma_docker_short}{comma_remote}{comma_py_python_version}{comma_target}{comma_force_docker_sdk_for_python_dev}{comma_force_docker_sdk_for_python_pypi}"
+retry_on_error = "in-ci"
 
 [sessions.ansible_test_integration.ansible_vars]
 force_docker_sdk_for_python_dev = { type = "value", value = false, template_value = "" }

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,12 +12,31 @@ import nox
 
 try:
     import antsibull_nox
+    from antsibull_nox.cli import run as run_antsibull_nox
 except ImportError:
     print("You need to install antsibull-nox in the same Python environment as nox.")
     sys.exit(1)
 
 
 antsibull_nox.load_antsibull_nox_toml()
+
+
+@nox.session(name="update-azp-config", python=False)
+def update_azp_config(session: nox.Session) -> None:
+    command = [
+        "antsibull-nox",
+        "update-azp-config",
+        "--exclude-tags",
+        "docker",
+        "--min-ansible-core",
+        "2.18",
+    ]
+    if antsibull_nox.IN_CI:
+        command.append("--fail-on-change")
+    session.debug(" ".join(command))
+    result = run_antsibull_nox(command)
+    if result != 0:
+        session.fail(f"Execution failed with status code {result}")
 
 
 # Allow to run the noxfile with `python noxfile.py`, `pipx run noxfile.py`, or similar.

--- a/tests/utils/shippable/nox.sh
+++ b/tests/utils/shippable/nox.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -o pipefail -eux
+
+nox_session="$1"
+
+docker images ansible/ansible
+docker images quay.io/ansible/*
+docker ps
+
+for container in $(docker ps --format '{{.Image}} {{.ID}}' | grep -v -e '^drydock/' -e '^quay.io/ansible/azure-pipelines-test-container:' | sed 's/^.* //'); do
+    docker rm -f "${container}" || true  # ignore errors
+done
+
+docker ps
+command -v python
+python -V
+
+function retry
+{
+    # shellcheck disable=SC2034
+    for repetition in 1 2 3; do
+        set +e
+        "$@"
+        result=$?
+        set -e
+        if [ ${result} == 0 ]; then
+            return ${result}
+        fi
+        echo "@* -> ${result}"
+    done
+    echo "Command '@*' failed 3 times!"
+    exit 255
+}
+
+command -v pip
+pip --version
+pip list --disable-pip-version-check
+retry pip install https://github.com/ansible-community/antsibull-nox/archive/main.tar.gz --disable-pip-version-check
+
+export PYTHONIOENCODING='utf-8'
+
+if [ -n "${COVERAGE:-}" ]; then
+    # on-demand coverage reporting triggered by setting the COVERAGE environment variable to a non-empty value
+    export COVERAGE="--coverage"
+elif [[ "${COMMIT_MESSAGE}" =~ ci_coverage ]]; then
+    # on-demand coverage reporting triggered by having 'ci_coverage' in the latest commit message
+    export COVERAGE="--coverage"
+else
+    # on-demand coverage reporting disabled (default behavior, always-on coverage reporting remains enabled)
+    export COVERAGE="--coverage-check"
+fi
+
+if [ -n "${COMPLETE:-}" ]; then
+    # disable change detection triggered by setting the COMPLETE environment variable to a non-empty value
+    export ANTSIBULL_CHANGE_DETECTION=""
+elif [[ "${COMMIT_MESSAGE}" =~ ci_complete ]]; then
+    # disable change detection triggered by having 'ci_complete' in the latest commit message
+    export ANTSIBULL_CHANGE_DETECTION=""
+else
+    # enable change detection (default behavior)
+    export ANTSIBULL_CHANGE_DETECTION="true"
+    export ANTSIBULL_BASE_BRANCH="${SYSTEM_PULLREQUEST_TARGETBRANCH}"
+    # Create a branch for the current HEAD, which happens to be a merge commit
+    git checkout -b "pull-request-branch"
+    # Name the target branch
+    git branch "${SYSTEM_PULLREQUEST_TARGETBRANCH}" --track "origin/${SYSTEM_PULLREQUEST_TARGETBRANCH}"
+    # Show branches
+    git branch -vv
+fi
+
+if [[ "${COVERAGE:-}" == "--coverage" ]]; then
+    export ANTSIBULL_NOX_TIMEOUT=60
+else
+    export ANTSIBULL_NOX_TIMEOUT=50
+fi
+
+export FORCE_COLOR=1
+export ANTSIBULL_NOX_IGNORE_INSTALLED_COLLECTIONS="true"
+export ANTSIBULL_NOX_ALWAYS_COPY_REPO_STRUCTURE="true"  # https://github.com/ansible/ansible/issues/87052
+
+nox -e "${nox_session}" -- ${COVERAGE}


### PR DESCRIPTION
##### SUMMARY
Also generate the AZP matrix with nox, so antsibull-nox.toml is the full source of truth for CI.

Uses https://github.com/ansible-community/antsibull-nox/pull/200 for updating the CI config, https://github.com/ansible-community/antsibull-nox/pull/201 for `--retry-on-error` support, and https://github.com/ansible-community/antsibull-nox/pull/203 to make antsibull-nox recognize AZP.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
