### PR TITLE
CI: Replace devel RHEL 9.7 and 10.1 remotes with 9.8 and 10.2

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -120,26 +120,26 @@ stages:
       - template: templates/matrix.yml
         parameters:
           targets:
-            - name: RHEL 10.1 + group 1 + sdk-dev-latest
-              test: ansible-test-integration-devel-rhel-10.1-azp-1
-            - name: RHEL 10.1 + group 2 + sdk-dev-latest
-              test: ansible-test-integration-devel-rhel-10.1-azp-2
-            - name: RHEL 10.1 + group 3 + sdk-dev-latest
-              test: ansible-test-integration-devel-rhel-10.1-azp-3
-            - name: RHEL 10.1 + group 4 + sdk-dev-latest
-              test: ansible-test-integration-devel-rhel-10.1-azp-4
-            - name: RHEL 10.1 + group 5 + sdk-dev-latest
-              test: ansible-test-integration-devel-rhel-10.1-azp-5
-            - name: RHEL 9.7 + group 1
-              test: ansible-test-integration-devel-rhel-9.7-azp-1
-            - name: RHEL 9.7 + group 2
-              test: ansible-test-integration-devel-rhel-9.7-azp-2
-            - name: RHEL 9.7 + group 3
-              test: ansible-test-integration-devel-rhel-9.7-azp-3
-            - name: RHEL 9.7 + group 4
-              test: ansible-test-integration-devel-rhel-9.7-azp-4
-            - name: RHEL 9.7 + group 5
-              test: ansible-test-integration-devel-rhel-9.7-azp-5
+            - name: RHEL 10.2 + group 1 + sdk-dev-latest
+              test: ansible-test-integration-devel-rhel-10.2-azp-1
+            - name: RHEL 10.2 + group 2 + sdk-dev-latest
+              test: ansible-test-integration-devel-rhel-10.2-azp-2
+            - name: RHEL 10.2 + group 3 + sdk-dev-latest
+              test: ansible-test-integration-devel-rhel-10.2-azp-3
+            - name: RHEL 10.2 + group 4 + sdk-dev-latest
+              test: ansible-test-integration-devel-rhel-10.2-azp-4
+            - name: RHEL 10.2 + group 5 + sdk-dev-latest
+              test: ansible-test-integration-devel-rhel-10.2-azp-5
+            - name: RHEL 9.8 + group 1
+              test: ansible-test-integration-devel-rhel-9.8-azp-1
+            - name: RHEL 9.8 + group 2
+              test: ansible-test-integration-devel-rhel-9.8-azp-2
+            - name: RHEL 9.8 + group 3
+              test: ansible-test-integration-devel-rhel-9.8-azp-3
+            - name: RHEL 9.8 + group 4
+              test: ansible-test-integration-devel-rhel-9.8-azp-4
+            - name: RHEL 9.8 + group 5
+              test: ansible-test-integration-devel-rhel-9.8-azp-5
 
   - stage: Summary
     condition: succeededOrFailed()

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -251,14 +251,14 @@ docker = "quay.io/ansible-community/test-image:archlinux"
 [[sessions.ansible_test_integration.groups.sessions]]
 ansible_core = "devel"
 target = [ "azp/1/", "azp/2/", "azp/3/", "azp/4/", "azp/5/" ]
-remote = [ "rhel/10.1" ]
+remote = [ "rhel/10.2" ]
 ansible_vars = { force_docker_sdk_for_python_dev = { type = "value", value = true, template_value = "sdk-dev-latest" } }
 
 [[sessions.ansible_test_integration.groups.sessions]]
 ansible_core = "devel"
 target = [ "azp/1/", "azp/2/", "azp/3/", "azp/4/", "azp/5/" ]
 remote = [
-    "rhel/9.7",
+    "rhel/9.8",
     # For some reason, Ubuntu 24.04 is *extremely* slower than RHEL 9.6
     # "ubuntu/24.04",
 ]

--- a/tests/integration/targets/setup_podman/tasks/main.yml
+++ b/tests/integration/targets/setup_podman/tasks/main.yml
@@ -57,7 +57,7 @@
               ansible.builtin.systemd_service:
                 name: "{{ podman_socket_service }}"
                 state: started
-                scope: "{{ 'global' if podman_user_id.stdout == '0' and ansible_facts.os_family == 'RedHat' and (ansible_facts.distribution_major_version | int < 10) else 'user' }}"
+                scope: "{{ 'global' if podman_user_id.stdout == '0' and ansible_facts.os_family == 'RedHat' and (ansible_facts.distribution_version is version('9.8', '<')) else 'user' }}"
               environment:
                 XDG_RUNTIME_DIR: "{{ '/run' if podman_user_id.stdout == '0' else ('/run/user/' ~ podman_user_id.stdout) }}"
 


### PR DESCRIPTION
##### SUMMARY
See https://forum.ansible.com/t/ansible-test-devel-rhel-9-7-and-10-1-remotes-replaced-by-9-8-and-10-2/45976.

Ref: https://github.com/ansible/ansible/commit/9cc7281c69fe74282fc8831fb6796d0700f8f9a6

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
