### PR TITLE
Stop relying on deprecated field when parsing image pulling errors

### DIFF
--- a/changelogs/fragments/1302-docker-image.yml
+++ b/changelogs/fragments/1302-docker-image.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "docker_image, docker_image_pull, docker_container - also handle errors if only ``errorDetail`` is set, but not ``error``.
+     The ``error`` field has been `deprecated in Moby apparently a very long time ago <https://github.com/moby/moby/commit/3043c2641990d94298c6377b7ef14709263a4709>`__
+     (https://github.com/ansible-collections/community.docker/pull/1302)."

--- a/plugins/module_utils/_common_api.py
+++ b/plugins/module_utils/_common_api.py
@@ -564,7 +564,7 @@ class AnsibleDockerClientBase(Client):
             self._raise_for_status(response)
             for line in self._stream_helper(response, decode=True):
                 self.log(line, pretty_print=True)
-                if line.get("error"):
+                if line.get("error") or line.get("errorDetail"):
                     if line.get("errorDetail"):
                         error_detail = line.get("errorDetail")
                         self.fail(

--- a/plugins/modules/docker_image.py
+++ b/plugins/modules/docker_image.py
@@ -995,7 +995,7 @@ class ImageManager(DockerBaseClass):
             self.log(line, pretty_print=True)
             self._extract_output_line(line, build_output)
 
-            if line.get("error"):
+            if line.get("error") or line.get("errorDetail"):
                 if line.get("errorDetail"):
                     error_detail = line.get("errorDetail")
                     self.fail(


### PR DESCRIPTION
##### SUMMARY
`error` has been deprecated in 2013 (I first used Docker in 2024, I think). This field was still used in Docker SDK for Python until recently (https://github.com/docker/docker-py/pull/3307) as well...

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pulling images through API