### PR TITLE
Add files to ignore on build and distribution to end consumers of the collection

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -7,7 +7,7 @@
 
 namespace: community
 name: docker
-version: 5.3.0
+version: 5.3.1
 readme: README.md
 authors:
   - Ansible Docker Working Group
@@ -28,3 +28,16 @@ build_ignore:
 # https://docs.ansible.com/ansible/devel/dev_guide/developing_collections.html#ignoring-files-and-folders
   - .gitignore
   - changelogs/.plugin-cache.yaml
+  - .azure-pipelines
+  - .github
+  - .git-blame-ignore-revs
+  - tests
+  - .ansible-lint
+  - .flake8
+  - .mypy.ini
+  - .pylintrc
+  - .yamllint*
+  - noxfile.py
+  - antsibull-nox.toml
+  - ruff.toml
+  - '*.tar.gz'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change is regarding the collection distribution. In the current manifest tests, linters, ci-cd files are not ignored and are being delivered to the end user. They are not needed for runtime and only take additional disk space.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Ansible galaxy.yml manifest file.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
We add all files we want to ignore on collection build operation in galaxy.yml block called "build_ignore". When the command `ansible-galaxy collection build` is run it will exclude those files from the built tarball archive that is later distributed to end consumers of this collection. So all the files that are not needed for runtime or have no value for end user should be ignored.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1. install community.docker collection from galaxy `ansible-galaxy collection install community.docker`
2. go to it's location
3. run `du -h docker`
4. checkout my PR commit
5. run `ansible-galaxy collection build -f`
6. run `ansible-galaxy collection install community-docker-5.3.1.tar.gz -f`
7. go to collection's location (~/.ansible/collections/ansible_collections/community or any other)
8. run `du -h docker`

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
BEFORE the change:
community → ansible-galaxy collection install community.docker -f
Starting galaxy collection install process
Process install dependency map
Starting collection install process
Downloading https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/artifacts/community-docker-5.2.1.tar.gz to /home/doftmoon/.ansible/tmp/ansible-local-9809vshob1nj/tmpadsgijbt/community-docker-5.2.1-_jih5uks
Installing 'community.docker:5.2.1' to '/home/doftmoon/.ansible/collections/ansible_collections/community/docker'
community.docker:5.2.1 was installed successfully
'community.library_inventory_filtering_v1:1.1.1' is already installed, skipping.
community → du -h docker | tail -n 2
3.3M	docker/tests
5.6M	docker
community → pwd
/home/doftmoon/.ansible/collections/ansible_collections/community
community → ll docker
.rw-r--r--  882 doftmoon 30 Jun 17:25 .ansible-lint
drwxr-xr-x    - doftmoon 30 Jun 17:25 .azure-pipelines
.rw-r--r--  502 doftmoon 30 Jun 17:25 .flake8
.rw-r--r--  480 doftmoon 30 Jun 17:25 .git-blame-ignore-revs
drwxr-xr-x    - doftmoon 30 Jun 17:25 .github
.rw-r--r--  747 doftmoon 30 Jun 17:25 .mypy.ini
.rw-r--r--  20k doftmoon 30 Jun 17:25 .pylintrc
.rw-r--r-- 1.1k doftmoon 30 Jun 17:25 .yamllint
.rw-r--r-- 1.1k doftmoon 30 Jun 17:25 .yamllint-docs
.rw-r--r-- 1.1k doftmoon 30 Jun 17:25 .yamllint-examples
.rw-r--r--  10k doftmoon 30 Jun 17:25 antsibull-nox.toml
.rw-r--r-- 174k doftmoon 30 Jun 17:25 CHANGELOG.md
.rw-r--r--  195 doftmoon 30 Jun 17:25 CHANGELOG.md.license
.rw-r--r-- 105k doftmoon 30 Jun 17:25 CHANGELOG.rst
.rw-r--r--  195 doftmoon 30 Jun 17:25 CHANGELOG.rst.license
drwxr-xr-x    - doftmoon 30 Jun 17:25 changelogs
.rw-r--r--  35k doftmoon 30 Jun 17:25 COPYING
drwxr-xr-x    - doftmoon 30 Jun 17:25 docs
.rw-r--r-- 193k doftmoon 30 Jun 17:25 FILES.json
drwxr-xr-x    - doftmoon 30 Jun 17:25 LICENSES
.rw-r--r--  966 doftmoon 30 Jun 17:25 MANIFEST.json
drwxr-xr-x    - doftmoon 30 Jun 17:25 meta
.rw-r--r--  677 doftmoon 30 Jun 17:25 noxfile.py
drwxr-xr-x    - doftmoon 30 Jun 17:25 plugins
.rw-r--r--  12k doftmoon 30 Jun 17:25 README.md
.rw-r--r--  367 doftmoon 30 Jun 17:25 REUSE.toml
.rw-r--r-- 1.3k doftmoon 30 Jun 17:25 ruff.toml
drwxr-xr-x    - doftmoon 30 Jun 17:25 tests

AFTER:
community → du -h docker | tail -n 2
1.5M	docker/plugins
2.1M	docker
```
