### PR TITLE
Add command_as_args option for docker_swarm_service CLI-compatible mapping

### DIFF
--- a/changelogs/fragments/1044-swarm-service-command-args.yml
+++ b/changelogs/fragments/1044-swarm-service-command-args.yml
@@ -1,7 +1,10 @@
-bugfixes:
-  - docker_swarm_service - map ``command`` and ``args`` to ContainerSpec.Args
-    (matching ``docker service create IMAGE [COMMAND] [ARG...]``) so the image
-    ENTRYPOINT is preserved. Previously ``command`` was sent as ContainerSpec.Command,
-    which replaced the entrypoint and broke flag-style commands such as
-    ``-config.file=...`` (https://github.com/ansible-collections/community.docker/issues/1044,
-    https://github.com/ansible-collections/community.docker/issues/212).
+minor_changes:
+  - docker_swarm_service - add ``command_as_args`` option. When set to ``true``,
+    ``command`` and ``args`` are concatenated and mapped to ContainerSpec.Args
+    (matching ``docker service create IMAGE [COMMAND] [ARG...]``), preserving the
+    image ENTRYPOINT. The default remains ``false`` (historical mapping of
+    ``command`` to ContainerSpec.Command and ``args`` to ContainerSpec.Args) for
+    backward compatibility
+    (https://github.com/ansible-collections/community.docker/issues/1044,
+    https://github.com/ansible-collections/community.docker/issues/212,
+    https://github.com/ansible-collections/community.docker/pull/1307).

--- a/changelogs/fragments/1044-swarm-service-command-args.yml
+++ b/changelogs/fragments/1044-swarm-service-command-args.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - docker_swarm_service - map ``command`` and ``args`` to ContainerSpec.Args
+    (matching ``docker service create IMAGE [COMMAND] [ARG...]``) so the image
+    ENTRYPOINT is preserved. Previously ``command`` was sent as ContainerSpec.Command,
+    which replaced the entrypoint and broke flag-style commands such as
+    ``-config.file=...`` (https://github.com/ansible-collections/community.docker/issues/1044,
+    https://github.com/ansible-collections/community.docker/issues/212).

--- a/changelogs/fragments/1044-swarm-service-command-args.yml
+++ b/changelogs/fragments/1044-swarm-service-command-args.yml
@@ -1,8 +1,8 @@
 minor_changes:
   - docker_swarm_service - add ``command_as_args`` option. When set to ``true``,
-    ``command`` and ``args`` are concatenated and mapped to ContainerSpec.Args
+    ``command`` and ``args`` are concatenated and mapped to ``ContainerSpec.Args``
     (matching ``docker service create IMAGE [COMMAND] [ARG...]``), preserving the
-    image ENTRYPOINT. The default remains ``false`` (historical mapping of
+    image ``ENTRYPOINT``. The default remains ``false`` (historical mapping of
     ``command`` to ContainerSpec.Command and ``args`` to ContainerSpec.Args) for
     backward compatibility
     (https://github.com/ansible-collections/community.docker/issues/1044,

--- a/changelogs/fragments/1044-swarm-service-command-args.yml
+++ b/changelogs/fragments/1044-swarm-service-command-args.yml
@@ -3,7 +3,7 @@ minor_changes:
     ``command`` and ``args`` are concatenated and mapped to ``ContainerSpec.Args``
     (matching ``docker service create IMAGE [COMMAND] [ARG...]``), preserving the
     image ``ENTRYPOINT``. The default remains ``false`` (historical mapping of
-    ``command`` to ContainerSpec.Command and ``args`` to ContainerSpec.Args) for
+    ``command`` to ``ContainerSpec.Command`` and ``args`` to ``ContainerSpec.Args``) for
     backward compatibility
     (https://github.com/ansible-collections/community.docker/issues/1044,
     https://github.com/ansible-collections/community.docker/issues/212,

--- a/plugins/modules/docker_swarm_service.py
+++ b/plugins/modules/docker_swarm_service.py
@@ -65,8 +65,7 @@ options:
       - If V(true), O(command) and O(args) are concatenated and written only to
         C(ContainerSpec.Args), matching C(docker service create IMAGE [COMMAND] [ARG...])
         so the image C(ENTRYPOINT) is preserved.
-      - The default may change to V(true) in a future major release after a deprecation
-        period.
+      - The current default will eventually be depreacted and change to V(true).
     type: bool
     default: false
     version_added: 5.3.0

--- a/plugins/modules/docker_swarm_service.py
+++ b/plugins/modules/docker_swarm_service.py
@@ -50,7 +50,7 @@ options:
       - When O(command_as_args=false) (default), this is sent as ContainerSpec.Command,
         which replaces the image C(ENTRYPOINT). This is the historical module behavior.
       - When O(command_as_args=true), this is combined with O(args) and sent as
-        ContainerSpec.Args (same as the Docker CLI
+        C(ContainerSpec.Args) (same as the Docker CLI
         C(docker service create IMAGE [COMMAND] [ARG...])), so the image C(ENTRYPOINT)
         is preserved. Use this for flag-style commands (for example C(-config.file=...))
         that must be passed as arguments to the image entrypoint

--- a/plugins/modules/docker_swarm_service.py
+++ b/plugins/modules/docker_swarm_service.py
@@ -1097,12 +1097,11 @@ def _combine_command_args(
     Matches docker CLI ``service create IMAGE [COMMAND] [ARG...]``, which places
     all post-image tokens into ContainerSpec.Args (preserving ENTRYPOINT).
     """
-    combined: list[str] = []
-    if command is not None:
-        combined.extend(command)
-    if args is not None:
-        combined.extend(args)
-    return combined if combined else None
+    if command is None:
+        return args
+    if args is None:
+        return command
+    return command + args
 
 
 def has_list_changed(

--- a/plugins/modules/docker_swarm_service.py
+++ b/plugins/modules/docker_swarm_service.py
@@ -36,6 +36,9 @@ options:
     description:
       - List arguments to be passed to the container.
       - Corresponds to the C(ARG) parameter of C(docker service create).
+      - Appended after O(command) when building the service's ContainerSpec.
+      - Together with O(command), these values are sent as ContainerSpec.Args
+        (matching the Docker CLI), so the image C(ENTRYPOINT) is preserved.
     type: list
     elements: str
   command:
@@ -43,6 +46,11 @@ options:
       - Command to execute when the container starts.
       - A command may be either a string or a list or a list of strings.
       - Corresponds to the C(COMMAND) parameter of C(docker service create).
+      - Together with O(args), this is sent as ContainerSpec.Args (same as the
+        Docker CLI C(docker service create IMAGE [COMMAND] [ARG...])), so the
+        image C(ENTRYPOINT) is preserved. Previously this was incorrectly sent
+        as ContainerSpec.Command, which replaced the entrypoint and broke
+        common flag-style commands (for example C(-config.file=...)).
     type: raw
   configs:
     description:
@@ -1054,6 +1062,23 @@ def has_dict_changed(
     return False
 
 
+def _combine_command_args(
+    command: list[str] | None, args: list[str] | None
+) -> list[str] | None:
+    """
+    Combine ansible command + args into a single argv list.
+
+    Matches docker CLI ``service create IMAGE [COMMAND] [ARG...]``, which places
+    all post-image tokens into ContainerSpec.Args (preserving ENTRYPOINT).
+    """
+    combined: list[str] = []
+    if command is not None:
+        combined.extend(command)
+    if args is not None:
+        combined.extend(args)
+    return combined if combined else None
+
+
 def has_list_changed(
     new_list: list[t.Any] | None,
     old_list: list[t.Any] | None,
@@ -1675,10 +1700,15 @@ class DockerService(DockerBaseClass):
             needs_rebuild = not self.can_update_networks
         if self.replicas != os.replicas:
             differences.add("replicas", parameter=self.replicas, active=os.replicas)
-        if has_list_changed(self.command, os.command, sort_lists=False):
-            differences.add("command", parameter=self.command, active=os.command)
-        if has_list_changed(self.args, os.args, sort_lists=False):
-            differences.add("args", parameter=self.args, active=os.args)
+        # command + args are stored as ContainerSpec.Args (CLI-compatible).
+        # Older module versions incorrectly wrote command to ContainerSpec.Command,
+        # so compare the combined command line from either field.
+        desired_cmdline = _combine_command_args(self.command, self.args)
+        active_cmdline = _combine_command_args(os.command, os.args)
+        if has_list_changed(desired_cmdline, active_cmdline, sort_lists=False):
+            differences.add(
+                "command", parameter=desired_cmdline, active=active_cmdline
+            )
         if has_list_changed(self.constraints, os.constraints):
             differences.add(
                 "constraints", parameter=self.constraints, active=os.constraints
@@ -1999,10 +2029,13 @@ class DockerService(DockerBaseClass):
         dns_config = types.DNSConfig(**dns_config_args) if dns_config_args else None
 
         container_spec_args: dict[str, t.Any] = {}
-        if self.command is not None:
-            container_spec_args["command"] = self.command
-        if self.args is not None:
-            container_spec_args["args"] = self.args
+        # Match `docker service create IMAGE [COMMAND] [ARG...]`: the CLI places
+        # all post-image tokens into ContainerSpec.Args so ENTRYPOINT is kept.
+        # Writing Command instead replaces ENTRYPOINT and breaks flag-style
+        # commands such as `-config.file=...` (see #1044, #212).
+        combined_args = _combine_command_args(self.command, self.args)
+        if combined_args is not None:
+            container_spec_args["args"] = combined_args
         if self.env is not None:
             container_spec_args["env"] = self.env
         if self.user is not None:

--- a/plugins/modules/docker_swarm_service.py
+++ b/plugins/modules/docker_swarm_service.py
@@ -52,7 +52,7 @@ options:
       - When O(command_as_args=true), this is combined with O(args) and sent as
         C(ContainerSpec.Args) (same as the Docker CLI
         C(docker service create IMAGE [COMMAND] [ARG...])), so the image C(ENTRYPOINT)
-        is preserved. Use this for flag-style commands (for example C(-config.file=...))
+        is preserved. Use this for flag-style commands (for example V(--config.file=...))
         that must be passed as arguments to the image entrypoint
         (see U(https://github.com/ansible-collections/community.docker/issues/1044)).
     type: raw

--- a/plugins/modules/docker_swarm_service.py
+++ b/plugins/modules/docker_swarm_service.py
@@ -38,7 +38,7 @@ options:
       - Corresponds to the C(ARG) parameter of C(docker service create).
       - When O(command_as_args=true), these values are appended after O(command)
         and both are sent as ContainerSpec.Args (matching the Docker CLI).
-      - When O(command_as_args=false) (default), O(args) is sent as ContainerSpec.Args
+      - When O(command_as_args=false), O(args) is sent as C(ContainerSpec.Args)
         while O(command) is sent as ContainerSpec.Command.
     type: list
     elements: str

--- a/plugins/modules/docker_swarm_service.py
+++ b/plugins/modules/docker_swarm_service.py
@@ -36,9 +36,10 @@ options:
     description:
       - List arguments to be passed to the container.
       - Corresponds to the C(ARG) parameter of C(docker service create).
-      - Appended after O(command) when building the service's ContainerSpec.
-      - Together with O(command), these values are sent as ContainerSpec.Args
-        (matching the Docker CLI), so the image C(ENTRYPOINT) is preserved.
+      - When O(command_as_args=true), these values are appended after O(command)
+        and both are sent as ContainerSpec.Args (matching the Docker CLI).
+      - When O(command_as_args=false) (default), O(args) is sent as ContainerSpec.Args
+        while O(command) is sent as ContainerSpec.Command.
     type: list
     elements: str
   command:
@@ -46,12 +47,29 @@ options:
       - Command to execute when the container starts.
       - A command may be either a string or a list or a list of strings.
       - Corresponds to the C(COMMAND) parameter of C(docker service create).
-      - Together with O(args), this is sent as ContainerSpec.Args (same as the
-        Docker CLI C(docker service create IMAGE [COMMAND] [ARG...])), so the
-        image C(ENTRYPOINT) is preserved. Previously this was incorrectly sent
-        as ContainerSpec.Command, which replaced the entrypoint and broke
-        common flag-style commands (for example C(-config.file=...)).
+      - When O(command_as_args=false) (default), this is sent as ContainerSpec.Command,
+        which replaces the image C(ENTRYPOINT). This is the historical module behavior.
+      - When O(command_as_args=true), this is combined with O(args) and sent as
+        ContainerSpec.Args (same as the Docker CLI
+        C(docker service create IMAGE [COMMAND] [ARG...])), so the image C(ENTRYPOINT)
+        is preserved. Use this for flag-style commands (for example C(-config.file=...))
+        that must be passed as arguments to the image entrypoint
+        (see U(https://github.com/ansible-collections/community.docker/issues/1044)).
     type: raw
+  command_as_args:
+    description:
+      - Controls how O(command) and O(args) are mapped to the service ContainerSpec.
+      - If V(false) (default), O(command) is written to ContainerSpec.Command and
+        O(args) to ContainerSpec.Args. This matches the historical module behavior
+        (ContainerSpec.Command replaces the image C(ENTRYPOINT)).
+      - If V(true), O(command) and O(args) are concatenated and written only to
+        ContainerSpec.Args, matching C(docker service create IMAGE [COMMAND] [ARG...])
+        so the image C(ENTRYPOINT) is preserved.
+      - The default may change to V(true) in a future major release after a deprecation
+        period.
+    type: bool
+    default: false
+    version_added: 5.3.0
   configs:
     description:
       - List of dictionaries describing the service configs.
@@ -704,13 +722,21 @@ rebuilt:
 
 EXAMPLES = r"""
 ---
-- name: Set command and arguments
+- name: Set command and arguments (historical mapping)
   community.docker.docker_swarm_service:
     name: myservice
     image: alpine
     command: sleep
     args:
       - "3600"
+
+- name: Pass flags to the image ENTRYPOINT (CLI-compatible mapping)
+  community.docker.docker_swarm_service:
+    name: loki
+    image: grafana/loki:main
+    command_as_args: true
+    command:
+      - '-config.file=/etc/loki/loki-config.yaml'
 
 - name: Set a bind mount
   community.docker.docker_swarm_service:
@@ -1186,6 +1212,7 @@ class DockerService(DockerBaseClass):
         self.image: str | None = ""
         self.command: t.Any = None
         self.args: list[str] | None = None
+        self.command_as_args: bool = False
         self.endpoint_mode: t.Literal["vip", "dnsrr"] | None = None
         self.dns: list[str] | None = None
         self.healthcheck: dict[str, t.Any] | None = None
@@ -1498,6 +1525,7 @@ class DockerService(DockerBaseClass):
         s = DockerService(client.docker_api_version, client.docker_py_version)
         s.image = image_digest
         s.args = ap["args"]
+        s.command_as_args = ap["command_as_args"]
         s.endpoint_mode = ap["endpoint_mode"]
         s.dns = ap["dns"]
         s.dns_search = ap["dns_search"]
@@ -1700,15 +1728,21 @@ class DockerService(DockerBaseClass):
             needs_rebuild = not self.can_update_networks
         if self.replicas != os.replicas:
             differences.add("replicas", parameter=self.replicas, active=os.replicas)
-        # command + args are stored as ContainerSpec.Args (CLI-compatible).
-        # Older module versions incorrectly wrote command to ContainerSpec.Command,
-        # so compare the combined command line from either field.
-        desired_cmdline = _combine_command_args(self.command, self.args)
-        active_cmdline = _combine_command_args(os.command, os.args)
-        if has_list_changed(desired_cmdline, active_cmdline, sort_lists=False):
-            differences.add(
-                "command", parameter=desired_cmdline, active=active_cmdline
-            )
+        if self.command_as_args:
+            # command + args are stored as ContainerSpec.Args (CLI-compatible).
+            # Older module versions wrote command to ContainerSpec.Command,
+            # so compare the combined command line from either field.
+            desired_cmdline = _combine_command_args(self.command, self.args)
+            active_cmdline = _combine_command_args(os.command, os.args)
+            if has_list_changed(desired_cmdline, active_cmdline, sort_lists=False):
+                differences.add(
+                    "command", parameter=desired_cmdline, active=active_cmdline
+                )
+        else:
+            if has_list_changed(self.command, os.command, sort_lists=False):
+                differences.add("command", parameter=self.command, active=os.command)
+            if has_list_changed(self.args, os.args, sort_lists=False):
+                differences.add("args", parameter=self.args, active=os.args)
         if has_list_changed(self.constraints, os.constraints):
             differences.add(
                 "constraints", parameter=self.constraints, active=os.constraints
@@ -2029,13 +2063,20 @@ class DockerService(DockerBaseClass):
         dns_config = types.DNSConfig(**dns_config_args) if dns_config_args else None
 
         container_spec_args: dict[str, t.Any] = {}
-        # Match `docker service create IMAGE [COMMAND] [ARG...]`: the CLI places
-        # all post-image tokens into ContainerSpec.Args so ENTRYPOINT is kept.
-        # Writing Command instead replaces ENTRYPOINT and breaks flag-style
-        # commands such as `-config.file=...` (see #1044, #212).
-        combined_args = _combine_command_args(self.command, self.args)
-        if combined_args is not None:
-            container_spec_args["args"] = combined_args
+        if self.command_as_args:
+            # Match `docker service create IMAGE [COMMAND] [ARG...]`: the CLI places
+            # all post-image tokens into ContainerSpec.Args so ENTRYPOINT is kept.
+            # Writing Command instead replaces ENTRYPOINT and breaks flag-style
+            # commands such as `-config.file=...` (see #1044, #212).
+            combined_args = _combine_command_args(self.command, self.args)
+            if combined_args is not None:
+                container_spec_args["args"] = combined_args
+        else:
+            # Historical mapping: command -> ContainerSpec.Command, args -> Args.
+            if self.command is not None:
+                container_spec_args["command"] = self.command
+            if self.args is not None:
+                container_spec_args["args"] = self.args
         if self.env is not None:
             container_spec_args["env"] = self.env
         if self.user is not None:
@@ -2781,6 +2822,7 @@ def main() -> None:
         "networks": {"type": "list", "elements": "raw"},
         "command": {"type": "raw"},
         "args": {"type": "list", "elements": "str"},
+        "command_as_args": {"type": "bool", "default": False},
         "env": {"type": "raw"},
         "env_files": {"type": "list", "elements": "path"},
         "force_update": {"type": "bool", "default": False},

--- a/plugins/modules/docker_swarm_service.py
+++ b/plugins/modules/docker_swarm_service.py
@@ -58,12 +58,12 @@ options:
     type: raw
   command_as_args:
     description:
-      - Controls how O(command) and O(args) are mapped to the service ContainerSpec.
-      - If V(false) (default), O(command) is written to ContainerSpec.Command and
-        O(args) to ContainerSpec.Args. This matches the historical module behavior
+      - Controls how O(command) and O(args) are mapped to the service C(ContainerSpec).
+      - If V(false) (default), O(command) is written to C(ContainerSpec.Command) and
+        O(args) to C(ContainerSpec.Args). This matches the historical module behavior
         (ContainerSpec.Command replaces the image C(ENTRYPOINT)).
       - If V(true), O(command) and O(args) are concatenated and written only to
-        ContainerSpec.Args, matching C(docker service create IMAGE [COMMAND] [ARG...])
+        C(ContainerSpec.Args), matching C(docker service create IMAGE [COMMAND] [ARG...])
         so the image C(ENTRYPOINT) is preserved.
       - The default may change to V(true) in a future major release after a deprecation
         period.

--- a/plugins/modules/docker_swarm_service.py
+++ b/plugins/modules/docker_swarm_service.py
@@ -47,7 +47,7 @@ options:
       - Command to execute when the container starts.
       - A command may be either a string or a list or a list of strings.
       - Corresponds to the C(COMMAND) parameter of C(docker service create).
-      - When O(command_as_args=false) (default), this is sent as ContainerSpec.Command,
+      - When O(command_as_args=false), this is sent as C(ContainerSpec.Command),
         which replaces the image C(ENTRYPOINT). This is the historical module behavior.
       - When O(command_as_args=true), this is combined with O(args) and sent as
         C(ContainerSpec.Args) (same as the Docker CLI

--- a/tests/unit/plugins/modules/test_docker_swarm_service.py
+++ b/tests/unit/plugins/modules/test_docker_swarm_service.py
@@ -376,3 +376,19 @@ def test_get_docker_networks() -> None:
         docker_swarm_service.get_docker_networks(
             [{"name": "test", "nonexisting_option": "foo"}], {"test": "1"}
         )
+
+
+def test_combine_command_args() -> None:
+    """command + args must form ContainerSpec.Args (docker CLI compatible)."""
+    combine = docker_swarm_service._combine_command_args
+    assert combine(None, None) is None
+    assert combine(["sleep"], ["3600"]) == ["sleep", "3600"]
+    # Flag-style command alone (issue #1044 / #212) becomes Args, not Command
+    assert combine(["-config.file=/etc/loki/loki-config.yaml"], None) == [
+        "-config.file=/etc/loki/loki-config.yaml"
+    ]
+    assert combine(None, ["--path.rootfs=/host"]) == ["--path.rootfs=/host"]
+    assert combine(["prometheus"], ["--config.file=a.yml"]) == [
+        "prometheus",
+        "--config.file=a.yml",
+    ]

--- a/tests/unit/plugins/modules/test_docker_swarm_service.py
+++ b/tests/unit/plugins/modules/test_docker_swarm_service.py
@@ -379,11 +379,11 @@ def test_get_docker_networks() -> None:
 
 
 def test_combine_command_args() -> None:
-    """command + args must form ContainerSpec.Args (docker CLI compatible)."""
+    """command + args combine into a single argv list for CLI-compatible mode."""
     combine = docker_swarm_service._combine_command_args
     assert combine(None, None) is None
     assert combine(["sleep"], ["3600"]) == ["sleep", "3600"]
-    # Flag-style command alone (issue #1044 / #212) becomes Args, not Command
+    # Flag-style command alone (issue #1044 / #212)
     assert combine(["-config.file=/etc/loki/loki-config.yaml"], None) == [
         "-config.file=/etc/loki/loki-config.yaml"
     ]
@@ -392,3 +392,63 @@ def test_combine_command_args() -> None:
         "prometheus",
         "--config.file=a.yml",
     ]
+
+
+def _make_service(
+    command: list[str] | None = None,
+    args: list[str] | None = None,
+    command_as_args: bool = False,
+) -> docker_swarm_service.DockerService:
+    svc = docker_swarm_service.DockerService(
+        docker_swarm_service.LooseVersion("1.40"),
+        docker_swarm_service.LooseVersion("5.0.0"),
+    )
+    svc.image = "alpine:latest"
+    svc.command = command
+    svc.args = args
+    svc.command_as_args = command_as_args
+    return svc
+
+
+def test_build_container_spec_legacy_command_mapping(mocker: t.Any) -> None:
+    """Default command_as_args=false keeps historical Command/Args split."""
+    captured: dict[str, t.Any] = {}
+
+    class FakeContainerSpec:
+        def __init__(self, image: str, **kwargs: t.Any) -> None:
+            captured["image"] = image
+            captured.update(kwargs)
+
+    mocker.patch.object(docker_swarm_service.types, "ContainerSpec", FakeContainerSpec)
+
+    svc = _make_service(command=["sleep"], args=["3600"], command_as_args=False)
+    svc.build_container_spec()
+    assert captured.get("command") == ["sleep"]
+    assert captured.get("args") == ["3600"]
+
+
+def test_build_container_spec_command_as_args(mocker: t.Any) -> None:
+    """command_as_args=true maps command+args to ContainerSpec.Args only."""
+    captured: dict[str, t.Any] = {}
+
+    class FakeContainerSpec:
+        def __init__(self, image: str, **kwargs: t.Any) -> None:
+            captured["image"] = image
+            captured.update(kwargs)
+
+    mocker.patch.object(docker_swarm_service.types, "ContainerSpec", FakeContainerSpec)
+
+    svc = _make_service(
+        command=["-config.file=/etc/loki/loki-config.yaml"],
+        args=None,
+        command_as_args=True,
+    )
+    svc.build_container_spec()
+    assert "command" not in captured
+    assert captured.get("args") == ["-config.file=/etc/loki/loki-config.yaml"]
+
+    captured.clear()
+    svc = _make_service(command=["sleep"], args=["3600"], command_as_args=True)
+    svc.build_container_spec()
+    assert "command" not in captured
+    assert captured.get("args") == ["sleep", "3600"]


### PR DESCRIPTION
##### SUMMARY

`docker service create IMAGE [COMMAND] [ARG...]` places all post-image tokens into **ContainerSpec.Args**, preserving the image ENTRYPOINT. Historically this module wrote `command` to **ContainerSpec.Command**, which replaces the entrypoint and makes flag-style commands fail with:

```text
exec: -config.file=...: stat -config.file=...: no such file or directory
```

This matches the failure in #1044 (Loki/Portainer/Prometheus) and the earlier report in #212 (node-exporter).

Flipping the default mapping would be a **breaking change**. Per review feedback, this PR instead adds an opt-in option:

- `command_as_args: false` (**default**): historical mapping — `command` → ContainerSpec.Command, `args` → ContainerSpec.Args
- `command_as_args: true`: CLI-compatible mapping — `command` + `args` → ContainerSpec.Args only (ENTRYPOINT preserved)

The default may be deprecated and flipped in a future major release.

Fixes #212
Fixes #1044

##### ISSUE TYPE
- Feature Pull Request
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm_service

##### ADDITIONAL INFORMATION

**Historical (default) behavior unchanged:**
```yaml
community.docker.docker_swarm_service:
  name: myservice
  image: alpine
  command: sleep
  args:
    - 3600
```
→ ContainerSpec.Command = `[sleep]`, Args = `[3600]`

**CLI-compatible opt-in (fixes #1044):**
```yaml
community.docker.docker_swarm_service:
  name: loki
  image: grafana/loki:main
  command_as_args: true
  command:
    - '-config.file=/etc/loki/loki-config.yaml'
```
→ ContainerSpec.Args = `[-config.file=...]` (entrypoint kept)

Changelog fragment and unit tests cover both modes.