### PR TITLE
WIP: Use new Secrets API

### DIFF
--- a/plugins/module_utils/_secrets.py
+++ b/plugins/module_utils/_secrets.py
@@ -8,32 +8,35 @@ import typing as t
 from collections.abc import Mapping, Sequence
 
 try:
-    from ansible.module_utils.secrets import register_secret  # type: ignore[import-not-found]
+    from ansible.module_utils.secrets import register_secret, register_secrets  # type: ignore[import-not-found]
 
     HAS_SECRETS_API = True
 except ImportError:
     HAS_SECRETS_API = False
 
 
-def _mark_recursively(value: t.Any, *, int_to_string: bool = False) -> t.Any:
+def _collect_recursively(
+    value: t.Any, collected_values: list[str], *, int_to_string: bool = False
+) -> None:
     if isinstance(value, Mapping):
-        return {
-            k: _mark_recursively(v, int_to_string=int_to_string)
-            for k, v in value.items()
-        }
-    if isinstance(value, str):
-        return register_secret(value)
-    if isinstance(value, Sequence):
-        return [_mark_recursively(v, int_to_string=int_to_string) for v in value]
-    if int_to_string and isinstance(value, int):
-        register_secret(str(value))
-    return value
+        for v in value.items():
+            _collect_recursively(v, collected_values, int_to_string=int_to_string)
+    elif isinstance(value, str):
+        collected_values.append(value)
+    elif isinstance(value, Sequence):
+        for v in value:
+            _collect_recursively(v, collected_values, int_to_string=int_to_string)
+    elif int_to_string and isinstance(value, int):
+        collected_values.append(str(value))
 
 
 def mark_values_as_secrets(value: t.Any, *, int_to_string: bool = False) -> t.Any:
-    """Register all strings appearing in the (potentially nested) data structure value secrets."""
+    """Register all strings appearing in the (potentially nested) data structure ``value`` as secrets."""
     if HAS_SECRETS_API:
-        value = _mark_recursively(value)
+        collected_values: list[str] = []
+        _collect_recursively(value, collected_values, int_to_string=int_to_string)
+        if collected_values:
+            register_secrets(collected_values)
     return value
 
 

--- a/plugins/module_utils/_secrets.py
+++ b/plugins/module_utils/_secrets.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2026 Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import typing as t
+from collections.abc import Mapping, Sequence
+
+try:
+    from ansible.module_utils.secrets import register_secret  # type: ignore[import-not-found]
+
+    HAS_SECRETS_API = True
+except ImportError:
+    HAS_SECRETS_API = False
+
+
+def _mark_recursively(value: t.Any, *, int_to_string: bool = False) -> t.Any:
+    if isinstance(value, Mapping):
+        return {
+            k: _mark_recursively(v, int_to_string=int_to_string)
+            for k, v in value.items()
+        }
+    if isinstance(value, str):
+        return register_secret(value)
+    if isinstance(value, Sequence):
+        return [_mark_recursively(v, int_to_string=int_to_string) for v in value]
+    if int_to_string and isinstance(value, int):
+        register_secret(str(value))
+    return value
+
+
+def mark_values_as_secrets(value: t.Any, *, int_to_string: bool = False) -> t.Any:
+    """Register all strings appearing in the (potentially nested) data structure value secrets."""
+    if HAS_SECRETS_API:
+        value = _mark_recursively(value)
+    return value
+
+
+def mark_as_secret(value: str) -> str:
+    """Register a string as a secret."""
+    if HAS_SECRETS_API:
+        value = register_secret(value)
+    return value

--- a/plugins/modules/docker_swarm.py
+++ b/plugins/modules/docker_swarm.py
@@ -262,21 +262,29 @@ swarm_facts:
         Worker:
           description:
             - Token to join the cluster as a new *worker* node.
-            - B(Note:) if this value has been specified as O(join_token), the value here will not be the token, but C(VALUE_SPECIFIED_IN_NO_LOG_PARAMETER).
+            - B(Note:) for ansible-core before 2.22, if this value has been specified as O(join_token),
+              the value here will not be the token, but C(VALUE_SPECIFIED_IN_NO_LOG_PARAMETER).
               If you pass O(join_token), make sure your playbook/role does not depend on this return value!
+              For ansible-core 2.22+, this value is always properly returned. It will be registered as a secret,
+              though, and thus cannot be shown with M(ansible.builtin.debug).
           returned: success
           type: str
           example: SWMTKN-1--xxxxx
         Manager:
           description:
             - Token to join the cluster as a new *manager* node.
-            - B(Note:) if this value has been specified as O(join_token), the value here will not be the token, but C(VALUE_SPECIFIED_IN_NO_LOG_PARAMETER).
+            - B(Note:) for ansible-core before 2.22, if this value has been specified as O(join_token),
+              the value here will not be the token, but C(VALUE_SPECIFIED_IN_NO_LOG_PARAMETER).
               If you pass O(join_token), make sure your playbook/role does not depend on this return value!
+              For ansible-core 2.22+, this value is always properly returned. It will be registered as a secret,
+              though, and thus cannot be shown with M(ansible.builtin.debug).
           returned: success
           type: str
           example: SWMTKN-1--xxxxx
     UnlockKey:
-      description: The swarm unlock-key if O(autolock_managers=true).
+      description:
+        - The swarm unlock-key if O(autolock_managers=true).
+        - B(Note) that on ansible-core 2.22+, this will be registered as a secret.
       returned: on success if O(autolock_managers=true) and swarm is initialised, or if O(autolock_managers) has changed.
       type: str
       example: SWMKEY-1-xxx
@@ -301,6 +309,9 @@ except ImportError:
 
 from ansible_collections.community.docker.plugins.module_utils._common import (
     RequestException,
+)
+from ansible_collections.community.docker.plugins.module_utils._secrets import (
+    mark_values_as_secrets,
 )
 from ansible_collections.community.docker.plugins.module_utils._swarm import (
     AnsibleDockerSwarmClient,
@@ -563,8 +574,8 @@ class SwarmManager(DockerBaseClass):
         self.differences.add("state", parameter="present", active="absent")
         self.results["changed"] = True
         self.results["swarm_facts"] = {
-            "JoinTokens": self.swarm_info.get("JoinTokens"),
-            "UnlockKey": self.swarm_info.get("UnlockKey"),
+            "JoinTokens": mark_values_as_secrets(self.swarm_info.get("JoinTokens")),
+            "UnlockKey": mark_values_as_secrets(self.swarm_info.get("UnlockKey")),
         }
 
     def __update_swarm(self) -> None:


### PR DESCRIPTION
##### SUMMARY
The Secrets API is being introduced for ansible-core 2.22 and allows modules and plugins to mark secret values for redaction. As opposed to the rudimentary `no_log` handling up until ansible-core 2.21, this improves masking of secret values.

More infos:
* https://forum.ansible.com/t/46291
* https://github.com/ansible/ansible/pull/87457
* https://github.com/ansible/ansible-documentation/pull/3934

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
various
