### PR TITLE
CI: Replace Alpine 3.23 with 3.24 for devel

### DIFF
--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -200,7 +200,7 @@ description = "Meta session for running all ansible-test-integration-2.21-* sess
 [[sessions.ansible_test_integration.groups.sessions]]
 ansible_core = "2.21"
 target = [ "azp/4/", "azp/5/" ]
-docker = [ "fedora43", "ubuntu2204", "ubuntu2404" ]
+docker = [ "fedora43", "ubuntu2204", "ubuntu2404", "alpine323" ]
 
 [[sessions.ansible_test_integration.groups.sessions]]
 ansible_core = "2.21"
@@ -216,7 +216,7 @@ description = "Meta session for running all ansible-test-integration-devel-* ses
 [[sessions.ansible_test_integration.groups.sessions]]
 ansible_core = "devel"
 target = [ "azp/4/", "azp/5/" ]
-docker = [ "fedora44", "ubuntu2404", "ubuntu2604", "alpine323" ]
+docker = [ "fedora44", "ubuntu2404", "ubuntu2604", "alpine324" ]
 
 [[sessions.ansible_test_integration.groups.sessions]]
 ansible_core = "devel"


### PR DESCRIPTION
##### SUMMARY
ansible-core devel bumped its Alpine 3.23 VM/container image to 3.24.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
