### PR TITLE
CI: Split nox step into prepare and execute

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -37,7 +37,9 @@ variables:
   - name: coverageBranches
     value: main
   - name: entryPoint
-    value: tests/utils/shippable/shippable.sh
+    value: tests/utils/shippable/nox.sh
+  - name: prepareEntryPoint
+    value: tests/utils/shippable/nox-prepare.sh
   - name: fetchDepth
     value: 0
 

--- a/.azure-pipelines/templates/test.yml
+++ b/.azure-pipelines/templates/test.yml
@@ -23,6 +23,8 @@ jobs:
           - checkout: self
             fetchDepth: $(fetchDepth)
             path: $(checkoutPath)
+          - bash: .azure-pipelines/scripts/run-tests.sh "$(prepareEntryPoint)" "${{ job.test }}" "$(coverageBranches)" "$(Agent.TempDirectory)"
+            displayName: Prepare Tests
           - bash: .azure-pipelines/scripts/run-tests.sh "$(entryPoint)" "${{ job.test }}" "$(coverageBranches)" "$(Agent.TempDirectory)"
             displayName: Run Tests
           - bash: .azure-pipelines/scripts/process-results.sh

--- a/tests/utils/shippable/nox-prepare.sh
+++ b/tests/utils/shippable/nox-prepare.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -o pipefail -eux
+
+nox_session="$1"
+
+docker images ansible/ansible
+docker images quay.io/ansible/*
+docker ps
+
+for container in $(docker ps --format '{{.Image}} {{.ID}}' | grep -v -e '^drydock/' -e '^quay.io/ansible/azure-pipelines-test-container:' | sed 's/^.* //'); do
+    docker rm -f "${container}" || true  # ignore errors
+done
+
+docker ps
+command -v python
+python -V
+
+function retry
+{
+    # shellcheck disable=SC2034
+    for repetition in 1 2 3; do
+        set +e
+        "$@"
+        result=$?
+        set -e
+        if [ ${result} == 0 ]; then
+            return ${result}
+        fi
+        echo "@* -> ${result}"
+    done
+    echo "Command '@*' failed 3 times!"
+    exit 255
+}
+
+command -v pip
+pip --version
+pip list --disable-pip-version-check
+retry pip install https://github.com/ansible-community/antsibull-nox/archive/main.tar.gz --disable-pip-version-check
+
+export PYTHONIOENCODING='utf-8'
+
+export FORCE_COLOR=1
+export ANTSIBULL_NOX_IGNORE_INSTALLED_COLLECTIONS="true"
+
+if [ "${nox_session}" == "extra-sanity-tests" ]; then
+    nox --verbose --install-only
+else
+    nox --verbose --install-only -e "${nox_session}"
+fi

--- a/tests/utils/shippable/nox.sh
+++ b/tests/utils/shippable/nox.sh
@@ -7,40 +7,6 @@ set -o pipefail -eux
 
 nox_session="$1"
 
-docker images ansible/ansible
-docker images quay.io/ansible/*
-docker ps
-
-for container in $(docker ps --format '{{.Image}} {{.ID}}' | grep -v -e '^drydock/' -e '^quay.io/ansible/azure-pipelines-test-container:' | sed 's/^.* //'); do
-    docker rm -f "${container}" || true  # ignore errors
-done
-
-docker ps
-command -v python
-python -V
-
-function retry
-{
-    # shellcheck disable=SC2034
-    for repetition in 1 2 3; do
-        set +e
-        "$@"
-        result=$?
-        set -e
-        if [ ${result} == 0 ]; then
-            return ${result}
-        fi
-        echo "@* -> ${result}"
-    done
-    echo "Command '@*' failed 3 times!"
-    exit 255
-}
-
-command -v pip
-pip --version
-pip list --disable-pip-version-check
-retry pip install https://github.com/ansible-community/antsibull-nox/archive/main.tar.gz --disable-pip-version-check
-
 export PYTHONIOENCODING='utf-8'
 
 if [ -n "${COVERAGE:-}" ]; then
@@ -91,4 +57,8 @@ export ANTSIBULL_NOX_COVERAGE_DESTINATION="${COVERAGE_DESTINATION_DIRECTORY}"
 export ANTSIBULL_NOX_COVERAGE_ANALYSIS_FILE="${COVERAGE_DESTINATION_DIRECTORY}/coverage-analyze-targets.json"
 export ANTSIBULL_NOX_COVERAGE_NO_XML="true"
 
-nox -e "${nox_session}" -- ${COVERAGE}
+if [ "${nox_session}" == "extra-sanity-tests" ]; then
+    nox --reuse-existing-virtualenvs --no-install
+else
+    nox --reuse-existing-virtualenvs --no-install -e "${nox_session}" -- ${COVERAGE}
+fi


### PR DESCRIPTION
##### SUMMARY
Split nox step in AZP CI into prepare and execute, similar to what the GitHub workflow is doing. Installation is done with more verbosity, so you can see what exactly is installed, but it doesn't pollute the actual run's log.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
