### PR TITLE
[stable-4] CI: Move ansible-core 2.18 completely to GHA

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -49,26 +49,6 @@ resources:
 pool: Standard
 
 stages:
-  - stage: remote_2_18
-    displayName: Remote ansible-core 2.18
-    dependsOn: []
-    variables:
-      entryPoint: tests/utils/shippable/nox.sh
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: RHEL 9.7 + group 1
-              test: ansible-test-integration-2.18-rhel-9.7-azp-1
-            - name: RHEL 9.7 + group 2
-              test: ansible-test-integration-2.18-rhel-9.7-azp-2
-            - name: RHEL 9.7 + group 3
-              test: ansible-test-integration-2.18-rhel-9.7-azp-3
-            - name: RHEL 9.7 + group 4
-              test: ansible-test-integration-2.18-rhel-9.7-azp-4
-            - name: RHEL 9.7 + group 5
-              test: ansible-test-integration-2.18-rhel-9.7-azp-5
-
   - stage: remote_2_19
     displayName: Remote ansible-core 2.19
     dependsOn: []
@@ -122,7 +102,6 @@ stages:
   - stage: Summary
     condition: succeededOrFailed()
     dependsOn:
-      - remote_2_18
       - remote_2_19
       - remote_2_20
     jobs:

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -50,7 +50,7 @@ pool: Standard
 
 stages:
   - stage: remote_2_19
-    displayName: Remote ansible-core 2.19
+    displayName: Remote 2.19
     dependsOn: []
     variables:
       entryPoint: tests/utils/shippable/nox.sh
@@ -70,7 +70,7 @@ stages:
               test: ansible-test-integration-2.19-ubuntu-22.04-azp-5
 
   - stage: remote_2_20
-    displayName: Remote ansible-core 2.20
+    displayName: Remote 2.20
     dependsOn: []
     variables:
       entryPoint: tests/utils/shippable/nox.sh

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,7 @@ def update_azp_config(session: nox.Session) -> None:
         "--exclude-tags",
         "docker",
         "--min-ansible-core",
-        "2.18",
+        "2.19",
     ]
     if antsibull_nox.IN_CI:
         command.append("--fail-on-change")


### PR DESCRIPTION
##### SUMMARY
ansible-core 2.18 is now EOL.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
