### PR TITLE
CI: Remove Debian Bullseye

### DIFF
--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -119,7 +119,6 @@ force_docker_sdk_for_python_pypi = { type = "value", value = false, template_val
 "azp/5/" = "group 5"
 
 [sessions.ansible_test_integration.nice_docker_names]
-"quay.io/ansible-community/test-image:debian-bullseye" = "Debian 11"
 "quay.io/ansible-community/test-image:debian-bookworm" = "Debian 12"
 "quay.io/ansible-community/test-image:debian-13-trixie" = "Debian 13"
 "quay.io/ansible-community/test-image:archlinux" = "Arch Linux"
@@ -217,12 +216,6 @@ description = "Meta session for running all ansible-test-integration-devel-* ses
 ansible_core = "devel"
 target = [ "azp/4/", "azp/5/" ]
 docker = [ "fedora44", "ubuntu2404", "ubuntu2604", "alpine324" ]
-
-[[sessions.ansible_test_integration.groups.sessions]]
-ansible_core = "devel"
-target = [ "azp/4/", "azp/5/" ]
-python_version = "3.9"
-docker = "quay.io/ansible-community/test-image:debian-bullseye"
 
 [[sessions.ansible_test_integration.groups.sessions]]
 ansible_core = "devel"


### PR DESCRIPTION
##### SUMMARY
I don't think it's worth the effort to keep that image working, especially now that the public debian-security repos for Debian Bullseye expired. So let's remove it from CI.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
